### PR TITLE
feat: add hero form mobile toggle

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,30 @@
+name: Build & Deploy (Pages)
+on:
+  push: { branches: [ main ] }
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with: { path: dist }
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.posthtmlrc.json
+++ b/.posthtmlrc.json
@@ -1,0 +1,7 @@
+{
+  "plugins": {
+    "posthtml-include": {
+      "root": "."
+    }
+  }
+}

--- a/404.html
+++ b/404.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Page not found – TurboSito</title>
+  <meta name="description" content="Page not found">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+  <style>
+    :root{--font-sans:"Inter",system-ui,-apple-system,Segoe UI,Roboto,Arial,"Noto Sans","Liberation Sans","Helvetica Neue",sans-serif}
+    .font-display{font-family:"Outfit",var(--font-sans)}
+    body{font-family:var(--font-sans)}
+  </style>
+  <link rel="alternate" hreflang="de" href="/TurboSito/de/">
+  <link rel="alternate" hreflang="en" href="/TurboSito/en/">
+  <link rel="alternate" hreflang="it" href="/TurboSito/it/">
+  <link rel="alternate" hreflang="x-default" href="/TurboSito/en/">
+  <link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+  <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <main class="container section-lg text-center">
+    <h1 class="text-4xl font-bold mb-4">Page not found</h1>
+    <p class="mb-6">Try one of these pages:</p>
+    <nav class="flex flex-wrap justify-center gap-4">
+      <a class="btn btn-outline" href="/TurboSito/de/">DE</a>
+      <a class="btn btn-outline" href="/TurboSito/en/">EN</a>
+      <a class="btn btn-outline" href="/TurboSito/it/">IT</a>
+    </nav>
+    <p class="mt-6">
+      <a class="link" href="/TurboSito/">Back to start</a>
+    </p>
+  </main>
+    <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
+</body>
+</html>

--- a/README.md
+++ b/README.md
@@ -180,3 +180,6 @@ Die Seiten sind bewusst schlank aufgebaut.  Um die Core Web Vitals einzuhalten
 ---
 
 *Diese Dokumentation fasst alle nötigen Schritte zusammen, um in 48 Stunden eine branchenspezifische Website zu liefern.  Die Performance‑Ziele orientieren sich an den Core Web Vitals von Google, bei denen eine LCP unter 2,5 s und ein CLS unter 0,1 als gut gelten【857787954025474†L171-L176】【52268135763575†L139-L144】.  Bitte ersetze die Platzhalter im Code, überprüfe die rechtlichen Anforderungen und teste alle Funktionen vor dem Launch.*
+## Build
+- Entwicklung: `npm i` → `npm run build` → Ausgabe in /dist
+- Pages Source: GitHub Actions (Settings → Pages → Source: GitHub Actions)

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -583,3 +583,10 @@ body.is-scrolled header{
 .case-hero{border-radius:var(--radius);box-shadow:var(--shadow-sm);border:1px solid var(--border);width:100%;height:auto}
 .kpi{display:grid;gap:.35rem;padding:16px;border-radius:12px;background:var(--bg-soft);border:1px solid var(--border)}
 .kpi big{font-size:clamp(26px,2.2vw,32px);font-weight:800}
+.badge{display:inline-flex;align-items:center;font:600 12px/1 var(--font);padding:.35rem .6rem;border:1px solid var(--border);border-radius:999px;background:var(--bg-soft);color:var(--muted)}
+.badge-demo{border-color:var(--accent);color:var(--accent)}
+.demo-hero{display:flex;gap:12px;flex-wrap:wrap;margin:12px 0 20px}
+.demo-grid{display:grid;gap:clamp(10px,2.2vw,16px);grid-template-columns:1fr}
+@media (min-width:900px){.demo-grid{grid-template-columns:repeat(3,1fr)}}
+.demo-card{border:1px solid var(--border);border-radius:16px;padding:16px;background:var(--bg);box-shadow:var(--shadow-sm)}
+.demo-cta{margin:24px 0;border:1px solid var(--border);border-radius:16px;padding:16px;background:var(--bg-soft);display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap}

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -1,0 +1,485 @@
+:root{
+  --bg:#0b0f1a; --card:#111a2b; --fg:#f6f8fd; --muted:#cbd3e4;
+  --accent:255,122,24; /* Orange Akzent (RGB) */
+  --ring:255,122,24;
+}
+html{color-scheme:dark}
+body{background:var(--bg); color:var(--fg);}
+.container{max-width:72rem; margin-inline:auto; padding-inline:1rem}
+.btn{
+  display:inline-flex; align-items:center; gap:.5rem;
+  padding:.75rem 1rem; border-radius:.75rem;
+  background:rgb(var(--accent)); color:#0b0f1a; font-weight:600;
+  transition:transform .15s ease, opacity .15s;
+}
+.btn:hover{transform:translateY(-1px)}
+.btn-outline{background:transparent; color:rgb(var(--accent)); outline:1px solid rgba(var(--accent),.4)}
+.card{
+  background:var(--card); border:1px solid rgba(255,255,255,.10);
+  border-radius:1rem; padding:1.25rem; box-shadow:0 10px 30px rgba(0,0,0,.25);
+}
+.kicker{letter-spacing:.08em; text-transform:uppercase; color:var(--muted); font-size:.8rem}
+h1,h2,h3{line-height:1.1; color:var(--fg)}
+.section{padding-block:4.5rem}
+.section-lg{padding-block:6.5rem}
+.badge{font-size:.75rem; padding:.25rem .5rem; border-radius:.5rem; background:rgba(var(--accent),.22); color:rgb(var(--accent))}
+.link{color:rgb(var(--accent)); text-underline-offset:3px}
+img{border-radius:.75rem}
+
+/* Utilities */
+.text-gradient{
+  background:linear-gradient(90deg, rgba(var(--accent),1) 0%, #ffd29b 100%);
+  -webkit-background-clip:text; background-clip:text; color:transparent;
+}
+.hero-subtitle{color:var(--muted); max-width:48rem}
+.hover-lift{transition:transform .2s ease, box-shadow .2s ease}
+.hover-lift:hover{transform:translateY(-2px)}
+.orb{
+  position:absolute; pointer-events:none; border-radius:9999px;
+  background:radial-gradient(closest-side, rgba(var(--accent),.22), transparent 70%);
+  width:44rem; height:44rem; filter:blur(2px);
+}
+@media (prefers-reduced-motion:no-preference){
+  .orb{animation:float 14s ease-in-out infinite alternate}
+  @keyframes float{from{transform:translate(-10%,-8%)} to{transform:translate(4%,6%)}}
+}
+.input{width:100%; border-radius:.75rem; background:transparent; border:1px solid rgba(255,255,255,.15); padding:.625rem .75rem}
+.input:focus{outline:none; box-shadow:0 0 0 3px rgba(var(--ring),.4)}
+.label{display:block; font-size:.9rem; font-weight:600; margin-bottom:.35rem}
+.help{font-size:.75rem; color:var(--muted); margin-top:.25rem}
+.text-muted{color:var(--muted)}
+.text-fg{color:var(--fg)}
+
+html[data-theme="light"]{
+  --bg:#ffffff; --card:#f6f7fb; --fg:#0b0f1a; --muted:#4b5563;
+  --accent:0,122,255; --ring:0,122,255;
+}
+nav a{
+  position:relative; display:inline-block;
+  background-size:0% 2px; background-repeat:no-repeat; background-position:0 100%;
+  background-image:linear-gradient(to right, rgb(var(--accent)), rgb(var(--accent)));
+  transition:background-size .2s ease;
+}
+nav a:hover{background-size:100% 2px}
+[aria-current="page"]::after{
+  content:""; position:absolute; left:0; right:0; bottom:-2px; height:2px;
+  background:rgb(var(--accent));
+}
+
+.reveal{opacity:0; transform:translateY(8px); transition:opacity .35s ease, transform .35s ease}
+.reveal.is-in{opacity:1; transform:none}
+@media (prefers-reduced-motion: reduce){
+  .reveal,.reveal.is-in{transition:none; transform:none; opacity:1}
+}
+.ph{display:none}
+.btn{box-shadow:0 8px 24px rgba(0,0,0,.22)}
+.btn:focus-visible{outline:none; box-shadow:0 0 0 3px rgba(var(--ring),.5)}
+.btn-outline:hover{background:rgba(var(--accent),.1)}
+.btn-lg{padding:1rem 1.25rem; border-radius:1rem; font-weight:700}
+.section-hero-tight{padding-block:7.5rem}
+.mockup{position:relative; overflow:hidden; background:linear-gradient(180deg, rgba(255,255,255,.03), transparent)}
+.mockup::after{content:""; position:absolute; inset:0; border-radius:inherit; box-shadow:inset 0 0 0 1px rgba(255,255,255,.06)}
+.mockup-chrome{position:absolute; top:.6rem; left:.75rem; display:flex; gap:.35rem; z-index:2}
+.mockup-chrome .dot{width:.6rem; height:.6rem; border-radius:9999px; background:rgba(255,255,255,.18)}
+.mockup-body{position:absolute; inset:0; display:flex; align-items:center; justify-content:center; text-align:center; padding:1.25rem}
+.logo-pill{
+  height:2.5rem;
+  border-radius:1.25rem;
+  background:linear-gradient(180deg, rgba(255,255,255,.06), rgba(0,0,0,.12));
+  box-shadow:inset 0 0 0 1px rgba(255,255,255,.08);
+}
+.logo-pill::after{
+  content:"";
+  display:block;
+  width:40%;
+  height:.55rem;
+  border-radius:.35rem;
+  background:rgba(255,255,255,.18);
+  margin:auto;
+}
+.skeleton{background:linear-gradient(110deg, rgba(255,255,255,.06) 8%, rgba(255,255,255,.12) 18%, rgba(255,255,255,.06) 33%); background-size:200% 100%; animation:shimmer 1.2s linear infinite}
+@keyframes shimmer{to{background-position:-200% 0}}
+footer a{color:var(--muted)}
+footer a:hover{color:var(--fg)}
+
+/* --- Testimonials (kontraststark) --- */
+.testimonial-header{display:flex;align-items:center;gap:.75rem;margin-bottom:.75rem}
+.avatar{
+  width:2.5rem;height:2.5rem;border-radius:9999px;
+  display:flex;align-items:center;justify-content:center;
+  background:rgba(255,255,255,.22);
+  color:var(--fg) !important; font-weight:800; letter-spacing:.02em
+}
+.testimonial-name{color:var(--fg) !important;font-weight:700}
+.testimonial-role{color:var(--muted) !important;font-size:.9rem}
+
+.lang-switch{display:flex;gap:.75rem;align-items:center}
+.lang-switch a{
+  font-weight:600; opacity:.9; text-decoration:none;
+  padding:.25rem .5rem; border-radius:.5rem; outline-offset:2px
+}
+.lang-switch a[aria-current="true"]{
+  background:rgba(255,255,255,.10); color:var(--fg)
+}
+.lang-switch a:hover{background:rgba(255,255,255,.06)}
+:root{ --border: rgba(255,255,255,.10) }
+html[data-theme="light"]{ --border: rgba(0,0,0,.08) }
+
+/* Language switch (falls noch nicht) */
+.lang-switch{ display:flex; gap:.5rem; align-items:center }
+.lang-switch a{ color:var(--fg); opacity:.9; border:1px solid var(--border);
+  padding:.2rem .5rem; border-radius:.5rem; text-decoration:none; font-weight:600 }
+.lang-switch a[aria-current="true"]{ background:rgba(255,255,255,.10) }
+.lang-switch a:hover{ background:rgba(255,255,255,.07) }
+
+/* Safety: entferne globale Tab-Leiste, falls vorhanden */
+.nav-tabs, header::after{ display:none !important }
+:root{ --measure: 68ch }
+main p{ max-width: var(--measure); line-height: 1.65 }
+.section{ padding-block: 3.5rem }
+.section-lg{ padding-block: 6rem }
+h1{ line-height:1.15; margin:.2em 0 .35em }
+h2{ line-height:1.2;  margin:0 0 1rem }
+h3{ line-height:1.25; margin:0 0 .75rem }
+.container > .card{ margin-top:1rem } /* Cards nicht zu dicht */
+.btn{ font-weight:700; border-radius:1rem; }
+.btn + .btn{ margin-left:.5rem }
+.card{ background: color-mix(in oklab, var(--bg) 86%, black 0%);
+       border:1px solid var(--border); border-radius:1rem; }
+.card.hover-lift{ transition: transform .2s ease, box-shadow .2s ease }
+.card.hover-lift:hover{ transform: translateY(-2px); box-shadow:0 10px 30px rgba(0,0,0,.22) }
+
+/* Testimonials */
+.testimonial-header{ display:flex; align-items:center; gap:.75rem; margin-bottom:.75rem }
+.avatar{ width:2.5rem; height:2.5rem; border-radius:9999px; display:flex; align-items:center; justify-content:center;
+         background: rgba(255,255,255,.22); color: var(--fg); font-weight:800 }
+.testimonial-name{ color: var(--fg); font-weight:700 }
+.testimonial-role{ color: var(--muted); font-size:.9rem }
+
+/* FAQ (sichtbar) */
+.faq .card{ border-color: var(--border) }
+.faq [data-acc-btn]{ display:flex; justify-content:space-between; width:100%;
+  padding:1rem 1.1rem; border-radius:.75rem; color:var(--fg); font-weight:700; background:transparent }
+.faq [data-acc-btn]:hover{ background:rgba(255,255,255,.06) }
+.faq [data-acc-btn][aria-expanded="true"]{ background:rgba(255,255,255,.10) }
+.faq [data-acc-btn]::after{ content:"+"; font-weight:800; opacity:.7 }
+.faq [data-acc-btn][aria-expanded="true"]::after{ content:"–" }
+.faq [data-acc-btn] + p{ color:var(--muted); padding:0 1.1rem 1rem }
+/* --- Light mode tokens --- */
+html[data-theme="light"]{
+  --bg:#f7f9fc;
+  --card:#ffffff;
+  --fg:#0b0f1a;
+  --muted:#465066;
+  --border:rgba(0,0,0,.08);
+}
+/* Cards & borders */
+.card{background:var(--card); border:1px solid var(--border); border-radius:1rem;}
+html[data-theme="light"] .card{box-shadow:0 8px 24px rgba(0,0,0,.06);}
+
+/* Skeleton (nicht schneeweiß im Light) */
+.skeleton{
+  background:linear-gradient(110deg,#e8eef7 8%,#f2f6fc 18%,#e8eef7 33%);
+  background-size:200% 100%; animation:shimmer 1.2s linear infinite;
+}
+
+/* Mockup: dezenter Chrom + innerer Rand in Light */
+.mockup{background:linear-gradient(180deg,rgba(0,0,0,.03),transparent);}
+.mockup::after{content:"";position:absolute;inset:0;border-radius:inherit;
+  box-shadow:inset 0 0 0 1px rgba(0,0,0,.06);}
+.mockup-chrome .dot{background:rgba(0,0,0,.15);}
+
+/* Trust-Logo-Pills im Light */
+html[data-theme="light"] .logo-pill{height:2.5rem;border-radius:1.25rem;background:linear-gradient(180deg,#eef3fb,#e5ecf7);
+  box-shadow:inset 0 0 0 1px rgba(0,0,0,.08);}
+html[data-theme="light"] .logo-pill::after{background:rgba(0,0,0,.15);}
+
+/* Überschriften immer sichtbar */
+h1,h2,h3{color:var(--fg);}
+
+/* Footer-Links lesbar im Light */
+footer a{color:var(--muted);} footer a:hover{color:var(--fg);}
+.text-gradient{background:linear-gradient(90deg, rgb(var(--accent)) 0%, #f5b679 100%); -webkit-background-clip:text; color:transparent;}
+.section-hero{padding-block:6rem;}
+@media (min-width:768px){ .section-hero{padding-block:7.5rem;} }
+.mockup-body{opacity:.9;}
+html[data-theme="light"] .mockup{box-shadow:0 20px 40px rgba(0,0,0,.1);}
+.theme-toggle{
+  display:inline-flex; align-items:center; gap:.5rem;
+  border:1px solid var(--border); border-radius:.65rem;
+  padding:.25rem .6rem; font-weight:600; cursor:pointer;
+  background:transparent; color:var(--fg);
+}
+.theme-toggle:hover{ background:rgba(255,255,255,.06) }
+.theme-toggle .icon{ width:1rem; height:1rem; display:inline-block }
+.theme-toggle .sun{ display:none }
+html[data-theme="light"] .theme-toggle .sun{ display:inline-block }
+html[data-theme="light"] .theme-toggle .moon{ display:none }
+.hamburger{ display:none; width:2.25rem; height:2.25rem; border:1px solid var(--border);
+  border-radius:.65rem; background:transparent; align-items:center; justify-content:center; }
+.hamburger span{ display:block; width:1.1rem; height:2px; background:var(--fg); position:relative }
+.hamburger span::before,.hamburger span::after{
+  content:""; position:absolute; left:0; width:100%; height:2px; background:var(--fg); }
+.hamburger span::before{ top:-6px } .hamburger span::after{ top:6px }
+@media (max-width: 768px){
+  nav.site-nav{ display:none }
+  .hamburger{ display:inline-flex }
+}
+
+/* Off-canvas */
+.mobile-menu{ position:fixed; inset:0; display:none; z-index:70; }
+.mobile-menu.open{ display:block }
+.mobile-menu .overlay{ position:absolute; inset:0; background:rgba(0,0,0,.5); }
+.mobile-menu .panel{
+  position:absolute; top:0; right:0; width:min(88vw, 360px); height:100%;
+  background:var(--bg); border-left:1px solid var(--border); padding:1rem;
+  display:flex; flex-direction:column; gap:1rem;
+}
+.mobile-menu .panel a{ display:block; padding:.7rem 0; color:var(--fg); font-weight:600; }
+.mobile-menu .panel .lang-switch{ margin-top:auto }
+/* Header row */
+header .container{display:flex;align-items:center;justify-content:space-between;gap:12px}
+.header-left{display:flex;align-items:center;gap:18px}
+.header-right{display:flex;align-items:center;gap:8px}
+
+/* Desktop: alles sichtbar */
+@media (min-width:768px){
+  nav.site-nav{display:flex}
+  .hamburger{display:none}
+  .theme-toggle{display:inline-flex}
+  .lang-switch{display:flex}
+}
+
+/* Mobile: kompakt rechts */
+@media (max-width:767px){
+  nav.site-nav{display:none}
+  .lang-switch{display:none}
+  .theme-toggle{display:inline-flex;padding:.25rem .5rem}
+  .header-right{margin-left:auto}
+  .hamburger{display:inline-flex}
+}
+
+/* Kleine Icon-Buttons angleichen */
+.hamburger{ width:2.25rem;height:2.25rem;border:1px solid var(--border);
+  border-radius:.65rem;align-items:center;justify-content:center;background:transparent}
+.hamburger span{width:1.1rem;height:2px;background:var(--fg);position:relative;display:block}
+.hamburger span::before,.hamburger span::after{content:"";position:absolute;left:0;width:100%;height:2px;background:var(--fg)}
+.hamburger span::before{top:-6px} .hamburger span::after{top:6px}
+
+/* Theme-Button kompakt halten */
+.theme-toggle{display:inline-flex;align-items:center;gap:.4rem;border:1px solid var(--border);
+  border-radius:.65rem;padding:.25rem .6rem;background:transparent;color:var(--fg)}
+.theme-toggle:hover{background:rgba(255,255,255,.06)}
+.theme-toggle .icon{width:1rem;height:1rem;display:inline-block}
+.theme-toggle .sun{display:none}
+html[data-theme="light"] .theme-toggle .sun{display:inline-block}
+html[data-theme="light"] .theme-toggle .moon{display:none}
+.logo-row{display:grid;grid-template-columns:repeat(5,minmax(0,1fr));gap:24px;align-items:center}
+.logo-row img{height:26px;width:auto;display:block;opacity:.9;transition:opacity .2s ease}
+.logo-row img:hover{opacity:1}
+.logo-row img{color:#e7eefc}
+html[data-theme="light"] .logo-row img{color:#1e2a3d;opacity:.8}
+.kpi-strip{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:24px}
+.kpi{background:var(--card);border:1px solid var(--border);border-radius:1rem;padding:1rem 1.25rem}
+.kpi dt{font-size:.8rem;letter-spacing:.04em;text-transform:uppercase;color:var(--muted)}
+.kpi dd{font-size:1.75rem;font-weight:800;line-height:1.1;color:var(--fg)}
+@media (max-width:768px){ .kpi-strip{grid-template-columns:1fr} }
+.only-mobile{display:inline-flex}
+@media (min-width:768px){ .only-mobile{display:none!important} }
+/* Kleine Abstände innerhalb der CTA-Gruppe */
+.cta-hero{display:flex;gap:.75rem;flex-wrap:wrap}
+/* Hero CTA group */
+.cta-hero{display:flex;gap:.75rem;flex-wrap:wrap}
+#quick-start{scroll-margin-top:90px}
+
+/* Quick-Start Card */
+.hero-card{background:var(--card);border:1px solid var(--border);border-radius:1rem;
+  padding:1rem 1.25rem;box-shadow:0 14px 36px rgba(0,0,0,.18)}
+.hero-card h3{margin:0 0 .25rem}
+.hero-card p{margin:0 0 .75rem;color:var(--muted)}
+.hero-card label{display:block;font-size:.85rem;color:var(--muted);margin:.5rem 0 .25rem}
+.hero-card input,.hero-card select{
+  width:100%;border:1px solid var(--border);border-radius:.65rem;
+  padding:.55rem .7rem;background:transparent;color:var(--fg)
+}
+.hero-card .actions{display:flex;gap:.5rem;margin-top:.9rem}
+.hero-card .btn{flex:1}
+
+/* Light-Boost */
+html[data-theme="light"] .hero-card{box-shadow:0 16px 40px rgba(0,0,0,.08)}
+:root{ --ring: 255 149 0 } /* Accent-Ring (Dark/Light ok) */
+.input{width:100%;border:1px solid var(--border);border-radius:.65rem;padding:.6rem .75rem;background:transparent;color:var(--fg)}
+.input:focus{outline:2px solid rgba(var(--ring),.55);outline-offset:2px;border-color:rgba(var(--ring),.4)}
+.field{margin:.7rem 0}
+.field label{display:block;font-size:.85rem;color:var(--muted);margin:0 0 .25rem}
+.hero-card{background:var(--card);border:1px solid var(--border);border-radius:1rem;padding:1rem 1.25rem;box-shadow:0 14px 36px rgba(0,0,0,.18)}
+.hero-card h3{margin:0 0 .25rem}
+.hero-card p.meta{margin:0 0 .75rem;color:var(--muted);font-size:.95rem}
+.hero-card .row{display:grid;grid-template-columns:1fr 1fr;gap:.75rem}
+@media(max-width:900px){ .hero-card .row{grid-template-columns:1fr} }
+.hero-card .actions{display:flex;gap:.6rem;margin-top:1rem}
+.btn, .btn-outline{height:2.75rem;padding:0 1rem;display:inline-flex;align-items:center;justify-content:center}
+.cta-hero .btn, .cta-hero .btn-outline{height:2.75rem}
+.help{font-size:.85rem;color:var(--muted);margin-top:.35rem}
+.consent{display:flex;gap:.5rem;align-items:flex-start;margin-top:.5rem}
+.consent input{margin-top:.15rem}
+#quick-start{scroll-margin-top:90px}
+
+/* ---------- Sticky Header + Polish ---------- */
+header{
+  position: sticky; top: 0; z-index: 60;
+  background: color-mix(in oklab, var(--bg) 92%, transparent);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--border);
+}
+header .container{ display:flex; align-items:center; justify-content:space-between; gap:12px }
+
+/* Nav-Links: Größe, Hover, Active */
+nav.site-nav a{
+  position:relative; display:inline-flex; align-items:center;
+  padding:.7rem .9rem; border-radius:.55rem; color:var(--fg);
+}
+nav.site-nav a:hover{ background: rgba(255,255,255,.06) }
+nav.site-nav a[aria-current="page"]{
+  background: rgba(255,255,255,.10);
+  box-shadow: inset 0 0 0 1px var(--border);
+}
+
+/* Shadow/Elevation beim Scroll */
+body.is-scrolled header{
+  box-shadow: 0 10px 30px rgba(0,0,0,.12);
+  border-bottom-color: color-mix(in oklab, var(--border) 70%, transparent);
+}
+
+/* ---------- Consent Checkbox Fix ---------- */
+/* Ältere Regel könnte alle Inputs in .hero-card auf width:100% setzen.
+   Hier überschreiben wir gezielt die Checkbox. */
+.hero-card input[type="checkbox"]{
+  width:auto; inline-size:auto; height:1.05rem; aspect-ratio:1/1;
+  accent-color: rgb(var(--accent));
+  border: 1px solid var(--border);
+}
+.consent{ display:flex; gap:.55rem; align-items:flex-start; margin-top:.5rem }
+.consent input{ margin-top:.2rem } /* nur kleiner vertikaler Versatz */
+
+ /* Fokusring für Textfelder/Select (falls noch nicht vorhanden) */
+.input:focus{
+  outline: 2px solid rgba(var(--ring, 255 149 0), .55);
+  outline-offset: 2px; border-color: rgba(var(--ring, 255 149 0), .35);
+}
+
+/* Optional: Field-Hervorhebung beim Fokus */
+.field:focus-within{ filter: drop-shadow(0 2px 12px rgba(0,0,0,.12)) }
+
+/* Leichtes Compacting der Formfelder */
+.field{ margin:.6rem 0 }
+.hero-card .actions{ gap:.55rem; margin-top:.9rem }
+.btn, .btn-outline, .cta-hero .btn, .cta-hero .btn-outline{ height:2.75rem }
+
+@media (max-width: 768px){
+  nav.site-nav{ display:none } /* mobile-nav übernimmt */
+}
+/* ---------- Theme tokens / Accent fallback ---------- */
+:root{
+  /* Fallback für Underline/Accent, falls nicht gesetzt */
+  --accent: 255 149 0; /* Orange in RGB-Triplet-Notation */
+}
+
+/* ---------- NAV POLISH (Light + Underline in allen Themes) ---------- */
+nav.site-nav a{
+  position:relative; display:inline-flex; align-items:center;
+  padding:.7rem .9rem; border-radius:.55rem; color:var(--fg);
+  transition: background .18s ease, color .18s ease;
+}
+/* Underline-Animation */
+nav.site-nav a::after{
+  content:""; position:absolute; left:.65rem; right:.65rem; bottom:.35rem;
+  height:2px; background: rgb(var(--accent)); transform: scaleX(0);
+  transform-origin: left; transition: transform .18s ease;
+}
+nav.site-nav a:hover::after,
+nav.site-nav a[aria-current="page"]::after{ transform: scaleX(1) }
+
+/* Hover/Active-Flächen */
+nav.site-nav a:hover{ background: rgba(255,255,255,.06) }
+nav.site-nav a[aria-current="page"]{
+  background: rgba(255,255,255,.10);
+  box-shadow: inset 0 0 0 1px var(--border);
+}
+
+/* Light-Theme braucht dunklere Flächen für sichtbare Hover */
+html[data-theme="light"] nav.site-nav a:hover{ background: rgba(0,0,0,.06) }
+html[data-theme="light"] nav.site-nav a[aria-current="page"]{
+  background: rgba(0,0,0,.08);
+  box-shadow: inset 0 0 0 1px rgba(0,0,0,.08);
+}
+
+/* ---------- BRAND / LOGO (Text) ---------- */
+.brand{ color:var(--fg) !important; font-weight:800; letter-spacing:.2px; opacity:.96 }
+.brand:hover{ opacity:1 }
+
+/* ---------- MOBILE HEADER SPACING ---------- */
+header .container{ display:flex; align-items:center; justify-content:space-between; gap:12px }
+.header-right{ display:flex; align-items:center; gap:10px }
+@media (max-width:768px){
+  header .container{ padding-inline:.75rem }
+  .theme-toggle{ padding:.25rem .5rem }
+  .hamburger{ width:2.25rem; height:2.25rem; }
+}
+
+/* ---------- CHECKBOX (DSGVO) – SICHTBAR IN DARK ---------- */
+/* frühere generische Regel .hero-card input {... width:100%} überschreibt Checkbox → hier gezielt fixen */
+.hero-card input[type="checkbox"]{
+  width:auto; inline-size:auto; height:1.05rem; aspect-ratio:1/1;
+  appearance:auto; /* native Checkbox rendern */
+  background: var(--card);
+  border:1px solid var(--border);
+  border-radius:.25rem;
+  accent-color: rgb(var(--accent)); /* sichtbarer Check in beiden Themes */
+}
+/* kleine Ausrichtung mit der Label-Zeile */
+.consent{ display:flex; gap:.55rem; align-items:flex-start; margin-top:.5rem }
+.consent input{ margin-top:.2rem }
+.consent span{ color:var(--muted) }
+
+/* ---------- Sticky Header Shadow beim Scroll (falls noch nicht) ---------- */
+body.is-scrolled header{
+  box-shadow: 0 10px 30px rgba(0,0,0,.12);
+  border-bottom-color: color-mix(in oklab, var(--border) 70%, transparent);
+}
+.mobile-menu{ position:fixed; inset:0; display:none; z-index:70 }
+.mobile-menu.open{ display:block }
+.mobile-menu .overlay{ position:absolute; inset:0; background:rgba(0,0,0,.5) }
+.mobile-menu .panel{
+  position:absolute; top:0; right:0; width:min(88vw, 360px); height:100%;
+  background:var(--bg); border-left:1px solid var(--border);
+  padding:1rem; display:flex; flex-direction:column; gap:10px;
+}
+.mobile-menu .mobile-links a{
+  display:block; padding:.9rem .25rem; border-bottom:1px solid var(--border); color:var(--fg); font-weight:600;
+}
+.mobile-menu .mobile-links a[aria-current="page"]{
+  background:rgba(255,255,255,.06); box-shadow:inset 0 -2px 0 0 rgb(var(--accent));
+}
+.mobile-menu .divider{ height:1px; background:var(--border); margin:.25rem 0 .5rem }
+.mobile-menu nav.lang-switch.mobile{ display:flex; gap:.5rem; flex-wrap:wrap }
+.mobile-menu nav.lang-switch.mobile a{
+  border:1px solid var(--border); border-radius:.5rem; padding:.25rem .5rem; font-weight:700; color:var(--fg);
+}
+.mobile-menu nav.lang-switch.mobile a[aria-current="page"]{
+  background:rgba(255,255,255,.1);
+}
+.hero-toggle{ display:none }
+@media (max-width:768px){
+  .hero-card.is-collapsed{ display:none }
+  .hero-toggle{ display:flex; margin-top:.75rem }
+  .hero-toggle .btn{ width:100%; height:2.75rem }
+}
+
+.micro-start{ display:none; gap:.5rem; margin-top:.75rem }
+.micro-start input{
+  flex:1; border:1px solid var(--border); border-radius:.65rem;
+  padding:.55rem .7rem; background:transparent; color:var(--fg)
+}
+.micro-start .btn{ height:2.75rem }
+@media (max-width:768px){ .micro-start{ display:flex } }

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -577,3 +577,9 @@ body.is-scrolled header{
 .case-card{ position:relative; overflow:hidden }
 .case-card .stretched-link{ position:absolute; inset:0; z-index:5; text-indent:-9999px; overflow:hidden; }
 .case-cta{ margin-top:.75rem }
+/* Case unification */
+.breadcrumbs{font:500 var(--fz-sm)/1.3 inherit;color:var(--muted);margin:0 0 12px}
+.breadcrumbs a{color:inherit;text-decoration:none;border-bottom:1px solid var(--border)}
+.case-hero{border-radius:var(--radius);box-shadow:var(--shadow-sm);border:1px solid var(--border);width:100%;height:auto}
+.kpi{display:grid;gap:.35rem;padding:16px;border-radius:12px;background:var(--bg-soft);border:1px solid var(--border)}
+.kpi big{font-size:clamp(26px,2.2vw,32px);font-weight:800}

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -573,3 +573,7 @@ body.is-scrolled header{
   .gallery{ grid-template-columns: 1fr; }
   .gallery .span-6, .gallery .span-12{ grid-column: 1 / -1; }
 }
+/* Clickable cards */
+.case-card{ position:relative; overflow:hidden }
+.case-card .stretched-link{ position:absolute; inset:0; z-index:5; text-indent:-9999px; overflow:hidden; }
+.case-cta{ margin-top:.75rem }

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -476,13 +476,6 @@ body.is-scrolled header{
   .hero-toggle .btn{ width:100%; height:2.75rem }
 }
 
-.micro-start{ display:none; gap:.5rem; margin-top:.75rem }
-.micro-start input{
-  flex:1; border:1px solid var(--border); border-radius:.65rem;
-  padding:.55rem .7rem; background:transparent; color:var(--fg)
-}
-.micro-start .btn{ height:2.75rem }
-@media (max-width:768px){ .micro-start{ display:flex } }
 /* Sticky CTA nur mobil */
 .sticky-cta{ display:none }
 @media (max-width:768px){
@@ -498,11 +491,19 @@ body.is-scrolled header{
   .sticky-cta{ opacity:0; transform:translateY(8px); transition:opacity .18s, transform .18s }
   .sticky-cta.is-visible{ opacity:1; transform:translateY(0) }
 
-  /* Hero-CTAs aufräumen: Projekt-starten-Button dort ausblenden */
-  .cta-hero a.btn-primary{ display:none }
-  /* Kontakt mobil ausblenden (bleibt im Menü) – falls noch nicht */
-  .cta-hero a.btn-contact{ display:none }
 }
 
-/* micro form deaktivieren */
-#micro-start{ display:none !important }
+/* Hero-CTAs (mobil aufräumen) */
+@media (max-width:768px){
+  .cta-hero a.btn-contact{ display:none }
+  .cta-hero a.btn-primary{ display:none }
+}
+
+/* Micro-Form sichtbar auf Mobil */
+.micro-start{ display:flex; gap:.5rem; margin-top:.75rem }
+.micro-start input{
+  flex:1; border:1px solid var(--border); border-radius:.65rem;
+  padding:.55rem .7rem; background:transparent; color:var(--fg)
+}
+.micro-start .btn{ height:2.75rem }
+@media (min-width:769px){ .micro-start{ display:none } }

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -483,3 +483,26 @@ body.is-scrolled header{
 }
 .micro-start .btn{ height:2.75rem }
 @media (max-width:768px){ .micro-start{ display:flex } }
+/* Sticky CTA nur mobil */
+.sticky-cta{ display:none }
+@media (max-width:768px){
+  .sticky-cta{
+    position:fixed; left:0; right:0; bottom:calc(8px + env(safe-area-inset-bottom));
+    z-index:55; display:flex; justify-content:center; pointer-events:none;
+  }
+  .sticky-cta .btn{
+    pointer-events:auto; min-width:78%; height:2.9rem; border-radius:.9rem;
+    box-shadow:0 14px 28px rgba(0,0,0,.28);
+  }
+  /* sanftes Ein-/Ausblenden */
+  .sticky-cta{ opacity:0; transform:translateY(8px); transition:opacity .18s, transform .18s }
+  .sticky-cta.is-visible{ opacity:1; transform:translateY(0) }
+
+  /* Hero-CTAs aufräumen: Projekt-starten-Button dort ausblenden */
+  .cta-hero a.btn-primary{ display:none }
+  /* Kontakt mobil ausblenden (bleibt im Menü) – falls noch nicht */
+  .cta-hero a.btn-contact{ display:none }
+}
+
+/* micro form deaktivieren */
+#micro-start{ display:none !important }

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -590,3 +590,6 @@ body.is-scrolled header{
 @media (min-width:900px){.demo-grid{grid-template-columns:repeat(3,1fr)}}
 .demo-card{border:1px solid var(--border);border-radius:16px;padding:16px;background:var(--bg);box-shadow:var(--shadow-sm)}
 .demo-cta{margin:24px 0;border:1px solid var(--border);border-radius:16px;padding:16px;background:var(--bg-soft);display:flex;align-items:center;justify-content:space-between;gap:12px;flex-wrap:wrap}
+.demo-page main{scroll-margin-top:80px}
+.section .container{max-width:980px;margin:0 auto}
+.muted{color:var(--muted)}

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -493,17 +493,19 @@ body.is-scrolled header{
 
 }
 
-/* Hero-CTAs (mobil aufräumen) */
 @media (max-width:768px){
-  .cta-hero a.btn-contact{ display:none }
-  .cta-hero a.btn-primary{ display:none }
-}
+  /* Hero-CTAs bereinigen */
+  .cta-hero [data-cta="contact"],
+  .cta-hero [data-cta="primary"]{ display:none !important; }
+  .cta-hero [data-cta="portfolio"]{ flex:1; }
 
-/* Micro-Form sichtbar auf Mobil */
-.micro-start{ display:flex; gap:.5rem; margin-top:.75rem }
-.micro-start input{
-  flex:1; border:1px solid var(--border); border-radius:.65rem;
-  padding:.55rem .7rem; background:transparent; color:var(--fg)
+  /* Micro-Form sichtbar lassen */
+  .micro-start{ display:flex; gap:.5rem; margin-top:.75rem }
+  .micro-start input{
+    flex:1; border:1px solid var(--border); border-radius:.65rem;
+    padding:.55rem .7rem; background:transparent; color:var(--fg);
+  }
+  .micro-start .btn{ height:2.75rem }
 }
-.micro-start .btn{ height:2.75rem }
+/* Desktop: Micro-Form ausblenden */
 @media (min-width:769px){ .micro-start{ display:none } }

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -517,3 +517,59 @@ body.is-scrolled header{
     display: none !important;
   }
 }
+:root{
+  /* Layout */
+  --container: 1200px;
+  --radius: 16px;
+  --shadow-sm: 0 4px 16px rgba(0,0,0,.08);
+  --shadow-md: 0 12px 28px rgba(0,0,0,.12);
+
+  /* Type scale (clamp für responsiv) */
+  --fz-xs: clamp(12px, .78vw, 13px);
+  --fz-sm: clamp(14px, .9vw, 15px);
+  --fz-md: clamp(16px, 1vw, 17px);
+  --fz-lg: clamp(20px, 1.25vw, 22px);
+  --fz-xl: clamp(28px, 2vw, 32px);
+  --fz-2xl: clamp(36px, 3vw, 44px);
+
+  /* Farben orientiert an bestehendem Theme */
+  --bg-soft: color-mix(in srgb, var(--bg) 92%, var(--fg) 8%);
+  --card: color-mix(in srgb, var(--bg) 86%, var(--fg) 14%);
+  --muted: color-mix(in srgb, var(--fg) 60%, transparent 40%);
+  --brand: var(--accent, #0b6bff);
+}
+
+.container{ width:min(100%, var(--container)); margin-inline:auto; padding-inline:clamp(16px, 4vw, 32px); }
+.section{ padding-block: clamp(32px, 6vw, 96px); }
+.grid-2{ display:grid; gap:clamp(16px, 3vw, 32px); grid-template-columns: 1fr; }
+@media (min-width: 900px){ .grid-2{ grid-template-columns: 1fr 1fr; } }
+
+.card{ background:var(--card); border:1px solid var(--border); border-radius:var(--radius); box-shadow:var(--shadow-sm); }
+.card.pad{ padding:clamp(16px, 2.5vw, 28px); }
+
+.badges{ display:flex; flex-wrap:wrap; gap:10px; }
+.badge{ font:600 var(--fz-sm)/1.2 inherit; padding:.45rem .7rem; border-radius:999px; border:1px solid var(--border); background:transparent; color:var(--fg); }
+.badge.brand{ background:color-mix(in srgb, var(--brand) 15%, transparent 85%); border-color:color-mix(in srgb, var(--brand) 40%, var(--border) 60%); color:var(--fg); }
+
+.avatar{ width:144px; height:144px; border-radius:50%; object-fit:cover; border:3px solid var(--border); box-shadow:var(--shadow-sm); }
+
+.timeline{ position:relative; display:grid; gap:20px; }
+.timeline::before{ content:""; position:absolute; left:10px; top:0; bottom:0; width:2px; background:var(--border); }
+.timeline-item{ position:relative; padding-left:36px; }
+.timeline-item::before{ content:""; position:absolute; left:2px; top:.4rem; width:16px; height:16px; border-radius:50%; background:var(--brand); box-shadow:0 0 0 4px color-mix(in srgb, var(--brand) 20%, transparent); }
+
+.kpi{ display:grid; gap:6px; padding:16px; border-radius:12px; background:var(--bg-soft); border:1px solid var(--border); }
+.kpi .num{ font:700 var(--fz-xl)/1.1 system-ui; }
+.kpi .lbl{ color:var(--muted); font-size:var(--fz-sm); }
+
+.hero-about h1{ font-size:var(--fz-2xl); margin:0 0 12px; }
+.hero-about p.lead{ font-size:var(--fz-lg); color:var(--muted); margin:0; }
+
+.gallery{ display:grid; gap:12px; grid-template-columns: repeat(12, 1fr); }
+.gallery img{ width:100%; height:auto; border-radius:12px; }
+.gallery .span-6{ grid-column: span 6; }
+.gallery .span-12{ grid-column: span 12; }
+@media (max-width: 720px){
+  .gallery{ grid-template-columns: 1fr; }
+  .gallery .span-6, .gallery .span-12{ grid-column: 1 / -1; }
+}

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -509,3 +509,11 @@ body.is-scrolled header{
 }
 /* Desktop: Micro-Form ausblenden */
 @media (min-width:769px){ .micro-start{ display:none } }
+@media (max-width:768px){
+  /* Oberen Projekt-Start-Button im Hero sicher ausblenden (mehrere Fallback-Selektoren) */
+  .cta-hero .btn-primary,
+  .cta-hero [data-cta="primary"],
+  .cta-hero [data-open-form]{
+    display: none !important;
+  }
+}

--- a/assets/img/logos/acme.svg
+++ b/assets/img/logos/acme.svg
@@ -1,0 +1,3 @@
+<svg width="140" height="28" viewBox="0 0 140 28" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+  <text x="0" y="20" font-family="Inter,system-ui,sans-serif" font-size="20" font-weight="800">ACME</text>
+</svg>

--- a/assets/img/logos/aurora.svg
+++ b/assets/img/logos/aurora.svg
@@ -1,0 +1,3 @@
+<svg width="140" height="28" viewBox="0 0 140 28" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+  <text x="0" y="20" font-family="Inter,system-ui,sans-serif" font-size="20" font-weight="700">Aurora</text>
+</svg>

--- a/assets/img/logos/nimbus.svg
+++ b/assets/img/logos/nimbus.svg
@@ -1,0 +1,3 @@
+<svg width="140" height="28" viewBox="0 0 140 28" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+  <text x="0" y="20" font-family="Inter,system-ui,sans-serif" font-size="20" font-weight="700">Nimbus</text>
+</svg>

--- a/assets/img/logos/orbit.svg
+++ b/assets/img/logos/orbit.svg
@@ -1,0 +1,3 @@
+<svg width="140" height="28" viewBox="0 0 140 28" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+  <text x="0" y="20" font-family="Inter,system-ui,sans-serif" font-size="20" font-weight="700">Orbit</text>
+</svg>

--- a/assets/img/logos/pixel.svg
+++ b/assets/img/logos/pixel.svg
@@ -1,0 +1,3 @@
+<svg width="140" height="28" viewBox="0 0 140 28" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+  <text x="0" y="20" font-family="Inter,system-ui,sans-serif" font-size="20" font-weight="700">Pixel</text>
+</svg>

--- a/assets/js/faq.js
+++ b/assets/js/faq.js
@@ -1,0 +1,11 @@
+(()=> {
+  const items = document.querySelectorAll('.faq [data-acc-btn]');
+  items.forEach(btn => {
+    const p = document.getElementById(btn.getAttribute('aria-controls'));
+    btn.addEventListener('click', () => {
+      const ex = btn.getAttribute('aria-expanded') === 'true';
+      btn.setAttribute('aria-expanded', String(!ex));
+      p.hidden = ex;
+    });
+  });
+})();

--- a/assets/js/hero-form.js
+++ b/assets/js/hero-form.js
@@ -1,0 +1,53 @@
+(() => {
+  const form = document.querySelector('#quick-start');
+  if (!form) return;
+
+  const $ = (s) => form.querySelector(s);
+  const submitBtn = $('#qs-submit');
+  const msg = $('#qs-msg');
+  const email = $('#email');
+  const name = $('#name');
+  const ok = $('#ok');
+  const hp = $('#company');
+  const note = $('#note');
+  const charHelp = $('#charHelp');
+
+  // Live counter
+  note?.addEventListener('input', () => {
+    const left = 140 - (note.value?.length || 0);
+    if (charHelp) charHelp.textContent = `Noch ${left} Zeichen`;
+  });
+
+  // Tracking fields
+  const params = new URLSearchParams(location.search);
+  $('#lang').value = (document.documentElement.lang || 'de').slice(0,2);
+  $('#source').value = location.pathname;
+  $('#theme').value = document.documentElement.getAttribute('data-theme') || 'dark';
+  $('#utm').value = JSON.stringify({
+    utm_source:  params.get('utm_source')  || '',
+    utm_medium:  params.get('utm_medium')  || '',
+    utm_campaign:params.get('utm_campaign')|| ''
+  });
+
+  // Simple email check
+  const isEmail = (v) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v);
+
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    msg.textContent = '';
+
+    // Honeypot
+    if (hp && hp.value) { msg.textContent = 'Fehler. Bitte direkt per Kontakt melden.'; return; }
+
+    // Required checks
+    if (!name.value.trim()) { name.focus(); msg.textContent = 'Bitte Namen angeben.'; return; }
+    if (!isEmail(email.value)) { email.focus(); msg.textContent = 'Bitte gültige E-Mail angeben.'; return; }
+    if (!ok.checked) { ok.focus(); msg.textContent = 'Bitte Datenschutzzustimmung setzen.'; return; }
+
+    // Disable & redirect as GET
+    submitBtn.disabled = true;
+    const fd = new FormData(form);
+    const q = new URLSearchParams(fd).toString();
+    location.href = `/TurboSito/de/kontakt.html?${q}`;
+  });
+})();

--- a/assets/js/hero-mobile-toggle.js
+++ b/assets/js/hero-mobile-toggle.js
@@ -34,20 +34,19 @@
 })();
 
 (() => {
+  const card  = document.querySelector('.hero-card');
+  const big   = document.getElementById('quick-start');
   const micro = document.getElementById('micro-start');
-  const card = document.querySelector('.hero-card');
-  const form = document.getElementById('quick-start');
-  if (!micro || !card || !form) return;
 
-  micro.addEventListener('submit', (e) => {
+  // Micro -> großes Formular
+  micro?.addEventListener('submit', (e) => {
     e.preventDefault();
-    const email = micro.querySelector('#micro-email').value.trim();
+    const email = micro.querySelector('#micro-email')?.value?.trim();
     if (!email) return;
-    card.classList.remove('is-collapsed');
-    const bigEmail = form.querySelector('#email');
+    card?.classList.remove('is-collapsed');
+    const bigEmail = big?.querySelector('#email');
     if (bigEmail) bigEmail.value = email;
-    form.querySelector('#name')?.focus();
-    setTimeout(() =>
-      form.scrollIntoView({ behavior: 'smooth', block: 'start' }), 50);
+    big?.querySelector('#name')?.focus();
+    setTimeout(() => big?.scrollIntoView({behavior:'smooth', block:'start'}), 50);
   });
 })();

--- a/assets/js/hero-mobile-toggle.js
+++ b/assets/js/hero-mobile-toggle.js
@@ -1,0 +1,53 @@
+(() => {
+  const card = document.querySelector('.hero-card');
+  if (!card) return;
+
+  const makeToggle = () => {
+    if (window.innerWidth > 768) { card.classList.remove('is-collapsed'); toggle?.remove?.(); return; }
+    // schon vorhanden?
+    let t = document.querySelector('.hero-toggle');
+    if (!t) {
+      t = document.createElement('div');
+      t.className = 'hero-toggle';
+      t.innerHTML = `<a class="btn" href="#quick-start" data-open-form>Projekt starten</a>`;
+      // nach den linken CTAs einfügen:
+      const cta = document.querySelector('.cta-hero');
+      (cta?.parentElement || document.querySelector('main')).insertBefore(t, (cta?.nextSibling || null));
+    }
+    card.classList.add('is-collapsed');
+  };
+
+  const openForm = () => { card.classList.remove('is-collapsed'); setTimeout(() => card.scrollIntoView({behavior:'smooth', block:'start'}), 50); };
+
+  document.addEventListener('click', (e) => {
+    const a = e.target.closest('[data-open-form]');
+    if (a) { e.preventDefault(); openForm(); history.replaceState(null,'', '#quick-start'); }
+  });
+
+  // Anker-Öffnung (z.B. Link „Kontakt aufnehmen“)
+  if (location.hash === '#quick-start' && window.innerWidth <= 768) {
+    setTimeout(openForm, 60);
+  }
+
+  window.addEventListener('resize', makeToggle, {passive:true});
+  makeToggle();
+})();
+
+(() => {
+  const micro = document.getElementById('micro-start');
+  const card = document.querySelector('.hero-card');
+  const form = document.getElementById('quick-start');
+  if (!micro || !card || !form) return;
+
+  micro.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const email = micro.querySelector('#micro-email').value.trim();
+    if (!email) return;
+    card.classList.remove('is-collapsed');
+    const bigEmail = form.querySelector('#email');
+    if (bigEmail) bigEmail.value = email;
+    form.querySelector('#name')?.focus();
+    setTimeout(() =>
+      form.scrollIntoView({ behavior: 'smooth', block: 'start' }), 50);
+  });
+})();

--- a/assets/js/lang-switch.js
+++ b/assets/js/lang-switch.js
@@ -1,0 +1,21 @@
+(() => {
+  const KEY = 'site-lang';
+  const links = document.querySelectorAll('a[data-lang]');
+  const cur = (document.documentElement.lang || '').slice(0,2).toLowerCase();
+
+  // Markiere aktuelle Sprache
+  links.forEach(a => {
+    const isCur = a.dataset.lang === cur;
+    a.setAttribute('aria-current', isCur ? 'true' : 'false');
+  });
+
+  // Klick = Wahl merken
+  links.forEach(a => {
+    a.addEventListener('click', () => {
+      localStorage.setItem(KEY, a.dataset.lang);
+    });
+  });
+
+  // Optional: wenn auf /index.html und KEINE Wahl gespeichert,
+  // darf dein Autoredirect-Snippet weiterhin laufen (falls vorhanden).
+})();

--- a/assets/js/mobile-nav.js
+++ b/assets/js/mobile-nav.js
@@ -1,0 +1,59 @@
+(() => {
+  const btn = document.querySelector('[data-nav-toggle]');
+  if (!btn) return;
+
+  let menu = document.getElementById('mobile-menu');
+  if (!menu) {
+    menu = document.createElement('div');
+    menu.id = 'mobile-menu';
+    menu.className = 'mobile-menu';
+    menu.innerHTML = `
+      <div class="overlay" data-nav-close></div>
+      <div class="panel card">
+        <nav class="mobile-links" aria-label="Mobile Hauptnavigation"></nav>
+        <div class="divider"></div>
+        <nav class="lang-switch mobile" aria-label="Sprache"></nav>
+      </div>`;
+    document.body.appendChild(menu);
+  }
+
+  const trackLinks = () => {
+    const src = document.querySelector('nav.site-nav');
+    const dst = menu.querySelector('.mobile-links');
+    if (src && dst && !dst.childElementCount) {
+      dst.innerHTML = [...src.querySelectorAll('a')].map(a => {
+        const href = a.getAttribute('href');
+        const txt  = a.textContent.trim();
+        const cur  = a.getAttribute('aria-current') ? ' aria-current="page"' : '';
+        return `<a href="${href}"${cur}>${txt}</a>`;
+      }).join('');
+    }
+  };
+
+  const trackLang = () => {
+    const src = document.querySelector('nav.lang-switch');
+    const dst = menu.querySelector('nav.lang-switch.mobile');
+    if (dst && !dst.childElementCount) {
+      if (src) dst.innerHTML = src.innerHTML;
+      else {
+        const base = location.pathname
+          .replace(/\/(de|en|it)\//i,'/$1/')
+          .split('/')
+          .slice(0,3)
+          .join('/');
+        dst.innerHTML = ['de','en','it'].map(l =>
+          `<a href="${base.replace(/\/(de|en|it)\//i, `/${l}/`)}"${document.documentElement.lang?.startsWith(l)?' aria-current="page"':''}>${l.toUpperCase()}</a>`
+        ).join('');
+      }
+    }
+  };
+
+  const open = () => { menu.classList.add('open'); btn.setAttribute('aria-expanded','true'); };
+  const close = () => { menu.classList.remove('open'); btn.setAttribute('aria-expanded','false'); };
+
+  btn.addEventListener('click', () => menu.classList.contains('open') ? close() : open());
+  menu.addEventListener('click', e => { if (e.target.closest('[data-nav-close]')) close(); });
+
+  trackLinks();
+  trackLang();
+})();

--- a/assets/js/nav-active.js
+++ b/assets/js/nav-active.js
@@ -1,0 +1,11 @@
+/* nav-active.js */
+(() => {
+  const norm = p => (p.replace(/\/index\.html$/,'/').replace(/\/+$/,'/') || '/');
+  const here = norm(location.pathname);
+  document.querySelectorAll('nav a[href]').forEach(a => {
+    try {
+      const href = new URL(a.getAttribute('href'), location.origin).pathname;
+      if (norm(href) === here) a.setAttribute('aria-current','page');
+    } catch (e) {}
+  });
+})();

--- a/assets/js/reveal.js
+++ b/assets/js/reveal.js
@@ -1,0 +1,9 @@
+(() => {
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+  const els = [...document.querySelectorAll('.reveal')];
+  if (!('IntersectionObserver' in window)) { els.forEach(el => el.classList.add('is-in')); return; }
+  const io = new IntersectionObserver((ents) => {
+    ents.forEach(e => { if (e.isIntersecting) { e.target.classList.add('is-in'); io.unobserve(e.target); } });
+  }, { threshold: 0.01, rootMargin: '0px 0px -10% 0px' });
+  els.forEach(el => io.observe(el));
+})();

--- a/assets/js/scroll-header.js
+++ b/assets/js/scroll-header.js
@@ -1,0 +1,5 @@
+(() => {
+  const tick=()=>document.body.classList.toggle('is-scrolled', window.scrollY>2);
+  window.addEventListener('scroll', tick, {passive:true});
+  tick();
+})();

--- a/assets/js/sticky-cta.js
+++ b/assets/js/sticky-cta.js
@@ -1,7 +1,7 @@
 (() => {
   const isMobile = () => window.matchMedia('(max-width: 768px)').matches;
 
-  // Sticky Element einfügen, falls nicht vorhanden
+  // Sticky Element (falls fehlt) injizieren
   let bar = document.querySelector('.sticky-cta');
   if (!bar) {
     bar = document.createElement('div');
@@ -13,7 +13,7 @@
   const show = () => bar.classList.add('is-visible');
   const hide = () => bar.classList.remove('is-visible');
 
-  // Ausblenden wenn Formular sichtbar
+  // Großes Formular / Karte im View? → ausblenden
   const form = document.querySelector('#quick-start')?.closest('.hero-card') || document.querySelector('#quick-start');
   let io;
   if ('IntersectionObserver' in window && form) {
@@ -24,26 +24,32 @@
     io.observe(form);
   }
 
-  // Menü-offen? (Overlay/Panel vorhanden → class .open), dann CTA ausblenden
+  // Mobile-Menü offen? → ausblenden
   const menu = document.getElementById('mobile-menu');
   const tickMenu = () => {
     const open = menu?.classList.contains('open');
     if (open) hide(); else if (isMobile()) show();
   };
-  menu?.addEventListener('transitionend', tickMenu);
   document.addEventListener('click', e => {
     if (e.target.closest('[data-nav-toggle],[data-nav-close]')) setTimeout(tickMenu, 50);
   });
 
-  // Scroll-Heuristik: ab 160px einblenden (wenn nicht durch IO/menü versteckt)
-  let lastY = window.scrollY;
+  // Eingabe-Fokus (Micro-Form + großes Formular) → ausblenden (Keyboard)
+  const isFormField = (el) => el && (el.tagName === 'INPUT' || el.tagName === 'SELECT' || el.tagName === 'TEXTAREA');
+  document.addEventListener('focusin', (e) => {
+    if (isFormField(e.target) && (e.target.closest('#micro-start') || e.target.closest('#quick-start'))) hide();
+  });
+  document.addEventListener('focusout', () => {
+    if (isMobile() && !menu?.classList.contains('open')) show();
+  });
+
+  // Scroll-Heuristik: ab 160px einblenden (wenn nichts anderes greift)
   const onScroll = () => {
     if (!isMobile()) return hide();
-    const y = window.scrollY;
-    if (y > 160 && !menu?.classList.contains('open')) show(); else hide();
-    lastY = y;
+    if (!form) return show();
+    if (window.scrollY > 160 && !menu?.classList.contains('open')) show();
   };
   window.addEventListener('scroll', onScroll, { passive: true });
   window.addEventListener('resize', onScroll);
-  onScroll(); // initial
+  onScroll(); // init
 })();

--- a/assets/js/sticky-cta.js
+++ b/assets/js/sticky-cta.js
@@ -1,5 +1,5 @@
 (() => {
-  const THRESHOLD = 140; // erst ab diesem Scrollwert anzeigen
+  const THRESHOLD = 0.35; // Anteil der Seite, ab dem eingeblendet wird
   const isMobile = () => window.matchMedia('(max-width: 768px)').matches;
 
   // Sticky-Leiste einfügen (falls nicht vorhanden)
@@ -42,7 +42,8 @@
     if (menuOpen()) return hide();
     if (formInView) return hide();
 
-    const scrolled = window.scrollY >= THRESHOLD;
+    const maxY = document.documentElement.scrollHeight - window.innerHeight;
+    const scrolled = (maxY > 0) && (window.scrollY / maxY) >= THRESHOLD;
     if (scrolled) show(); else hide();
   };
 

--- a/assets/js/sticky-cta.js
+++ b/assets/js/sticky-cta.js
@@ -1,0 +1,49 @@
+(() => {
+  const isMobile = () => window.matchMedia('(max-width: 768px)').matches;
+
+  // Sticky Element einfügen, falls nicht vorhanden
+  let bar = document.querySelector('.sticky-cta');
+  if (!bar) {
+    bar = document.createElement('div');
+    bar.className = 'sticky-cta';
+    bar.innerHTML = `<a class="btn" href="#quick-start" data-open-form aria-label="Projekt starten">Projekt starten</a>`;
+    document.body.appendChild(bar);
+  }
+
+  const show = () => bar.classList.add('is-visible');
+  const hide = () => bar.classList.remove('is-visible');
+
+  // Ausblenden wenn Formular sichtbar
+  const form = document.querySelector('#quick-start')?.closest('.hero-card') || document.querySelector('#quick-start');
+  let io;
+  if ('IntersectionObserver' in window && form) {
+    io = new IntersectionObserver((entries) => {
+      const inView = entries.some(e => e.isIntersecting);
+      if (inView) hide(); else if (isMobile()) show();
+    }, { rootMargin: '0px 0px -30% 0px', threshold: 0.01 });
+    io.observe(form);
+  }
+
+  // Menü-offen? (Overlay/Panel vorhanden → class .open), dann CTA ausblenden
+  const menu = document.getElementById('mobile-menu');
+  const tickMenu = () => {
+    const open = menu?.classList.contains('open');
+    if (open) hide(); else if (isMobile()) show();
+  };
+  menu?.addEventListener('transitionend', tickMenu);
+  document.addEventListener('click', e => {
+    if (e.target.closest('[data-nav-toggle],[data-nav-close]')) setTimeout(tickMenu, 50);
+  });
+
+  // Scroll-Heuristik: ab 160px einblenden (wenn nicht durch IO/menü versteckt)
+  let lastY = window.scrollY;
+  const onScroll = () => {
+    if (!isMobile()) return hide();
+    const y = window.scrollY;
+    if (y > 160 && !menu?.classList.contains('open')) show(); else hide();
+    lastY = y;
+  };
+  window.addEventListener('scroll', onScroll, { passive: true });
+  window.addEventListener('resize', onScroll);
+  onScroll(); // initial
+})();

--- a/assets/js/sticky-cta.js
+++ b/assets/js/sticky-cta.js
@@ -1,7 +1,8 @@
 (() => {
+  const THRESHOLD = 140; // erst ab diesem Scrollwert anzeigen
   const isMobile = () => window.matchMedia('(max-width: 768px)').matches;
 
-  // Sticky Element (falls fehlt) injizieren
+  // Sticky-Leiste einfügen (falls nicht vorhanden)
   let bar = document.querySelector('.sticky-cta');
   if (!bar) {
     bar = document.createElement('div');
@@ -9,47 +10,46 @@
     bar.innerHTML = `<a class="btn" href="#quick-start" data-open-form aria-label="Projekt starten">Projekt starten</a>`;
     document.body.appendChild(bar);
   }
-
   const show = () => bar.classList.add('is-visible');
   const hide = () => bar.classList.remove('is-visible');
 
-  // Großes Formular / Karte im View? → ausblenden
-  const form = document.querySelector('#quick-start')?.closest('.hero-card') || document.querySelector('#quick-start');
-  let io;
-  if ('IntersectionObserver' in window && form) {
-    io = new IntersectionObserver((entries) => {
-      const inView = entries.some(e => e.isIntersecting);
-      if (inView) hide(); else if (isMobile()) show();
+  // Formular-Karte (für IO-Hide)
+  const card = document.querySelector('#quick-start')?.closest('.hero-card') || document.querySelector('#quick-start');
+  // Mobile-Menü (für Hide bei offenem Menü)
+  const menu = document.getElementById('mobile-menu');
+
+  let formInView = false;
+  if ('IntersectionObserver' in window && card) {
+    const io = new IntersectionObserver((entries) => {
+      formInView = entries.some(e => e.isIntersecting);
+      tick(); // Sichtbarkeit neu bewerten
     }, { rootMargin: '0px 0px -30% 0px', threshold: 0.01 });
-    io.observe(form);
+    io.observe(card);
   }
 
-  // Mobile-Menü offen? → ausblenden
-  const menu = document.getElementById('mobile-menu');
-  const tickMenu = () => {
-    const open = menu?.classList.contains('open');
-    if (open) hide(); else if (isMobile()) show();
-  };
-  document.addEventListener('click', e => {
-    if (e.target.closest('[data-nav-toggle],[data-nav-close]')) setTimeout(tickMenu, 50);
-  });
+  const menuOpen = () => menu?.classList.contains('open');
 
-  // Eingabe-Fokus (Micro-Form + großes Formular) → ausblenden (Keyboard)
-  const isFormField = (el) => el && (el.tagName === 'INPUT' || el.tagName === 'SELECT' || el.tagName === 'TEXTAREA');
-  document.addEventListener('focusin', (e) => {
-    if (isFormField(e.target) && (e.target.closest('#micro-start') || e.target.closest('#quick-start'))) hide();
+  // Eingabefokus (Keyboard) => Sticky ausblenden
+  const isField = el => el && /^(INPUT|SELECT|TEXTAREA)$/.test(el.tagName);
+  document.addEventListener('focusin', e => {
+    if (isField(e.target)) hide();
   });
-  document.addEventListener('focusout', () => {
-    if (isMobile() && !menu?.classList.contains('open')) show();
-  });
+  document.addEventListener('focusout', () => tick());
 
-  // Scroll-Heuristik: ab 160px einblenden (wenn nichts anderes greift)
-  const onScroll = () => {
+  // Hauptlogik: nur mobil, nur nach Scroll, nicht bei offenem Menü, nicht wenn Formular im View
+  const tick = () => {
     if (!isMobile()) return hide();
-    if (!form) return show();
-    if (window.scrollY > 160 && !menu?.classList.contains('open')) show();
+    if (menuOpen()) return hide();
+    if (formInView) return hide();
+
+    const scrolled = window.scrollY >= THRESHOLD;
+    if (scrolled) show(); else hide();
   };
-  window.addEventListener('scroll', onScroll, { passive: true });
-  window.addEventListener('resize', onScroll);
-  onScroll(); // init
+
+  window.addEventListener('scroll', tick, { passive: true });
+  window.addEventListener('resize', tick, { passive: true });
+
+  // Startzustand: versteckt, bis gescrollt wurde
+  hide();
+  tick();
 })();

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -1,0 +1,20 @@
+(() => {
+  const KEY='site-theme';
+  const root=document.documentElement;
+  const prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const saved=localStorage.getItem(KEY);
+  const initial = saved || (prefersDark ? 'dark' : 'light');
+  const apply = (mode) => {
+    root.setAttribute('data-theme', mode);
+    localStorage.setItem(KEY, mode);
+    const btn=document.querySelector('[data-theme-toggle]');
+    if (btn) btn.setAttribute('aria-pressed', mode==='dark' ? 'true' : 'false');
+  };
+  apply(initial);
+  document.addEventListener('click', (e) => {
+    const btn = e.target.closest('[data-theme-toggle]');
+    if (!btn) return;
+    const next = (root.getAttribute('data-theme')==='dark') ? 'light' : 'dark';
+    apply(next);
+  });
+})();

--- a/cancel.html
+++ b/cancel.html
@@ -5,16 +5,25 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Zahlung abgebrochen / Pagamento annullato</title>
     <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+<style>
+  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+  .font-display{font-family:"Outfit", var(--font-sans)}
+  body{font-family:var(--font-sans)}
+</style>
+<link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
 </head>
 <body class="font-sans text-gray-800 bg-white dark:bg-[#111827] transition-colors">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
     <div class="min-h-screen flex items-center justify-center p-6">
         <div class="max-w-md text-center">
             <h1 class="text-3xl font-bold mb-4" data-lang="de">Zahlung abgebrochen</h1>
             <h1 class="text-3xl font-bold mb-4" data-lang="it">Pagamento annullato</h1>
             <p class="mb-4" data-lang="de">Ihre Zahlung wurde abgebrochen. Sie können es erneut versuchen oder uns bei Fragen kontaktieren.</p>
             <p class="mb-4" data-lang="it">Il pagamento è stato annullato. Puoi riprovare o contattarci per domande.</p>
-            <a href="/landing/" class="mt-4 inline-block px-6 py-3 bg-red-600 text-white font-semibold rounded hover:bg-red-700" data-lang="de">Zurück zur Startseite</a>
-            <a href="/landing/" class="mt-4 inline-block px-6 py-3 bg-red-600 text-white font-semibold rounded hover:bg-red-700" data-lang="it">Torna alla home</a>
+            <a href="/TurboSito/landing/" class="mt-4 inline-block px-6 py-3 bg-red-600 text-white font-semibold rounded hover:bg-red-700" data-lang="de">Zurück zur Startseite</a>
+            <a href="/TurboSito/landing/" class="mt-4 inline-block px-6 py-3 bg-red-600 text-white font-semibold rounded hover:bg-red-700" data-lang="it">Torna alla home</a>
         </div>
     </div>
     <script>
@@ -25,5 +34,10 @@
             });
         });
     </script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
 </body>
 </html>

--- a/de/_partials/footer.html
+++ b/de/_partials/footer.html
@@ -1,0 +1,10 @@
+<footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Kontakt: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/de/impressum.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Impressum</a>
+      <span class="mx-2">·</span>
+      <a href="/TurboSito/de/datenschutz.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Datenschutz</a>
+    </p>
+  </div>
+</footer>

--- a/de/_partials/header.html
+++ b/de/_partials/header.html
@@ -1,0 +1,26 @@
+<header id="site-header">
+  <div class="container flex items-center justify-between gap-4">
+    <nav class="site-nav">
+      <a class="brand" href="/TurboSito/de/">TurboSito</a>
+      <a href="/TurboSito/de/ueber-mich.html">Über mich</a>
+      <a href="/TurboSito/de/leistungen.html">Leistungen</a>
+      <a href="/TurboSito/de/portfolio.html">Portfolio</a>
+      <a href="/TurboSito/de/kontakt.html">Kontakt</a>
+    </nav>
+    <div class="header-right flex items-center gap-2">
+    <nav class="lang-switch" aria-label="Sprachumschalter">
+      <a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a>
+      <a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a>
+      <a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a>
+    </nav>
+    <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü">
+      <span aria-hidden="true"></span>
+    </button>
+    <button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false">
+      <span class="icon sun" aria-hidden="true">☀️</span>
+      <span class="icon moon" aria-hidden="true">🌙</span>
+      <span>Theme</span>
+    </button>
+  </div>
+  </div>
+</header>

--- a/de/cases/landingpage-tech-startup.html
+++ b/de/cases/landingpage-tech-startup.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Landingpage für Tech-Startup – Case Study</title>
+  <meta name="description" content="40% mehr Anmeldungen nach Launch. Ansatz, Lösung und Ergebnisse.">
+  <link rel="canonical" href="/TurboSito/de/cases/landingpage-tech-startup.html">
+  <link rel="alternate" hreflang="de" href="/TurboSito/de/cases/landingpage-tech-startup.html">
+  <link rel="alternate" hreflang="en" href="/TurboSito/en/cases/landingpage-tech-startup.html">
+  <link rel="alternate" hreflang="it" href="/TurboSito/it/cases/landingpage-tech-startup.html">
+  <link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+</head>
+<body>
+<header class="section" style="padding-block:24px"><div class="container" style="display:flex;justify-content:space-between;align-items:center;gap:16px">
+  <a class="badge brand" href="/TurboSito/de/">TurboSito</a>
+  <nav style="display:flex;gap:14px"><a href="/TurboSito/de/portfolio.html">Portfolio</a><a href="/TurboSito/de/ueber-mich.html">Über mich</a></nav>
+</div></header>
+
+<section class="section">
+  <div class="container">
+    <div class="badges" style="margin-bottom:12px">
+      <span class="badge brand">Case Study</span><span class="badge">Landingpage</span><span class="badge">Tailwind</span><span class="badge">A/B</span>
+    </div>
+    <h1 style="margin:0 0 8px">Landingpage für Tech-Startup</h1>
+    <p class="muted" style="margin:0 0 16px">Von 0 auf Launch in 48h – klare Struktur, schnelle Performance, messbare Steigerung.</p>
+    <div class="gallery" style="margin-top:12px">
+      <img class="span-12" src="/TurboSito/assets/img/cases/startup-hero.jpg" alt="Hero-Ansicht">
+    </div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container" style="display:grid; gap:16px; grid-template-columns: repeat(3, 1fr);">
+    <div class="kpi"><div class="num">+40%</div><div class="lbl">Anmeldungen</div></div>
+    <div class="kpi"><div class="num">1.1s</div><div class="lbl">LCP (mobil)</div></div>
+    <div class="kpi"><div class="num">48h</div><div class="lbl">Time-to-Launch</div></div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container grid-2">
+    <div class="card pad">
+      <h2 style="margin-top:0">Problem</h2>
+      <p>Landingpage generierte zu wenige Anmeldungen, langsame Ladezeiten, unklare Botschaft.</p>
+      <h3>Hypothesen</h3>
+      <ul><li>Klarere Value Proposition</li><li>Schnellere LCP</li><li>Stärkere CTA-Platzierung</li></ul>
+    </div>
+    <div class="card pad">
+      <h2 style="margin-top:0">Ansatz &amp; Lösung</h2>
+      <ul>
+        <li>Wireframe → schlanke Hero-Struktur, Social-Proof, präzise Benefits</li>
+        <li>Technik: Static Export + Tailwind, Bildoptimierung, lazy images</li>
+        <li>A/B-Test CTA-Varianten</li>
+      </ul>
+      <h3>Stack</h3>
+      <div class="badges"><span class="badge">Eleventy</span><span class="badge">Tailwind</span><span class="badge">Alpine</span><span class="badge">Plausible</span></div>
+    </div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container gallery">
+    <img class="span-6" src="/TurboSito/assets/img/cases/startup-section.jpg" alt="Sektion">
+    <img class="span-6" src="/TurboSito/assets/img/cases/startup-mobile.jpg" alt="Mobil">
+    <img class="span-12" src="/TurboSito/assets/img/cases/startup-graph.jpg" alt="Ergebnis-Graph">
+  </div>
+</section>
+
+<section class="section">
+  <div class="container card pad" style="display:flex;justify-content:space-between;align-items:center;gap:12px">
+    <div><strong>Live:</strong> <a href="#" rel="noopener">Zum Projekt</a> · <strong>Code:</strong> <a href="#" rel="noopener">GitHub</a></div>
+    <a class="btn" href="/TurboSito/de/#quick-start">Ähnliches Projekt starten</a>
+  </div>
+</section>
+
+<footer class="section"><div class="container" style="display:flex;gap:12px">
+  <a href="/TurboSito/de/portfolio.html">Zurück zum Portfolio</a>
+</div></footer>
+</body>
+</html>

--- a/de/cases/landingpage-tech-startup.html
+++ b/de/cases/landingpage-tech-startup.html
@@ -1,80 +1,110 @@
-<!doctype html>
-<html lang="de">
+<!DOCTYPE html>
+<html lang="de" class="scroll-smooth">
 <head>
-  <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Landingpage für Tech-Startup – Case Study</title>
   <meta name="description" content="40% mehr Anmeldungen nach Launch. Ansatz, Lösung und Ergebnisse.">
-  <link rel="canonical" href="/TurboSito/de/cases/landingpage-tech-startup.html">
-  <link rel="alternate" hreflang="de" href="/TurboSito/de/cases/landingpage-tech-startup.html">
-  <link rel="alternate" hreflang="en" href="/TurboSito/en/cases/landingpage-tech-startup.html">
-  <link rel="alternate" hreflang="it" href="/TurboSito/it/cases/landingpage-tech-startup.html">
+  <link rel="canonical" href="https://deine-domain.tld/de/cases/landingpage-tech-startup.html">
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/cases/landingpage-tech-startup.html">
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/cases/landingpage-tech-startup.html">
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/cases/landingpage-tech-startup.html">
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+<style>
+  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+  .font-display{font-family:"Outfit", var(--font-sans)}
+  body{font-family:var(--font-sans)}
+</style>
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+  <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
 </head>
-<body>
-<header class="section" style="padding-block:24px"><div class="container" style="display:flex;justify-content:space-between;align-items:center;gap:16px">
-  <a class="badge brand" href="/TurboSito/de/">TurboSito</a>
-  <nav style="display:flex;gap:14px"><a href="/TurboSito/de/portfolio.html">Portfolio</a><a href="/TurboSito/de/ueber-mich.html">Über mich</a></nav>
-</div></header>
-
-<section class="section">
-  <div class="container">
-    <div class="badges" style="margin-bottom:12px">
-      <span class="badge brand">Case Study</span><span class="badge">Landingpage</span><span class="badge">Tailwind</span><span class="badge">A/B</span>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Zum Inhalt springen</a>
+<header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/de/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/de/">Start</a><a href="/TurboSito/de/ueber-mich.html">Über mich</a><a href="/TurboSito/de/leistungen.html">Leistungen</a><a href="/TurboSito/de/portfolio.html" aria-current="page" class="text-indigo-600 font-semibold">Portfolio</a><a href="/TurboSito/de/kontakt.html">Kontakt</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Sprache"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button></div></div></header>
+<main id="content">
+  <section class="section">
+    <div class="container">
+      <nav class="breadcrumbs"><a href="/TurboSito/de/portfolio.html">Portfolio</a> · <span>Case Study</span></nav>
+      <div class="badges mb-3">
+        <span class="badge brand">Case Study</span><span class="badge">Landingpage</span><span class="badge">Tailwind</span><span class="badge">A/B</span>
+      </div>
+      <h1 class="mb-2">Landingpage für Tech-Startup</h1>
+      <p class="muted mb-4">Von 0 auf Launch in 48h – klare Struktur, schnelle Performance, messbare Steigerung.</p>
+      <div class="gallery mt-3">
+        <img class="case-hero" src="/TurboSito/assets/img/cases/startup-hero.jpg" alt="Hero-Ansicht" width="1200" height="675" loading="lazy" decoding="async">
+      </div>
     </div>
-    <h1 style="margin:0 0 8px">Landingpage für Tech-Startup</h1>
-    <p class="muted" style="margin:0 0 16px">Von 0 auf Launch in 48h – klare Struktur, schnelle Performance, messbare Steigerung.</p>
-    <div class="gallery" style="margin-top:12px">
-      <img class="span-12" src="/TurboSito/assets/img/cases/startup-hero.jpg" alt="Hero-Ansicht">
+  </section>
+  <section class="section">
+    <div class="container grid gap-4 md:grid-cols-3">
+      <div class="card kpi"><big>+40%</big><span>Anmeldungen</span></div>
+      <div class="card kpi"><big>1.1s</big><span>LCP (mobil)</span></div>
+      <div class="card kpi"><big>48h</big><span>Time-to-Launch</span></div>
     </div>
-  </div>
-</section>
-
-<section class="section">
-  <div class="container" style="display:grid; gap:16px; grid-template-columns: repeat(3, 1fr);">
-    <div class="kpi"><div class="num">+40%</div><div class="lbl">Anmeldungen</div></div>
-    <div class="kpi"><div class="num">1.1s</div><div class="lbl">LCP (mobil)</div></div>
-    <div class="kpi"><div class="num">48h</div><div class="lbl">Time-to-Launch</div></div>
-  </div>
-</section>
-
-<section class="section">
-  <div class="container grid-2">
-    <div class="card pad">
-      <h2 style="margin-top:0">Problem</h2>
-      <p>Landingpage generierte zu wenige Anmeldungen, langsame Ladezeiten, unklare Botschaft.</p>
-      <h3>Hypothesen</h3>
-      <ul><li>Klarere Value Proposition</li><li>Schnellere LCP</li><li>Stärkere CTA-Platzierung</li></ul>
+  </section>
+  <section class="section">
+    <div class="container grid-2">
+      <div class="card pad">
+        <h2>Problem</h2>
+        <p>Landingpage generierte zu wenige Anmeldungen, langsame Ladezeiten, unklare Botschaft.</p>
+        <h3>Hypothesen</h3>
+        <ul><li>Klarere Value Proposition</li><li>Schnellere LCP</li><li>Stärkere CTA-Platzierung</li></ul>
+      </div>
+      <div class="card pad">
+        <h2>Ansatz &amp; Lösung</h2>
+        <ul>
+          <li>Wireframe → schlanke Hero-Struktur, Social-Proof, präzise Benefits</li>
+          <li>Technik: Static Export + Tailwind, Bildoptimierung, lazy images</li>
+          <li>A/B-Test CTA-Varianten</li>
+        </ul>
+        <h3>Stack</h3>
+        <div class="badges"><span class="badge">Eleventy</span><span class="badge">Tailwind</span><span class="badge">Alpine</span><span class="badge">Plausible</span></div>
+      </div>
     </div>
-    <div class="card pad">
-      <h2 style="margin-top:0">Ansatz &amp; Lösung</h2>
-      <ul>
-        <li>Wireframe → schlanke Hero-Struktur, Social-Proof, präzise Benefits</li>
-        <li>Technik: Static Export + Tailwind, Bildoptimierung, lazy images</li>
-        <li>A/B-Test CTA-Varianten</li>
-      </ul>
-      <h3>Stack</h3>
-      <div class="badges"><span class="badge">Eleventy</span><span class="badge">Tailwind</span><span class="badge">Alpine</span><span class="badge">Plausible</span></div>
+  </section>
+  <section class="section">
+    <div class="container gallery">
+      <img class="span-6" src="/TurboSito/assets/img/cases/startup-section.jpg" alt="Sektion" width="800" height="600" loading="lazy" decoding="async">
+      <img class="span-6" src="/TurboSito/assets/img/cases/startup-mobile.jpg" alt="Mobil" width="800" height="600" loading="lazy" decoding="async">
+      <img class="span-12" src="/TurboSito/assets/img/cases/startup-graph.jpg" alt="Ergebnis-Graph" width="1200" height="675" loading="lazy" decoding="async">
     </div>
+  </section>
+  <section class="section">
+    <div class="container card pad flex justify-between items-center gap-3 flex-wrap">
+      <div><strong>Live:</strong> <a href="#" rel="noopener">Zum Projekt</a> · <strong>Code:</strong> <a href="#" rel="noopener">GitHub</a></div>
+      <a class="btn" href="/TurboSito/de/#quick-start">Ähnliches Projekt starten</a>
+    </div>
+  </section>
+  <section class="section">
+    <div class="container card pad flex justify-between items-center gap-4 flex-wrap">
+      <div>
+        <h3 class="m-0 mb-1">Bereit, loszulegen?</h3>
+        <p class="muted m-0">Schick mir die wichtigsten Infos – ich melde mich heute noch.</p>
+      </div>
+      <div class="flex gap-3">
+        <a class="btn" href="/TurboSito/de/#quick-start">Projekt starten</a>
+        <a class="btn btn-outline" href="/TurboSito/de/portfolio.html">Weitere Projekte</a>
+      </div>
+    </div>
+  </section>
+</main>
+<footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Kontakt: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/de/impressum.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Impressum</a>
+      <span class="mx-2">·</span>
+      <a href="/TurboSito/de/datenschutz.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Datenschutz</a>
+    </p>
   </div>
-</section>
-
-<section class="section">
-  <div class="container gallery">
-    <img class="span-6" src="/TurboSito/assets/img/cases/startup-section.jpg" alt="Sektion">
-    <img class="span-6" src="/TurboSito/assets/img/cases/startup-mobile.jpg" alt="Mobil">
-    <img class="span-12" src="/TurboSito/assets/img/cases/startup-graph.jpg" alt="Ergebnis-Graph">
-  </div>
-</section>
-
-<section class="section">
-  <div class="container card pad" style="display:flex;justify-content:space-between;align-items:center;gap:12px">
-    <div><strong>Live:</strong> <a href="#" rel="noopener">Zum Projekt</a> · <strong>Code:</strong> <a href="#" rel="noopener">GitHub</a></div>
-    <a class="btn" href="/TurboSito/de/#quick-start">Ähnliches Projekt starten</a>
-  </div>
-</section>
-
-<footer class="section"><div class="container" style="display:flex;gap:12px">
-  <a href="/TurboSito/de/portfolio.html">Zurück zum Portfolio</a>
-</div></footer>
+</footer>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
 </body>
 </html>

--- a/de/danke.html
+++ b/de/danke.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="de" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Danke – TurboSito</title>
+  <meta name="description" content="Vielen Dank für Ihre Nachricht.">
+  <link rel="canonical" href="https://deine-domain.tld/de/danke.html">
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/danke.html">
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/thanks.html">
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/grazie.html">
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/thanks.html">
+  <meta property="og:title" content="Danke – TurboSito">
+  <meta property="og:description" content="Vielen Dank für Ihre Nachricht.">
+  <meta property="og:url" content="https://deine-domain.tld/de/danke.html">
+  <meta property="og:locale" content="de_DE">
+  <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+<style>
+  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+  .font-display{font-family:"Outfit", var(--font-sans)}
+  body{font-family:var(--font-sans)}
+</style>
+<link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+<script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
+<header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/de/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/de/">Start</a><a href="/TurboSito/de/ueber-mich.html">Über mich</a><a href="/TurboSito/de/leistungen.html">Leistungen</a><a href="/TurboSito/de/portfolio.html">Portfolio</a><a href="/TurboSito/de/kontakt.html">Kontakt</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Sprache"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button></div></div></header>
+
+<main id="content" class="max-w-3xl mx-auto px-4 py-20 text-center">
+  <h1 class="text-4xl font-bold mb-4">Danke!</h1>
+  <p class="mb-6">Ihre Nachricht wurde gesendet.</p>
+  <a href="/TurboSito/de/" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Zur Startseite</a>
+</main>
+<footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Kontakt: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/de/impressum.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Impressum</a>
+      <span class="mx-2">·</span>
+      <a href="/TurboSito/de/datenschutz.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Datenschutz</a>
+    </p>
+  </div>
+</footer>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+</body>
+</html>

--- a/de/datenschutz.html
+++ b/de/datenschutz.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="de" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Datenschutz – TurboSito</title>
+  <meta name="description" content="Informationen zum Datenschutz.">
+  <link rel="canonical" href="https://deine-domain.tld/de/datenschutz.html">
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/datenschutz.html">
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/legal.html">
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/privacy.html">
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
+  <meta property="og:title" content="Datenschutz – TurboSito">
+  <meta property="og:description" content="Informationen zum Datenschutz.">
+  <meta property="og:url" content="https://deine-domain.tld/de/datenschutz.html">
+  <meta property="og:locale" content="de_DE">
+  <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+<style>
+  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+  .font-display{font-family:"Outfit", var(--font-sans)}
+  body{font-family:var(--font-sans)}
+</style>
+<link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+<script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
+<a href="#main" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:bg-white focus:text-indigo-600 focus:px-3 focus:py-2 focus:rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500">Zum Inhalt springen</a>
+<header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/de/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/de/">Start</a><a href="/TurboSito/de/ueber-mich.html">Über mich</a><a href="/TurboSito/de/leistungen.html">Leistungen</a><a href="/TurboSito/de/portfolio.html">Portfolio</a><a href="/TurboSito/de/kontakt.html">Kontakt</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Sprache"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button></div></div></header>
+
+<main id="content" class="max-w-3xl mx-auto px-4 py-12 space-y-6">
+  <h1 class="text-3xl font-bold mb-6">Datenschutz</h1>
+  <section>
+    <h2 class="text-2xl font-semibold mb-2">Verantwortlicher</h2>
+    <p>Platzhalter für Angaben zum Verantwortlichen.</p>
+  </section>
+  <section>
+    <h2 class="text-2xl font-semibold mb-2">Datenarten</h2>
+    <p>Platzhalter für verarbeitete Datenarten.</p>
+  </section>
+  <section>
+    <h2 class="text-2xl font-semibold mb-2">Zwecke</h2>
+    <p>Platzhalter für Verarbeitungszwecke.</p>
+  </section>
+  <section>
+    <h2 class="text-2xl font-semibold mb-2">Rechtsgrundlagen</h2>
+    <p>Platzhalter für Rechtsgrundlagen.</p>
+  </section>
+  <section>
+    <h2 class="text-2xl font-semibold mb-2">Kontakt</h2>
+    <p>Platzhalter für Kontaktinformationen.</p>
+  </section>
+  <p><a href="/TurboSito/de/kontakt.html" class="text-indigo-600 hover:underline">Zur Kontaktseite</a></p>
+</main>
+<footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Kontakt: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/de/impressum.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Impressum</a>
+      <span class="mx-2">·</span>
+      <a href="/TurboSito/de/datenschutz.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Datenschutz</a>
+    </p>
+  </div>
+</footer>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+</body>
+</html>

--- a/de/demos/corporate-site.html
+++ b/de/demos/corporate-site.html
@@ -4,14 +4,14 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Corporate-Site (Demo) – TurboSito</title>
-  <meta name="description" content="Demo einer Corporate-Site – kein Kundenprojekt.">
+  <meta name="description" content="Demo – kein Kundenprojekt. Vorschau auf Stil & Prozess.">
   <link rel="canonical" href="https://deine-domain.tld/de/demos/corporate-site.html">
   <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/demos/corporate-site.html">
   <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/demos/corporate-site.html">
   <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/demos/corporate-site.html">
   <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
   <meta property="og:title" content="Corporate-Site (Demo) – TurboSito">
-  <meta property="og:description" content=" Demo einer Corporate-Site – kein Kundenprojekt.">
+  <meta property="og:description" content="Demo – kein Kundenprojekt. Vorschau auf Stil & Prozess.">
   <meta property="og:url" content="https://deine-domain.tld/de/demos/corporate-site.html">
   <meta property="og:locale" content="de_DE">
   <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
@@ -25,8 +25,16 @@
   </style>
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"WebPage",
+    "name":"Corporate-Site (Demo)",
+    "isPartOf":"Portfolio Demo"
+  }
+  </script>
 </head>
-<body class="font-sans text-gray-900">
+<body class="font-sans text-gray-900 demo-page">
   <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
 <header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/de/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/de/">Start</a><a href="/TurboSito/de/ueber-mich.html">Über mich</a><a href="/TurboSito/de/leistungen.html">Leistungen</a><a href="/TurboSito/de/portfolio.html">Portfolio</a><a href="/TurboSito/de/kontakt.html">Kontakt</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Sprache"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button></div></div></header>
 <main id="content" class="section"><div class="container">
@@ -59,9 +67,9 @@
     </div>
     <div class="demo-card">
       <h3>Mini-Formular</h3>
-      <form onsubmit="return false" style="display:flex;gap:8px;flex-wrap:wrap">
+      <form class="demo-mini-form" style="display:flex;gap:8px;flex-wrap:wrap">
         <input type="email" placeholder="E-Mail" required class="input" style="min-width:220px">
-        <button class="btn">Los geht’s</button>
+        <button class="btn" type="submit">Los geht’s</button>
       </form>
     </div>
   </div>
@@ -93,5 +101,17 @@
   <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
   <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
   <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+  <script>
+  document.querySelectorAll('.demo-mini-form').forEach(f=>{
+    f.addEventListener('submit',e=>{
+      e.preventDefault();
+      const email=f.querySelector('input[type=email]').value.trim();
+      if(email){
+        localStorage.setItem('lead_email', email);
+        location.href='/TurboSito/de/kontakt.html';
+      }
+    });
+  });
+  </script>
 </body>
 </html>

--- a/de/demos/corporate-site.html
+++ b/de/demos/corporate-site.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="de" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Corporate-Site (Demo) – TurboSito</title>
+  <meta name="description" content="Demo einer Corporate-Site – kein Kundenprojekt.">
+  <link rel="canonical" href="https://deine-domain.tld/de/demos/corporate-site.html">
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/demos/corporate-site.html">
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/demos/corporate-site.html">
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/demos/corporate-site.html">
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
+  <meta property="og:title" content="Corporate-Site (Demo) – TurboSito">
+  <meta property="og:description" content=" Demo einer Corporate-Site – kein Kundenprojekt.">
+  <meta property="og:url" content="https://deine-domain.tld/de/demos/corporate-site.html">
+  <meta property="og:locale" content="de_DE">
+  <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+  <style>
+    :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+    .font-display{font-family:"Outfit", var(--font-sans)}
+    body{font-family:var(--font-sans)}
+  </style>
+  <link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+  <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
+<header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/de/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/de/">Start</a><a href="/TurboSito/de/ueber-mich.html">Über mich</a><a href="/TurboSito/de/leistungen.html">Leistungen</a><a href="/TurboSito/de/portfolio.html">Portfolio</a><a href="/TurboSito/de/kontakt.html">Kontakt</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Sprache"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button></div></div></header>
+<main id="content" class="section"><div class="container">
+  <nav class="breadcrumbs"><a href="/TurboSito/de/portfolio.html">Portfolio</a> · <span>Demo</span></nav>
+  <span class="badge badge-demo">Demo</span>
+  <h1>Corporate-Site (Demo)</h1>
+  <p class="muted">Dies ist eine Demo – kein Kundenprojekt. Demo – modulare Unternehmensseite mit klarer Navigation, Leistungs- und Team-Sektion.</p>
+  <div class="demo-hero">
+    <a class="btn" href="/TurboSito/de/#quick-start">Projekt starten</a>
+    <a class="btn btn-outline" href="/TurboSito/de/kontakt.html">Kontakt</a>
+  </div>
+  <div class="demo-grid">
+    <div class="demo-card"><h3>Navigation & IA</h3><p>Strukturierte Menüs, klare Seitenhierarchie.</p></div>
+    <div class="demo-card"><h3>Performance</h3><p>Statischer Export, sauberes Markup, lazy Inhalte.</p></div>
+    <div class="demo-card"><h3>Trust-Elemente</h3><p>Testimonials, Logo-Leiste, CTA-Footer.</p></div>
+  </div>
+  <h2>Komponenten</h2>
+  <div class="demo-grid">
+    <div class="demo-card">
+      <h3>Buttons</h3>
+      <div style="display:flex;gap:8px;flex-wrap:wrap">
+        <a class="btn">Primary</a>
+        <a class="btn btn-outline">Outline</a>
+        <a class="btn btn-ghost">Ghost</a>
+      </div>
+    </div>
+    <div class="demo-card">
+      <h3>Karte</h3>
+      <p class="muted">Beispielkarte mit Schatten, Radius und Tokenfarben.</p>
+    </div>
+    <div class="demo-card">
+      <h3>Mini-Formular</h3>
+      <form onsubmit="return false" style="display:flex;gap:8px;flex-wrap:wrap">
+        <input type="email" placeholder="E-Mail" required class="input" style="min-width:220px">
+        <button class="btn">Los geht’s</button>
+      </form>
+    </div>
+  </div>
+  <div class="demo-cta">
+    <div>
+      <h3 style="margin:0 0 4px">Bereit, loszulegen?</h3>
+      <p class="muted" style="margin:0">Schick mir die wichtigsten Infos – ich melde mich heute noch.</p>
+    </div>
+    <div style="display:flex;gap:12px;flex-wrap:wrap">
+      <a class="btn" href="/TurboSito/de/#quick-start">Projekt starten</a>
+      <a class="btn btn-outline" href="/TurboSito/de/portfolio.html">Weitere Projekte</a>
+    </div>
+  </div>
+</div></main>
+<footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Kontakt: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/de/impressum.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Impressum</a>
+      <span class="mx-2">·</span>
+      <a href="/TurboSito/de/datenschutz.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Datenschutz</a>
+    </p>
+  </div>
+</footer>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+</body>
+</html>

--- a/de/demos/fashion-shop.html
+++ b/de/demos/fashion-shop.html
@@ -4,14 +4,14 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Fashion-Shop (Demo) – TurboSito</title>
-  <meta name="description" content="Demo einer Fashion-Shop – kein Kundenprojekt.">
+  <meta name="description" content="Demo – kein Kundenprojekt. Vorschau auf Stil & Prozess.">
   <link rel="canonical" href="https://deine-domain.tld/de/demos/fashion-shop.html">
   <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/demos/fashion-shop.html">
   <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/demos/fashion-shop.html">
   <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/demos/fashion-shop.html">
   <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
   <meta property="og:title" content="Fashion-Shop (Demo) – TurboSito">
-  <meta property="og:description" content="Demo eines Fashion-Shops – kein Kundenprojekt.">
+  <meta property="og:description" content="Demo – kein Kundenprojekt. Vorschau auf Stil & Prozess.">
   <meta property="og:url" content="https://deine-domain.tld/de/demos/fashion-shop.html">
   <meta property="og:locale" content="de_DE">
   <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
@@ -25,8 +25,16 @@
   </style>
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"WebPage",
+    "name":"Fashion-Shop (Demo)",
+    "isPartOf":"Portfolio Demo"
+  }
+  </script>
 </head>
-<body class="font-sans text-gray-900">
+<body class="font-sans text-gray-900 demo-page">
   <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
 <header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/de/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/de/">Start</a><a href="/TurboSito/de/ueber-mich.html">Über mich</a><a href="/TurboSito/de/leistungen.html">Leistungen</a><a href="/TurboSito/de/portfolio.html">Portfolio</a><a href="/TurboSito/de/kontakt.html">Kontakt</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Sprache"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button></div></div></header>
 <main id="content" class="section"><div class="container">
@@ -59,9 +67,9 @@
     </div>
     <div class="demo-card">
       <h3>Mini-Formular</h3>
-      <form onsubmit="return false" style="display:flex;gap:8px;flex-wrap:wrap">
+      <form class="demo-mini-form" style="display:flex;gap:8px;flex-wrap:wrap">
         <input type="email" placeholder="E-Mail" required class="input" style="min-width:220px">
-        <button class="btn">Los geht’s</button>
+        <button class="btn" type="submit">Los geht’s</button>
       </form>
     </div>
   </div>
@@ -93,5 +101,17 @@
   <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
   <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
   <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+  <script>
+  document.querySelectorAll('.demo-mini-form').forEach(f=>{
+    f.addEventListener('submit',e=>{
+      e.preventDefault();
+      const email=f.querySelector('input[type=email]').value.trim();
+      if(email){
+        localStorage.setItem('lead_email', email);
+        location.href='/TurboSito/de/kontakt.html';
+      }
+    });
+  });
+  </script>
 </body>
 </html>

--- a/de/demos/fashion-shop.html
+++ b/de/demos/fashion-shop.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="de" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Fashion-Shop (Demo) – TurboSito</title>
+  <meta name="description" content="Demo einer Fashion-Shop – kein Kundenprojekt.">
+  <link rel="canonical" href="https://deine-domain.tld/de/demos/fashion-shop.html">
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/demos/fashion-shop.html">
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/demos/fashion-shop.html">
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/demos/fashion-shop.html">
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
+  <meta property="og:title" content="Fashion-Shop (Demo) – TurboSito">
+  <meta property="og:description" content="Demo eines Fashion-Shops – kein Kundenprojekt.">
+  <meta property="og:url" content="https://deine-domain.tld/de/demos/fashion-shop.html">
+  <meta property="og:locale" content="de_DE">
+  <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+  <style>
+    :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+    .font-display{font-family:"Outfit", var(--font-sans)}
+    body{font-family:var(--font-sans)}
+  </style>
+  <link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+  <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
+<header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/de/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/de/">Start</a><a href="/TurboSito/de/ueber-mich.html">Über mich</a><a href="/TurboSito/de/leistungen.html">Leistungen</a><a href="/TurboSito/de/portfolio.html">Portfolio</a><a href="/TurboSito/de/kontakt.html">Kontakt</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Sprache"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button></div></div></header>
+<main id="content" class="section"><div class="container">
+  <nav class="breadcrumbs"><a href="/TurboSito/de/portfolio.html">Portfolio</a> · <span>Demo</span></nav>
+  <span class="badge badge-demo">Demo</span>
+  <h1>Fashion-Shop (Demo)</h1>
+  <p class="muted">Dies ist eine Demo – kein Kundenprojekt. Demo – Shop-Startseite mit Hero, Produkt-Grid und Checkout-CTA.</p>
+  <div class="demo-hero">
+    <a class="btn" href="/TurboSito/de/#quick-start">Projekt starten</a>
+    <a class="btn btn-outline" href="/TurboSito/de/kontakt.html">Kontakt</a>
+  </div>
+  <div class="demo-grid">
+    <div class="demo-card"><h3>Produkt-Grid</h3><p>Cards, Filter, responsive Tiles.</p></div>
+    <div class="demo-card"><h3>Speed</h3><p>Optimierte Assets, minimaler JS.</p></div>
+    <div class="demo-card"><h3>Conversion-CTAs</h3><p>Sticky CTA, Checkout-Link, Kaufimpulse.</p></div>
+  </div>
+  <h2>Komponenten</h2>
+  <div class="demo-grid">
+    <div class="demo-card">
+      <h3>Buttons</h3>
+      <div style="display:flex;gap:8px;flex-wrap:wrap">
+        <a class="btn">Primary</a>
+        <a class="btn btn-outline">Outline</a>
+        <a class="btn btn-ghost">Ghost</a>
+      </div>
+    </div>
+    <div class="demo-card">
+      <h3>Karte</h3>
+      <p class="muted">Beispielkarte mit Schatten, Radius und Tokenfarben.</p>
+    </div>
+    <div class="demo-card">
+      <h3>Mini-Formular</h3>
+      <form onsubmit="return false" style="display:flex;gap:8px;flex-wrap:wrap">
+        <input type="email" placeholder="E-Mail" required class="input" style="min-width:220px">
+        <button class="btn">Los geht’s</button>
+      </form>
+    </div>
+  </div>
+  <div class="demo-cta">
+    <div>
+      <h3 style="margin:0 0 4px">Bereit, loszulegen?</h3>
+      <p class="muted" style="margin:0">Schick mir die wichtigsten Infos – ich melde mich heute noch.</p>
+    </div>
+    <div style="display:flex;gap:12px;flex-wrap:wrap">
+      <a class="btn" href="/TurboSito/de/#quick-start">Projekt starten</a>
+      <a class="btn btn-outline" href="/TurboSito/de/portfolio.html">Weitere Projekte</a>
+    </div>
+  </div>
+</div></main>
+<footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Kontakt: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/de/impressum.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Impressum</a>
+      <span class="mx-2">·</span>
+      <a href="/TurboSito/de/datenschutz.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Datenschutz</a>
+    </p>
+  </div>
+</footer>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+</body>
+</html>

--- a/de/demos/saas-landing.html
+++ b/de/demos/saas-landing.html
@@ -4,14 +4,14 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>SaaS-Landing (Demo) – TurboSito</title>
-  <meta name="description" content="Demo einer SaaS-Landingpage – kein Kundenprojekt.">
+  <meta name="description" content="Demo – kein Kundenprojekt. Vorschau auf Stil & Prozess.">
   <link rel="canonical" href="https://deine-domain.tld/de/demos/saas-landing.html">
   <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/demos/saas-landing.html">
   <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/demos/saas-landing.html">
   <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/demos/saas-landing.html">
   <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
   <meta property="og:title" content="SaaS-Landing (Demo) – TurboSito">
-  <meta property="og:description" content="Demo einer SaaS-Landingpage – kein Kundenprojekt.">
+  <meta property="og:description" content="Demo – kein Kundenprojekt. Vorschau auf Stil & Prozess.">
   <meta property="og:url" content="https://deine-domain.tld/de/demos/saas-landing.html">
   <meta property="og:locale" content="de_DE">
   <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
@@ -25,8 +25,16 @@
   </style>
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+  <script type="application/ld+json">
+  {
+    "@context":"https://schema.org",
+    "@type":"WebPage",
+    "name":"SaaS-Landing (Demo)",
+    "isPartOf":"Portfolio Demo"
+  }
+  </script>
 </head>
-<body class="font-sans text-gray-900">
+<body class="font-sans text-gray-900 demo-page">
   <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
 <header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/de/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/de/">Start</a><a href="/TurboSito/de/ueber-mich.html">Über mich</a><a href="/TurboSito/de/leistungen.html">Leistungen</a><a href="/TurboSito/de/portfolio.html">Portfolio</a><a href="/TurboSito/de/kontakt.html">Kontakt</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Sprache"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button></div></div></header>
 <main id="content" class="section"><div class="container">
@@ -59,9 +67,9 @@
     </div>
     <div class="demo-card">
       <h3>Mini-Formular</h3>
-      <form onsubmit="return false" style="display:flex;gap:8px;flex-wrap:wrap">
+      <form class="demo-mini-form" style="display:flex;gap:8px;flex-wrap:wrap">
         <input type="email" placeholder="E-Mail" required class="input" style="min-width:220px">
-        <button class="btn">Los geht’s</button>
+        <button class="btn" type="submit">Los geht’s</button>
       </form>
     </div>
   </div>
@@ -93,5 +101,17 @@
   <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
   <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
   <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+  <script>
+  document.querySelectorAll('.demo-mini-form').forEach(f=>{
+    f.addEventListener('submit',e=>{
+      e.preventDefault();
+      const email=f.querySelector('input[type=email]').value.trim();
+      if(email){
+        localStorage.setItem('lead_email', email);
+        location.href='/TurboSito/de/kontakt.html';
+      }
+    });
+  });
+  </script>
 </body>
 </html>

--- a/de/demos/saas-landing.html
+++ b/de/demos/saas-landing.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="de" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>SaaS-Landing (Demo) – TurboSito</title>
+  <meta name="description" content="Demo einer SaaS-Landingpage – kein Kundenprojekt.">
+  <link rel="canonical" href="https://deine-domain.tld/de/demos/saas-landing.html">
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/demos/saas-landing.html">
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/demos/saas-landing.html">
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/demos/saas-landing.html">
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
+  <meta property="og:title" content="SaaS-Landing (Demo) – TurboSito">
+  <meta property="og:description" content="Demo einer SaaS-Landingpage – kein Kundenprojekt.">
+  <meta property="og:url" content="https://deine-domain.tld/de/demos/saas-landing.html">
+  <meta property="og:locale" content="de_DE">
+  <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+  <style>
+    :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+    .font-display{font-family:"Outfit", var(--font-sans)}
+    body{font-family:var(--font-sans)}
+  </style>
+  <link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+  <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
+<header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/de/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/de/">Start</a><a href="/TurboSito/de/ueber-mich.html">Über mich</a><a href="/TurboSito/de/leistungen.html">Leistungen</a><a href="/TurboSito/de/portfolio.html">Portfolio</a><a href="/TurboSito/de/kontakt.html">Kontakt</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Sprache"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button></div></div></header>
+<main id="content" class="section"><div class="container">
+  <nav class="breadcrumbs"><a href="/TurboSito/de/portfolio.html">Portfolio</a> · <span>Demo</span></nav>
+  <span class="badge badge-demo">Demo</span>
+  <h1>SaaS-Landing (Demo)</h1>
+  <p class="muted">Dies ist eine Demo – kein Kundenprojekt. Zeigt Stil, Struktur und Geschwindigkeit.</p>
+  <div class="demo-hero">
+    <a class="btn" href="/TurboSito/de/#quick-start">Projekt starten</a>
+    <a class="btn btn-outline" href="/TurboSito/de/kontakt.html">Kontakt</a>
+  </div>
+  <div class="demo-grid">
+    <div class="demo-card"><h3>Klarer Aufbau</h3><p>Above-the-fold, prägnante Benefits, eindeutige CTAs.</p></div>
+    <div class="demo-card"><h3>Performance</h3><p>Statischer Export, sauberes Markup, lazy Inhalte.</p></div>
+    <div class="demo-card"><h3>Conversion-ready</h3><p>Formular, Social-Proof, Scroll-CTAs vorbereitet.</p></div>
+  </div>
+  <h2>Komponenten</h2>
+  <div class="demo-grid">
+    <div class="demo-card">
+      <h3>Buttons</h3>
+      <div style="display:flex;gap:8px;flex-wrap:wrap">
+        <a class="btn">Primary</a>
+        <a class="btn btn-outline">Outline</a>
+        <a class="btn btn-ghost">Ghost</a>
+      </div>
+    </div>
+    <div class="demo-card">
+      <h3>Karte</h3>
+      <p class="muted">Beispielkarte mit Schatten, Radius und Tokenfarben.</p>
+    </div>
+    <div class="demo-card">
+      <h3>Mini-Formular</h3>
+      <form onsubmit="return false" style="display:flex;gap:8px;flex-wrap:wrap">
+        <input type="email" placeholder="E-Mail" required class="input" style="min-width:220px">
+        <button class="btn">Los geht’s</button>
+      </form>
+    </div>
+  </div>
+  <div class="demo-cta">
+    <div>
+      <h3 style="margin:0 0 4px">Bereit, loszulegen?</h3>
+      <p class="muted" style="margin:0">Schick mir die wichtigsten Infos – ich melde mich heute noch.</p>
+    </div>
+    <div style="display:flex;gap:12px;flex-wrap:wrap">
+      <a class="btn" href="/TurboSito/de/#quick-start">Projekt starten</a>
+      <a class="btn btn-outline" href="/TurboSito/de/portfolio.html">Weitere Projekte</a>
+    </div>
+  </div>
+</div></main>
+<footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Kontakt: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/de/impressum.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Impressum</a>
+      <span class="mx-2">·</span>
+      <a href="/TurboSito/de/datenschutz.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Datenschutz</a>
+    </p>
+  </div>
+</footer>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+</body>
+</html>

--- a/de/impressum.html
+++ b/de/impressum.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="de" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Impressum – TurboSito</title>
+  <meta name="description" content="Anbieterkennzeichnung für TurboSito.">
+  <link rel="canonical" href="https://deine-domain.tld/de/impressum.html">
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/impressum.html">
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/legal.html">
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/note-legali.html">
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
+  <meta property="og:title" content="Impressum – TurboSito">
+  <meta property="og:description" content="Anbieterkennzeichnung für TurboSito.">
+  <meta property="og:url" content="https://deine-domain.tld/de/impressum.html">
+  <meta property="og:locale" content="de_DE">
+  <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+<style>
+  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+  .font-display{font-family:"Outfit", var(--font-sans)}
+  body{font-family:var(--font-sans)}
+</style>
+<link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+<script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
+<!-- header include start -->
+<a href="#main" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:bg-white focus:text-indigo-600 focus:px-3 focus:py-2 focus:rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500">Zum Inhalt springen</a>
+<header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/de/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/de/">Start</a><a href="/TurboSito/de/ueber-mich.html">Über mich</a><a href="/TurboSito/de/leistungen.html">Leistungen</a><a href="/TurboSito/de/portfolio.html">Portfolio</a><a href="/TurboSito/de/kontakt.html">Kontakt</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Sprache"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button></div></div></header>
+
+<main id="content" class="max-w-3xl mx-auto px-4 py-12">
+  <h1 class="text-3xl font-bold mb-6">Impressum</h1>
+  <p class="mb-4"><strong>Name:</strong> <!-- [[IMPR_NAME]] --><span data-key="IMPR_NAME" class="ph"></span></p>
+  <p class="mb-4"><strong>Adresse:</strong> <!-- [[IMPR_ADRESSE]] --><span data-key="IMPR_ADRESSE" class="ph"></span></p>
+  <p class="mb-4"><strong>E-Mail:</strong> <a href="mailto:[[IMPR_EMAIL]]" class="underline"><!-- [[IMPR_EMAIL]] --><span data-key="IMPR_EMAIL" class="ph"></span></a></p>
+  <p class="mb-8"><strong>Steuernummer:</strong> <!-- [[IMPR_STEUERNR]] --><span data-key="IMPR_STEUERNR" class="ph"></span></p>
+  <p><a href="/TurboSito/de/kontakt.html" class="text-indigo-600 hover:underline">Zur Kontaktseite</a></p>
+</main>
+<footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Kontakt: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/de/impressum.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Impressum</a>
+      <span class="mx-2">·</span>
+      <a href="/TurboSito/de/datenschutz.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Datenschutz</a>
+    </p>
+  </div>
+</footer>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+</body>
+</html>

--- a/de/index.html
+++ b/de/index.html
@@ -1,0 +1,427 @@
+<!DOCTYPE html>
+<html lang="de" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>TurboSito – Website in 48 Stunden</title>
+  <meta name="description" content="Website in 48 Stunden. Fixpreis. Mehr Anfragen – ohne Telefonat.">
+  <link rel="canonical" href="https://deine-domain.tld/de/">
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/">
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/">
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/">
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
+  <meta property="og:title" content="TurboSito – Website in 48 Stunden">
+  <meta property="og:description" content="Website in 48 Stunden. Fixpreis. Mehr Anfragen – ohne Telefonat.">
+  <meta property="og:url" content="https://deine-domain.tld/de/">
+  <meta property="og:locale" content="de_DE">
+  <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "name": "Max Mustermann",
+  "url": "https://deine-domain.tld",
+  "sameAs": [
+    "https://github.com/example",
+    "https://www.linkedin.com/in/example"
+  ],
+  "worksFor": {
+    "@type": "Organization",
+    "name": "TurboSito"
+  }
+}
+</script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": "TurboSito",
+  "url": "https://deine-domain.tld",
+  "inLanguage": "de",
+  "potentialAction": {
+    "@type": "SearchAction",
+    "target": "https://deine-domain.tld/de/?s={search_term_string}",
+    "query-input": "required name=search_term_string"
+  }
+}
+</script>
+  <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+<style>
+  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+  .font-display{font-family:"Outfit", var(--font-sans)}
+  body{font-family:var(--font-sans)}
+</style>
+<link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
+  <header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/de/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/de/">Start</a><a href="/TurboSito/de/ueber-mich.html">Über mich</a><a href="/TurboSito/de/leistungen.html">Leistungen</a><a href="/TurboSito/de/portfolio.html">Portfolio</a><a href="/TurboSito/de/kontakt.html">Kontakt</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Sprache"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button></div></div></header>
+
+  <main id="content" role="main">
+    <section class="relative overflow-hidden section-hero">
+      <div aria-hidden="true" class="orb -top-40 -left-40"></div>
+      <div class="container grid gap-10 md:grid-cols-12 items-center">
+        <div class="md:col-span-6 space-y-6">
+          <div class="kicker badge inline-block"></div>
+          <h1 class="font-display text-4xl md:text-6xl font-extrabold tracking-tight"><span class="text-gradient">Website in 48 Stunden</span></h1>
+          <p class="mt-4 text-lg hero-subtitle text-[var(--fg)]">Fixpreis. Mehr Anfragen – ohne Telefonat.</p>
+          <div class="cta-hero">
+            <a class="btn" href="#quick-start">Kontakt aufnehmen</a>
+            <a class="btn btn-outline" href="/TurboSito/de/portfolio.html">Portfolio ansehen</a>
+          </div>
+          <form id="micro-start" class="micro-start" novalidate>
+            <label class="sr-only" for="micro-email">E-Mail</label>
+            <input id="micro-email" name="email" type="email"
+                   placeholder="E-Mail eingeben" inputmode="email"
+                   autocomplete="email" required>
+            <button class="btn" type="submit">Los geht’s</button>
+          </form>
+        </div>
+        <div class="md:col-span-6 mt-10 md:mt-0">
+          <div class="hero-card">
+            <form id="quick-start" novalidate>
+  <h3 class="font-semibold text-lg">Projekt in 2&nbsp;Minuten starten</h3>
+  <p class="meta">Kurzinfo reicht – Details klären wir später. Antwort meist am selben Tag.</p>
+
+  <div class="field">
+    <label for="name">Name</label>
+    <input id="name" name="name" class="input" autocomplete="name" required>
+  </div>
+
+  <div class="field">
+    <label for="email">E-Mail</label>
+    <input id="email" name="email" class="input" type="email" inputmode="email" autocomplete="email" required>
+  </div>
+
+  <div class="field">
+    <label for="url">Website (optional)</label>
+    <input id="url" name="url" class="input" type="url" placeholder="https://…" inputmode="url" autocomplete="url">
+  </div>
+
+  <div class="row">
+    <div class="field">
+      <label for="ziel">Ziel</label>
+      <select id="ziel" name="ziel" class="input">
+        <option>Mehr Anfragen</option>
+        <option>Neuer Auftritt</option>
+        <option>Schnell live gehen</option>
+      </select>
+    </div>
+    <div class="field">
+      <label for="typ">Projekt-Typ</label>
+      <select id="typ" name="typ" class="input">
+        <option>Landingpage</option>
+        <option>Corporate Site</option>
+        <option>Shop/Produkt</option>
+      </select>
+    </div>
+  </div>
+
+  <div class="field">
+    <label for="note">Kurzbeschreibung (optional)</label>
+    <input id="note" name="note" class="input" maxlength="140" placeholder="1 Satz reicht.">
+    <div class="help" id="charHelp">Noch 140 Zeichen</div>
+  </div>
+
+  <!-- Honeypot + Tracking (versteckt) -->
+  <input type="text" name="company" id="company" tabindex="-1" aria-hidden="true" style="position:absolute;left:-9999px;">
+  <input type="hidden" name="lang" id="lang">
+  <input type="hidden" name="source" id="source">
+  <input type="hidden" name="theme" id="theme">
+  <input type="hidden" name="utm" id="utm">
+
+  <label class="consent">
+    <input type="checkbox" id="ok" required>
+    <span>Ich stimme der Verarbeitung meiner Angaben gemäß <a href="/TurboSito/de/datenschutz.html">Datenschutz</a> zu.</span>
+  </label>
+
+  <div class="actions">
+    <button class="btn" type="submit" id="qs-submit">Anfrage senden</button>
+    <a class="btn btn-outline" href="/TurboSito/de/kontakt.html">Kontakt</a>
+  </div>
+
+  <div class="help" aria-live="polite" id="qs-msg"></div>
+</form>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <h2 class="font-display text-3xl md:text-4xl font-bold mb-6">Ergebnisse in Zahlen</h2>
+        <div class="kpi-strip">
+          <dl class="kpi">
+            <dt>Launch</dt>
+            <dd>48&nbsp;Stunden</dd>
+          </dl>
+          <dl class="kpi">
+            <dt>Ladezeit (LCP)</dt>
+            <dd>≤&nbsp;1&nbsp;s</dd>
+          </dl>
+          <dl class="kpi">
+            <dt>Fixpreis</dt>
+            <dd>100&nbsp;%</dd>
+          </dl>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <h2 class="font-display text-3xl md:text-4xl font-bold mb-8 text-[var(--fg)]">Vorteile</h2>
+        <div class="grid gap-6 md:grid-cols-3">
+          <article class="card hover-lift reveal">
+            <div class="badge inline-flex items-center gap-2 mb-3">
+              <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24"><path fill="currentColor" d="M5 12h14M5 6h14M5 18h14"/></svg>
+              <span>Schnell online</span>
+            </div>
+            <p class="text-[var(--muted)]">Design, Umsetzung &amp; Launch innerhalb von 48 Stunden.</p>
+          </article>
+          <article class="card hover-lift reveal">
+            <div class="badge inline-flex items-center gap-2 mb-3">
+              <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24"><path fill="currentColor" d="M12 2l3 7h7l-5.5 4 2.5 7-7-4.5L5.5 20 8 13 3 9h7z"/></svg>
+              <span>Fixpreis</span>
+            </div>
+            <p class="text-[var(--muted)]">Klarer Festpreis ohne Überraschungen.</p>
+          </article>
+          <article class="card hover-lift reveal">
+            <div class="badge inline-flex items-center gap-2 mb-3">
+              <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24"><path fill="currentColor" d="M4 12h16v2H4zM4 6h16v2H4zM4 18h16v2H4z"/></svg>
+              <span>Auf Ergebnisse optimiert</span>
+            </div>
+            <p class="text-[var(--muted)]">Struktur, Texte &amp; Calls-to-Action für mehr Anfragen.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+    <section class="section">
+      <div class="container">
+        <h2 class="font-display text-3xl md:text-4xl font-bold mb-8 text-fg">Ausgewählte Projekte</h2>
+        <div class="grid gap-6 md:grid-cols-3">
+          <!-- Karte 1 -->
+          <article class="card group hover-lift">
+            <div class="ratio skeleton mb-3" aria-hidden="true"></div>
+            <h3 class="font-semibold text-lg text-fg">Landingpage für Tech-Startup</h3>
+            <p class="text-[var(--muted)] text-sm mb-3">40% mehr Anmeldungen nach Launch.</p>
+            <ul class="mt-2 flex flex-wrap gap-2">
+              <li><span class="badge">Tailwind</span></li>
+              <li><span class="badge">SEO</span></li>
+              <li><span class="badge">A/B</span></li>
+            </ul>
+            <div class="mt-3 flex gap-3">
+              <a class="btn btn-outline" href="/TurboSito/de/portfolio.html">Details</a>
+              <a class="link inline-flex items-center gap-1" href="/TurboSito/de/portfolio.html#live">Live</a>
+            </div>
+          </article>
+
+          <!-- Karte 2 -->
+          <article class="card group hover-lift">
+            <div class="ratio skeleton mb-3" aria-hidden="true"></div>
+            <h3 class="font-semibold text-lg text-fg">Corporate Website Beratung</h3>
+            <p class="text-[var(--muted)] text-sm mb-3">Leads um 30% gesteigert.</p>
+            <ul class="mt-2 flex flex-wrap gap-2">
+              <li><span class="badge">UX</span></li>
+              <li><span class="badge">Conversion</span></li>
+            </ul>
+            <div class="mt-3 flex gap-3">
+              <a class="btn btn-outline" href="/TurboSito/de/portfolio.html">Details</a>
+              <a class="link inline-flex items-center gap-1" href="/TurboSito/de/portfolio.html#live">Live</a>
+            </div>
+          </article>
+
+          <!-- Karte 3 -->
+          <article class="card group hover-lift">
+            <div class="ratio skeleton mb-3" aria-hidden="true"></div>
+            <h3 class="font-semibold text-lg text-fg">Shop für Modelabel</h3>
+            <p class="text-[var(--muted)] text-sm mb-3">Umsatz verdoppelt in 3 Monaten.</p>
+            <ul class="mt-2 flex flex-wrap gap-2">
+              <li><span class="badge">Shop</span></li>
+              <li><span class="badge">Speed</span></li>
+            </ul>
+            <div class="mt-3 flex gap-3">
+              <a class="btn btn-outline" href="/TurboSito/de/portfolio.html">Details</a>
+              <a class="link inline-flex items-center gap-1" href="/TurboSito/de/portfolio.html#live">Live</a>
+            </div>
+          </article>
+        </div>
+      </div>
+      </section>
+
+      <section class="section">
+        <div class="container">
+          <h2 class="font-display text-3xl md:text-4xl font-bold mb-8 text-fg">Was Kund:innen sagen</h2>
+          <div class="grid gap-6 md:grid-cols-2">
+            <article class="card hover-lift">
+              <div class="testimonial-header">
+                <div class="avatar">M</div>
+                <div>
+                  <div class="testimonial-name">Max M.</div>
+                  <div class="testimonial-role">Gründer, SaaS-Startup</div>
+                </div>
+              </div>
+              <div class="flex items-center gap-1 mb-2" aria-label="5 von 5 Sternen">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="rgb(var(--accent))"><path d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.62L12 2 9.19 8.62 2 9.24l5.46 4.73L5.82 21z"/></svg>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="rgb(var(--accent))"><path d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.62L12 2 9.19 8.62 2 9.24l5.46 4.73L5.82 21z"/></svg>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="rgb(var(--accent))"><path d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.62L12 2 9.19 8.62 2 9.24l5.46 4.73L5.82 21z"/></svg>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="rgb(var(--accent))"><path d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.62L12 2 9.19 8.62 2 9.24l5.46 4.73L5.82 21z"/></svg>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="rgb(var(--accent))"><path d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.62L12 2 9.19 8.62 2 9.24l5.46 4.73L5.82 21z"/></svg>
+              </div>
+              <p class="text-[var(--muted)]">„Unfassbar schnell. Montag Anfrage, Mittwoch live – und die Anfragen gingen hoch.“</p>
+            </article>
+
+            <article class="card hover-lift">
+              <div class="testimonial-header">
+                <div class="avatar">S</div>
+                <div>
+                  <div class="testimonial-name">Sara L.</div>
+                  <div class="testimonial-role">Marketingleitung, Consulting</div>
+                </div>
+              </div>
+              <div class="flex items-center gap-1 mb-2" aria-label="5 von 5 Sternen">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="rgb(var(--accent))"><path d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.62L12 2 9.19 8.62 2 9.24l5.46 4.73L5.82 21z"/></svg>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="rgb(var(--accent))"><path d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.62L12 2 9.19 8.62 2 9.24l5.46 4.73L5.82 21z"/></svg>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="rgb(var(--accent))"><path d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.62L12 2 9.19 8.62 2 9.24l5.46 4.73L5.82 21z"/></svg>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="rgb(var(--accent))"><path d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.62L12 2 9.19 8.62 2 9.24l5.46 4.73L5.82 21z"/></svg>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="rgb(var(--accent))"><path d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.62L12 2 9.19 8.62 2 9.24l5.46 4.73L5.82 21z"/></svg>
+              </div>
+              <p class="text-[var(--muted)]">„Sehr strukturiert, klarer Prozess, und das Ergebnis überzeugt. Würde wieder buchen.“</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="container">
+          <h2 class="font-display text-3xl md:text-4xl font-bold mb-8 text-[var(--fg)]">Ablauf</h2>
+        <ol class="space-y-6">
+          <li class="flex gap-4 items-start reveal">
+            <span class="badge inline-flex items-center justify-center w-8 h-8 rounded-full">1</span>
+            <div>
+              <h3 class="font-semibold text-[var(--fg)]">Kickoff</h3>
+              <p class="text-[var(--muted)]">10-Minuten-Formular – Ziel, Stil &amp; Beispiele.</p>
+            </div>
+          </li>
+          <li class="flex gap-4 items-start reveal">
+            <span class="badge inline-flex items-center justify-center w-8 h-8 rounded-full">2</span>
+            <div>
+              <h3 class="font-semibold text-[var(--fg)]">Design &amp; Aufbau</h3>
+              <p class="text-[var(--muted)]">Startseite und Unterseiten im gewählten Look &amp; Feel.</p>
+            </div>
+          </li>
+          <li class="flex gap-4 items-start reveal">
+            <span class="badge inline-flex items-center justify-center w-8 h-8 rounded-full">3</span>
+            <div>
+              <h3 class="font-semibold text-[var(--fg)]">Review</h3>
+              <p class="text-[var(--muted)]">Gemeinsamer Feinschliff, schnelle Iterationen.</p>
+            </div>
+          </li>
+          <li class="flex gap-4 items-start reveal">
+            <span class="badge inline-flex items-center justify-center w-8 h-8 rounded-full">4</span>
+            <div>
+              <h3 class="font-semibold text-[var(--fg)]">Go-Live</h3>
+              <p class="text-[var(--muted)]">Domain, Tracking &amp; Hand-over mit kurzer Anleitung.</p>
+            </div>
+          </li>
+        </ol>
+      </div>
+  </section>
+
+    <section class="section">
+      <div class="container">
+        <h2 class="font-display text-3xl md:text-4xl font-bold mb-8 text-fg">Pakete</h2>
+        <div class="grid gap-6 md:grid-cols-2">
+          <!-- Starter -->
+          <article class="card hover-lift reveal">
+            <div class="badge mb-3 inline-block">Starter</div>
+            <div class="text-3xl font-extrabold mb-2 text-fg">€ 990</div>
+            <p class="text-[var(--muted)] mb-4">1–3 Seiten, Launch in 48h.</p>
+            <ul class="space-y-2 text-sm text-[var(--muted)] mb-4">
+              <li class="flex items-center gap-2"><svg width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>Design &amp; Umsetzung</li>
+              <li class="flex items-center gap-2"><svg width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>Basis-SEO</li>
+              <li class="flex items-center gap-2"><svg width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>Kontakt-Formular</li>
+            </ul>
+            <a class="btn btn-lg" href="/TurboSito/de/kontakt.html">Anfragen</a>
+          </article>
+
+          <!-- Pro -->
+          <article class="card hover-lift reveal">
+            <div class="badge mb-3 inline-block">Pro</div>
+            <div class="text-3xl font-extrabold mb-2 text-fg">€ 1.990</div>
+            <p class="text-[var(--muted)] mb-4">Bis 6 Seiten, Extras inklusive.</p>
+            <ul class="space-y-2 text-sm text-[var(--muted)] mb-4">
+              <li class="flex items-center gap-2"><svg width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>Copy-Assist &amp; On-Page-SEO</li>
+              <li class="flex items-center gap-2"><svg width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>Mehrsprachig (DE/EN/IT)</li>
+              <li class="flex items-center gap-2"><svg width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M9 16.17 4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"/></svg>Performance-Feinschliff</li>
+            </ul>
+            <a class="btn btn-lg" href="/TurboSito/de/kontakt.html">Anfragen</a>
+          </article>
+        </div>
+      </div>
+    </section>
+<section class="section faq">
+  <div class="container">
+    <h2 class="font-display text-3xl md:text-4xl font-bold mb-6">FAQ</h2>
+
+    <div class="card mb-3">
+      <button data-acc-btn class="w-full text-left font-semibold text-fg" type="button" aria-expanded="false" aria-controls="f1">Wie läuft das in 48h ab?</button>
+      <p id="f1" class="text-muted mt-2" hidden>Kurzes Formular, dann Design & Aufbau, Review und Go-Live. Klare Milestones, schnelle Iterationen.</p>
+    </div>
+
+    <div class="card mb-3">
+      <button data-acc-btn class="w-full text-left font-semibold text-fg" type="button" aria-expanded="false" aria-controls="f2">Welche Inhalte brauche ich?</button>
+      <p id="f2" class="text-muted mt-2" hidden>Logo, kurze Stichpunkte zu Angebot/Zielen, 2–3 Referenzen oder Bilder reichen für den Start.</p>
+    </div>
+
+    <div class="card mb-3">
+      <button data-acc-btn class="w-full text-left font-semibold text-fg" type="button" aria-expanded="false" aria-controls="f3">Kann ich später erweitern?</button>
+      <p id="f3" class="text-muted mt-2" hidden>Ja — neue Seiten, Blog oder CMS sind jederzeit möglich. Die Struktur ist darauf vorbereitet.</p>
+    </div>
+
+    <div class="card">
+      <button data-acc-btn class="w-full text-left font-semibold text-fg" type="button" aria-expanded="false" aria-controls="f4">Wie läuft Bezahlung & Rechnung?</button>
+      <p id="f4" class="text-muted mt-2" hidden>Fixpreis per Rechnung. 50% Start, 50% nach Go-Live. Firmenangaben per Mail/Kontakt.</p>
+    </div>
+  </div>
+</section>
+
+    <section class="section">
+      <div class="container">
+        <form id="quick-start" class="card hover-lift flex flex-col md:flex-row items-center justify-between gap-4 reveal">
+          <div>
+            <h2 class="font-display text-2xl md:text-3xl font-bold text-[var(--fg)]">Bereit, loszulegen?</h2>
+            <p class="text-muted">Schick mir die wichtigsten Infos – ich melde mich heute noch.</p>
+          </div>
+          <div class="flex flex-col md:flex-row gap-3 w-full md:w-auto">
+            <input class="input md:w-60" type="email" name="email" placeholder="E-Mail" required>
+            <button class="btn" type="submit">Anfrage senden</button>
+            <a class="btn btn-outline" href="/TurboSito/de/portfolio.html">Portfolio ansehen</a>
+          </div>
+        </form>
+      </div>
+    </section>
+  </main>
+  <footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Kontakt: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/de/impressum.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Impressum</a>
+      <span class="mx-2">·</span>
+      <a href="/TurboSito/de/datenschutz.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Datenschutz</a>
+    </p>
+  </div>
+</footer>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/hero-form.js" defer></script>
+  <script src="/TurboSito/assets/js/hero-mobile-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+</body>
+</html>

--- a/de/index.html
+++ b/de/index.html
@@ -69,8 +69,9 @@
           <h1 class="font-display text-4xl md:text-6xl font-extrabold tracking-tight"><span class="text-gradient">Website in 48 Stunden</span></h1>
           <p class="mt-4 text-lg hero-subtitle text-[var(--fg)]">Fixpreis. Mehr Anfragen – ohne Telefonat.</p>
           <div class="cta-hero">
-            <a class="btn btn-contact" href="#quick-start">Kontakt aufnehmen</a>
-            <a class="btn btn-outline" href="/TurboSito/de/portfolio.html">Portfolio ansehen</a>
+            <a class="btn btn-contact" data-cta="contact" href="#quick-start">Kontakt aufnehmen</a>
+            <a class="btn btn-primary" data-cta="primary" href="#quick-start" data-open-form>Projekt starten</a>
+            <a class="btn btn-outline" data-cta="portfolio" href="/TurboSito/de/portfolio.html">Portfolio ansehen</a>
           </div>
           <form id="micro-start" class="micro-start" novalidate>
             <label class="sr-only" for="micro-email">E-Mail</label>

--- a/de/index.html
+++ b/de/index.html
@@ -204,19 +204,21 @@
         <h2 class="font-display text-3xl md:text-4xl font-bold mb-8 text-fg">Ausgewählte Projekte</h2>
         <div class="grid gap-6 md:grid-cols-3">
           <!-- Karte 1 -->
-          <article class="card group hover-lift">
+          <article class="card group hover-lift case-card" data-slug="landingpage-tech-startup">
             <div class="ratio skeleton mb-3" aria-hidden="true"></div>
-            <h3 class="font-semibold text-lg text-fg">Landingpage für Tech-Startup</h3>
+            <h3 class="font-semibold text-lg text-fg"><a href="/TurboSito/de/cases/landingpage-tech-startup.html">Landingpage für Tech-Startup</a></h3>
             <p class="text-[var(--muted)] text-sm mb-3">40% mehr Anmeldungen nach Launch.</p>
             <ul class="mt-2 flex flex-wrap gap-2">
               <li><span class="badge">Tailwind</span></li>
               <li><span class="badge">SEO</span></li>
               <li><span class="badge">A/B</span></li>
             </ul>
-            <div class="mt-3 flex gap-3">
+            <div class="mt-3 flex gap-3 relative z-10">
               <a class="btn btn-outline" href="/TurboSito/de/portfolio.html">Details</a>
               <a class="link inline-flex items-center gap-1" href="/TurboSito/de/portfolio.html#live">Live</a>
             </div>
+            <a class="btn btn-outline case-cta" href="/TurboSito/de/cases/landingpage-tech-startup.html">Case Study</a>
+            <a class="stretched-link" href="/TurboSito/de/cases/landingpage-tech-startup.html" aria-label="Zur Case Study: Landingpage für Tech-Startup"></a>
           </article>
 
           <!-- Karte 2 -->

--- a/de/index.html
+++ b/de/index.html
@@ -69,7 +69,7 @@
           <h1 class="font-display text-4xl md:text-6xl font-extrabold tracking-tight"><span class="text-gradient">Website in 48 Stunden</span></h1>
           <p class="mt-4 text-lg hero-subtitle text-[var(--fg)]">Fixpreis. Mehr Anfragen – ohne Telefonat.</p>
           <div class="cta-hero">
-            <a class="btn" href="#quick-start">Kontakt aufnehmen</a>
+            <a class="btn btn-contact" href="#quick-start">Kontakt aufnehmen</a>
             <a class="btn btn-outline" href="/TurboSito/de/portfolio.html">Portfolio ansehen</a>
           </div>
           <form id="micro-start" class="micro-start" novalidate>
@@ -423,5 +423,6 @@
   <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
   <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
   <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+  <script src="/TurboSito/assets/js/sticky-cta.js" defer></script>
 </body>
 </html>

--- a/de/index.html
+++ b/de/index.html
@@ -204,9 +204,10 @@
         <h2 class="font-display text-3xl md:text-4xl font-bold mb-8 text-fg">Ausgewählte Projekte</h2>
         <div class="grid gap-6 md:grid-cols-3">
           <!-- Karte 1 -->
-          <article class="card group hover-lift case-card" data-slug="landingpage-tech-startup">
+          <article class="card group hover-lift">
             <div class="ratio skeleton mb-3" aria-hidden="true"></div>
-            <h3 class="font-semibold text-lg text-fg"><a href="/TurboSito/de/cases/landingpage-tech-startup.html">Landingpage für Tech-Startup</a></h3>
+            <span class="badge badge-demo">Demo</span>
+            <h3 class="font-semibold text-lg text-fg"><a href="/TurboSito/de/demos/saas-landing.html">Landingpage für Tech-Startup</a></h3>
             <p class="text-[var(--muted)] text-sm mb-3">40% mehr Anmeldungen nach Launch.</p>
             <ul class="mt-2 flex flex-wrap gap-2">
               <li><span class="badge">Tailwind</span></li>
@@ -214,11 +215,9 @@
               <li><span class="badge">A/B</span></li>
             </ul>
             <div class="mt-3 flex gap-3 relative z-10">
-              <a class="btn btn-outline" href="/TurboSito/de/portfolio.html">Details</a>
-              <a class="link inline-flex items-center gap-1" href="/TurboSito/de/portfolio.html#live">Live</a>
+              <a class="btn btn-outline" href="/TurboSito/de/demos/saas-landing.html">Demo ansehen</a>
             </div>
-            <a class="btn btn-outline case-cta" href="/TurboSito/de/cases/landingpage-tech-startup.html">Case Study</a>
-            <a class="stretched-link" href="/TurboSito/de/cases/landingpage-tech-startup.html" aria-label="Zur Case Study: Landingpage für Tech-Startup"></a>
+            <a class="stretched-link" href="/TurboSito/de/demos/saas-landing.html" aria-label="Zur Demo: Landingpage für Tech-Startup"></a>
           </article>
 
           <!-- Karte 2 -->

--- a/de/kontakt.html
+++ b/de/kontakt.html
@@ -56,6 +56,15 @@
         </div>
         <button type="submit" class="btn btn-lg mt-3" aria-label="Nachricht senden">Anfrage senden</button>
       </form>
+      <script>
+      (()=>{
+        const e=localStorage.getItem('lead_email');
+        if(e){
+          const f=document.getElementById('email');
+          if(f){f.value=e;}
+        }
+      })();
+      </script>
     </div>
   </section>
 </main>

--- a/de/kontakt.html
+++ b/de/kontakt.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="de" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Kontakt – TurboSito</title>
+  <meta name="description" content="Ich melde mich innerhalb von 24–48h.">
+  <link rel="canonical" href="https://deine-domain.tld/de/kontakt.html">
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/kontakt.html">
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/contact.html">
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/contatti.html">
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
+  <meta property="og:title" content="Kontakt – TurboSito">
+  <meta property="og:description" content="Ich melde mich innerhalb von 24–48h.">
+  <meta property="og:url" content="https://deine-domain.tld/de/kontakt.html">
+  <meta property="og:locale" content="de_DE">
+  <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+<style>
+  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+  .font-display{font-family:"Outfit", var(--font-sans)}
+  body{font-family:var(--font-sans)}
+</style>
+<link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+<script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
+<header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/de/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/de/">Start</a><a href="/TurboSito/de/ueber-mich.html">Über mich</a><a href="/TurboSito/de/leistungen.html">Leistungen</a><a href="/TurboSito/de/portfolio.html">Portfolio</a><a href="/TurboSito/de/kontakt.html">Kontakt</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Sprache"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button></div></div></header>
+
+<main id="content">
+  <section class="section-lg max-w-3xl mx-auto px-4 py-20">
+    <h1 class="font-display text-3xl md:text-4xl font-bold mb-6">Kontakt</h1>
+    <p class="mb-8">Ich melde mich innerhalb von 24–48&nbsp;h.</p>
+    <div class="card max-w-2xl">
+      <form id="contact-form" name="contact" method="post" data-netlify="true" netlify-honeypot="bot-field" class="space-y-4" action="/TurboSito/de/danke.html">
+        <input type="hidden" name="form-name" value="contact">
+        <div class="hidden" aria-hidden="true"><label>Bitte leer lassen<input name="bot-field"></label></div>
+        <div>
+          <label for="name" class="label">Name</label>
+          <input id="name" name="name" required aria-invalid="false" class="input">
+        </div>
+        <div>
+          <label for="email" class="label">E-Mail</label>
+          <input id="email" name="email" type="email" required aria-invalid="false" class="input">
+        </div>
+        <div>
+          <label for="message" class="label">Nachricht</label>
+          <textarea id="message" name="message" required aria-invalid="false" class="input h-32"></textarea>
+        </div>
+        <div class="flex items-start gap-2">
+          <input id="consent" name="consent" type="checkbox" required class="mt-1 rounded border-white/15">
+          <label for="consent" class="label text-[var(--muted)]">Ich stimme der Verarbeitung meiner Daten gemäß <a href="/TurboSito/de/datenschutz.html" class="underline">Datenschutz</a> zu.</label>
+        </div>
+        <button type="submit" class="btn btn-lg mt-3" aria-label="Nachricht senden">Anfrage senden</button>
+      </form>
+    </div>
+  </section>
+</main>
+<footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Kontakt: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/de/impressum.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Impressum</a>
+      <span class="mx-2">·</span>
+      <a href="/TurboSito/de/datenschutz.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Datenschutz</a>
+    </p>
+  </div>
+</footer>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+</body>
+</html>

--- a/de/leistungen.html
+++ b/de/leistungen.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="de" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Leistungen – TurboSito</title>
+  <meta name="description" content="Webservices, die Ergebnisse liefern. Schnelle Umsetzung mit klarem Fokus auf Nutzen.">
+  <link rel="canonical" href="https://deine-domain.tld/de/leistungen.html">
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/leistungen.html">
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/services.html">
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/servizi.html">
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
+  <meta property="og:title" content="Leistungen – TurboSito">
+  <meta property="og:description" content="Webservices, die Ergebnisse liefern. Schnelle Umsetzung mit klarem Fokus auf Nutzen.">
+  <meta property="og:url" content="https://deine-domain.tld/de/leistungen.html">
+  <meta property="og:locale" content="de_DE">
+  <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+<style>
+  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+  .font-display{font-family:"Outfit", var(--font-sans)}
+  body{font-family:var(--font-sans)}
+</style>
+<link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+<script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
+<header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/de/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/de/">Start</a><a href="/TurboSito/de/ueber-mich.html">Über mich</a><a href="/TurboSito/de/leistungen.html">Leistungen</a><a href="/TurboSito/de/portfolio.html">Portfolio</a><a href="/TurboSito/de/kontakt.html">Kontakt</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Sprache"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button></div></div></header>
+
+  <main id="content">
+    <section class="section">
+      <div class="container">
+        <h1 class="font-display text-3xl md:text-4xl font-bold mb-8">Leistungen</h1>
+        <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          <article class="card hover-lift">
+            <span class="badge inline-flex items-center gap-2 mb-2"><svg width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M5 12h14M5 6h14M5 18h14"/></svg></span>
+            <h3 class="font-semibold text-xl mb-2">Blitzschnelle Landingpages</h3>
+            <p class="text-[var(--muted)] mb-3">Mehr Anfragen in 48 Stunden – fertig für den Launch.</p>
+            <ul class="space-y-1 text-sm text-[var(--muted)] list-disc pl-5">
+              <li>Individuelles Design</li>
+              <li>Responsive Umsetzung</li>
+              <li>Grundlegende SEO</li>
+              <li>Kontaktformular</li>
+            </ul>
+            <p class="text-sm text-[var(--muted)] mt-3">ab € 1.200</p>
+            <div class="mt-4"><a class="btn btn-outline" href="/TurboSito/de/kontakt.html">Anfragen</a></div>
+          </article>
+          <article class="card hover-lift">
+            <span class="badge inline-flex items-center gap-2 mb-2"><svg width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M5 12h14M5 6h14M5 18h14"/></svg></span>
+            <h3 class="font-semibold text-xl mb-2">Mehrsprachige Unternehmensseite</h3>
+            <p class="text-[var(--muted)] mb-3">Reichweite in mehreren Sprachen ohne Mehraufwand.</p>
+            <ul class="space-y-1 text-sm text-[var(--muted)] list-disc pl-5">
+              <li>Strukturierte Seiten</li>
+              <li>Sprachauswahl</li>
+              <li>SEO-Basics</li>
+              <li>Performance-Optimierung</li>
+              <li>Hosting-Setup</li>
+            </ul>
+            <p class="text-sm text-[var(--muted)] mt-3">ab € 2.500</p>
+            <div class="mt-4"><a class="btn btn-outline" href="/TurboSito/de/kontakt.html">Anfragen</a></div>
+          </article>
+          <article class="card hover-lift">
+            <span class="badge inline-flex items-center gap-2 mb-2"><svg width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M5 12h14M5 6h14M5 18h14"/></svg></span>
+            <h3 class="font-semibold text-xl mb-2">Wartung &amp; Optimierung</h3>
+            <p class="text-[var(--muted)] mb-3">Bleiben Sie schnell und sicher im Netz.</p>
+            <ul class="space-y-1 text-sm text-[var(--muted)] list-disc pl-5">
+              <li>Updates</li>
+              <li>Backups</li>
+              <li>Monitoring</li>
+              <li>Performance-Tuning</li>
+            </ul>
+            <p class="text-sm text-[var(--muted)] mt-3">ab € 150/Monat</p>
+            <div class="mt-4"><a class="btn btn-outline" href="/TurboSito/de/kontakt.html">Anfragen</a></div>
+          </article>
+        </div>
+      </div>
+    </section>
+  </main>
+  <footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Kontakt: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/de/impressum.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Impressum</a>
+      <span class="mx-2">·</span>
+      <a href="/TurboSito/de/datenschutz.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Datenschutz</a>
+    </p>
+  </div>
+</footer>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+</body>
+</html>

--- a/de/portfolio.html
+++ b/de/portfolio.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="de" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Portfolio – TurboSito</title>
+  <meta name="description" content="Auswahl aktueller Arbeiten und Projekte.">
+  <link rel="canonical" href="https://deine-domain.tld/de/portfolio.html">
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio.html">
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio.html">
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio.html">
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
+  <meta property="og:title" content="Portfolio – TurboSito">
+  <meta property="og:description" content="Auswahl aktueller Arbeiten und Projekte.">
+  <meta property="og:url" content="https://deine-domain.tld/de/portfolio.html">
+  <meta property="og:locale" content="de_DE">
+  <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+<style>
+  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+  .font-display{font-family:"Outfit", var(--font-sans)}
+  body{font-family:var(--font-sans)}
+</style>
+<link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+<script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
+<header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/de/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/de/">Start</a><a href="/TurboSito/de/ueber-mich.html">Über mich</a><a href="/TurboSito/de/leistungen.html">Leistungen</a><a href="/TurboSito/de/portfolio.html">Portfolio</a><a href="/TurboSito/de/kontakt.html">Kontakt</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Sprache"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button></div></div></header>
+
+<main id="content" class="max-w-6xl mx-auto px-4 py-20">
+  <section class="section-lg mb-12 text-center">
+    <h1 class="font-display text-3xl md:text-4xl font-bold mb-6">Portfolio</h1>
+    <p>Auswahl aktueller Arbeiten und Projekte.</p>
+  </section>
+  <section class="section grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+    <article class="card group hover-lift">
+      <picture>
+        <source srcset="/assets/portfolio/p1.webp" type="image/webp">
+        <img src="/TurboSito/assets/portfolio/p1.jpg" alt="Landingpage für Tech-Startup" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
+      </picture>
+      <h3 class="font-semibold text-lg">Landingpage für Tech-Startup</h3>
+      <ul class="mt-2 flex flex-wrap gap-2">
+        <li><span class="badge"><!-- [[TAG1_DE]] --><span data-key="TAG1_DE" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG2_DE]] --><span data-key="TAG2_DE" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG3_DE]] --><span data-key="TAG3_DE" class="ph"></span></span></li>
+      </ul>
+      <p class="text-[var(--muted)] text-sm mb-3">40% mehr Anmeldungen nach Launch.</p>
+      <div class="mt-3 flex gap-3">
+        <a class="btn btn-outline" href="[[LIVE_URL_DE]]">Live</a>
+        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_DE]]">Code</a>
+      </div>
+    </article>
+    <article class="card group hover-lift">
+      <picture>
+        <source srcset="/assets/portfolio/p2.webp" type="image/webp">
+        <img src="/TurboSito/assets/portfolio/p2.jpg" alt="Corporate Website für Beratungsfirma" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
+      </picture>
+      <h3 class="font-semibold text-lg">Corporate Website für Beratungsfirma</h3>
+      <ul class="mt-2 flex flex-wrap gap-2">
+        <li><span class="badge"><!-- [[TAG1_DE]] --><span data-key="TAG1_DE" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG2_DE]] --><span data-key="TAG2_DE" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG3_DE]] --><span data-key="TAG3_DE" class="ph"></span></span></li>
+      </ul>
+      <p class="text-[var(--muted)] text-sm mb-3">Leads um 30% gesteigert.</p>
+      <div class="mt-3 flex gap-3">
+        <a class="btn btn-outline" href="[[LIVE_URL_DE]]">Live</a>
+        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_DE]]">Code</a>
+      </div>
+    </article>
+    <article class="card group hover-lift">
+      <picture>
+        <source srcset="/assets/portfolio/p3.webp" type="image/webp">
+        <img src="/TurboSito/assets/portfolio/p3.jpg" alt="Online-Shop für Modebrand" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
+      </picture>
+      <h3 class="font-semibold text-lg">Online-Shop für Modebrand</h3>
+      <ul class="mt-2 flex flex-wrap gap-2">
+        <li><span class="badge"><!-- [[TAG1_DE]] --><span data-key="TAG1_DE" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG2_DE]] --><span data-key="TAG2_DE" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG3_DE]] --><span data-key="TAG3_DE" class="ph"></span></span></li>
+      </ul>
+      <p class="text-[var(--muted)] text-sm mb-3">Umsatz verdoppelt in 3 Monaten.</p>
+      <div class="mt-3 flex gap-3">
+        <a class="btn btn-outline" href="[[LIVE_URL_DE]]">Live</a>
+        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_DE]]">Code</a>
+      </div>
+    </article>
+    <article class="card group hover-lift">
+      <picture>
+        <source srcset="/assets/portfolio/p4.webp" type="image/webp">
+        <img src="/TurboSito/assets/portfolio/p4.jpg" alt="Portfolio-Site für Fotografin" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
+      </picture>
+      <h3 class="font-semibold text-lg">Portfolio-Site für Fotografin</h3>
+      <ul class="mt-2 flex flex-wrap gap-2">
+        <li><span class="badge"><!-- [[TAG1_DE]] --><span data-key="TAG1_DE" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG2_DE]] --><span data-key="TAG2_DE" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG3_DE]] --><span data-key="TAG3_DE" class="ph"></span></span></li>
+      </ul>
+      <p class="text-[var(--muted)] text-sm mb-3">Mehr Buchungen dank Online-Präsenz.</p>
+      <div class="mt-3 flex gap-3">
+        <a class="btn btn-outline" href="[[LIVE_URL_DE]]">Live</a>
+        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_DE]]">Code</a>
+      </div>
+    </article>
+    <article class="card group hover-lift">
+      <picture>
+        <source srcset="/assets/portfolio/p5.webp" type="image/webp">
+        <img src="/TurboSito/assets/portfolio/p5.jpg" alt="Event-Microsite" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
+      </picture>
+      <h3 class="font-semibold text-lg">Event-Microsite</h3>
+      <ul class="mt-2 flex flex-wrap gap-2">
+        <li><span class="badge"><!-- [[TAG1_DE]] --><span data-key="TAG1_DE" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG2_DE]] --><span data-key="TAG2_DE" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG3_DE]] --><span data-key="TAG3_DE" class="ph"></span></span></li>
+      </ul>
+      <p class="text-[var(--muted)] text-sm mb-3">2.000 Registrierungen in einer Woche.</p>
+      <div class="mt-3 flex gap-3">
+        <a class="btn btn-outline" href="[[LIVE_URL_DE]]">Live</a>
+        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_DE]]">Code</a>
+      </div>
+    </article>
+    <article class="card group hover-lift">
+      <picture>
+        <source srcset="/assets/portfolio/p6.webp" type="image/webp">
+        <img src="/TurboSito/assets/portfolio/p6.jpg" alt="Mehrsprachige Hotelseite" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
+      </picture>
+      <h3 class="font-semibold text-lg">Mehrsprachige Hotelseite</h3>
+      <ul class="mt-2 flex flex-wrap gap-2">
+        <li><span class="badge"><!-- [[TAG1_DE]] --><span data-key="TAG1_DE" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG2_DE]] --><span data-key="TAG2_DE" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG3_DE]] --><span data-key="TAG3_DE" class="ph"></span></span></li>
+      </ul>
+      <p class="text-[var(--muted)] text-sm mb-3">Internationale Buchungen um 25% erhöht.</p>
+      <div class="mt-3 flex gap-3">
+        <a class="btn btn-outline" href="[[LIVE_URL_DE]]">Live</a>
+        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_DE]]">Code</a>
+      </div>
+    </article>
+  </section>
+</main>
+<footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Kontakt: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/de/impressum.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Impressum</a>
+      <span class="mx-2">·</span>
+      <a href="/TurboSito/de/datenschutz.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Datenschutz</a>
+    </p>
+  </div>
+</footer>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+</body>
+</html>

--- a/de/portfolio.html
+++ b/de/portfolio.html
@@ -56,38 +56,42 @@
       <a class="stretched-link" href="/TurboSito/de/demos/saas-landing.html" aria-label="Zur Demo: SaaS-Landing (Demo)"></a>
     </article>
     <article class="card group hover-lift">
-      <picture>
-        <source srcset="/assets/portfolio/p2.webp" type="image/webp">
-        <img src="/TurboSito/assets/portfolio/p2.jpg" alt="Corporate Website für Beratungsfirma" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
-      </picture>
-      <h3 class="font-semibold text-lg">Corporate Website für Beratungsfirma</h3>
+      <a href="/TurboSito/de/demos/corporate-site.html">
+        <picture>
+          <source srcset="/assets/portfolio/p2.webp" type="image/webp">
+          <img src="/TurboSito/assets/portfolio/p2.jpg" alt="Corporate Website für Beratungsfirma" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
+        </picture>
+      </a>
+      <h3 class="font-semibold text-lg"><a href="/TurboSito/de/demos/corporate-site.html"><span class="badge badge-demo">Demo</span> Corporate Website für Beratungsfirma</a></h3>
       <ul class="mt-2 flex flex-wrap gap-2">
         <li><span class="badge"><!-- [[TAG1_DE]] --><span data-key="TAG1_DE" class="ph"></span></span></li>
         <li><span class="badge"><!-- [[TAG2_DE]] --><span data-key="TAG2_DE" class="ph"></span></span></li>
         <li><span class="badge"><!-- [[TAG3_DE]] --><span data-key="TAG3_DE" class="ph"></span></span></li>
       </ul>
-      <p class="text-[var(--muted)] text-sm mb-3">Leads um 30% gesteigert.</p>
+      <p class="text-[var(--muted)] text-sm mb-3">Demo – modulare Corporate-Seite.</p>
       <div class="mt-3 flex gap-3">
-        <a class="btn btn-outline" href="[[LIVE_URL_DE]]">Live</a>
-        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_DE]]">Code</a>
+        <a class="btn" href="/TurboSito/de/demos/corporate-site.html">Demo ansehen</a>
       </div>
+      <a class="stretched-link" href="/TurboSito/de/demos/corporate-site.html" aria-label="Zur Demo: Corporate Website für Beratungsfirma"></a>
     </article>
     <article class="card group hover-lift">
-      <picture>
-        <source srcset="/assets/portfolio/p3.webp" type="image/webp">
-        <img src="/TurboSito/assets/portfolio/p3.jpg" alt="Online-Shop für Modebrand" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
-      </picture>
-      <h3 class="font-semibold text-lg">Online-Shop für Modebrand</h3>
+      <a href="/TurboSito/de/demos/fashion-shop.html">
+        <picture>
+          <source srcset="/assets/portfolio/p3.webp" type="image/webp">
+          <img src="/TurboSito/assets/portfolio/p3.jpg" alt="Online-Shop für Modebrand" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
+        </picture>
+      </a>
+      <h3 class="font-semibold text-lg"><a href="/TurboSito/de/demos/fashion-shop.html"><span class="badge badge-demo">Demo</span> Online-Shop für Modebrand</a></h3>
       <ul class="mt-2 flex flex-wrap gap-2">
         <li><span class="badge"><!-- [[TAG1_DE]] --><span data-key="TAG1_DE" class="ph"></span></span></li>
         <li><span class="badge"><!-- [[TAG2_DE]] --><span data-key="TAG2_DE" class="ph"></span></span></li>
         <li><span class="badge"><!-- [[TAG3_DE]] --><span data-key="TAG3_DE" class="ph"></span></span></li>
       </ul>
-      <p class="text-[var(--muted)] text-sm mb-3">Umsatz verdoppelt in 3 Monaten.</p>
+      <p class="text-[var(--muted)] text-sm mb-3">Demo – Shop-Startseite.</p>
       <div class="mt-3 flex gap-3">
-        <a class="btn btn-outline" href="[[LIVE_URL_DE]]">Live</a>
-        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_DE]]">Code</a>
+        <a class="btn" href="/TurboSito/de/demos/fashion-shop.html">Demo ansehen</a>
       </div>
+      <a class="stretched-link" href="/TurboSito/de/demos/fashion-shop.html" aria-label="Zur Demo: Online-Shop für Modebrand"></a>
     </article>
     <article class="card group hover-lift">
       <picture>

--- a/de/portfolio.html
+++ b/de/portfolio.html
@@ -49,9 +49,9 @@
         <li><span class="badge"><!-- [[TAG2_DE]] --><span data-key="TAG2_DE" class="ph"></span></span></li>
         <li><span class="badge"><!-- [[TAG3_DE]] --><span data-key="TAG3_DE" class="ph"></span></span></li>
       </ul>
-      <p class="text-[var(--muted)] text-sm mb-3">40% mehr Anmeldungen nach Launch.</p>
+      <p class="text-[var(--muted)] text-sm mb-3">Demo – Vorschau auf Stil, Struktur und Geschwindigkeit.</p>
       <div class="mt-3 flex gap-3">
-        <a class="btn btn-outline" href="/TurboSito/de/demos/saas-landing.html">Demo ansehen</a>
+        <a class="btn" href="/TurboSito/de/demos/saas-landing.html">Demo ansehen</a>
       </div>
       <a class="stretched-link" href="/TurboSito/de/demos/saas-landing.html" aria-label="Zur Demo: SaaS-Landing (Demo)"></a>
     </article>

--- a/de/portfolio.html
+++ b/de/portfolio.html
@@ -36,22 +36,26 @@
     <p>Auswahl aktueller Arbeiten und Projekte.</p>
   </section>
   <section class="section grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-    <article class="card group hover-lift">
-      <picture>
-        <source srcset="/assets/portfolio/p1.webp" type="image/webp">
-        <img src="/TurboSito/assets/portfolio/p1.jpg" alt="Landingpage für Tech-Startup" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
-      </picture>
-      <h3 class="font-semibold text-lg">Landingpage für Tech-Startup</h3>
+    <article class="card group hover-lift case-card" data-slug="landingpage-tech-startup">
+      <a href="/TurboSito/de/cases/landingpage-tech-startup.html">
+        <picture>
+          <source srcset="/assets/portfolio/p1.webp" type="image/webp">
+          <img src="/TurboSito/assets/portfolio/p1.jpg" alt="Landingpage für Tech-Startup" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
+        </picture>
+      </a>
+      <h3 class="font-semibold text-lg"><a href="/TurboSito/de/cases/landingpage-tech-startup.html">Landingpage für Tech-Startup</a></h3>
       <ul class="mt-2 flex flex-wrap gap-2">
         <li><span class="badge"><!-- [[TAG1_DE]] --><span data-key="TAG1_DE" class="ph"></span></span></li>
         <li><span class="badge"><!-- [[TAG2_DE]] --><span data-key="TAG2_DE" class="ph"></span></span></li>
         <li><span class="badge"><!-- [[TAG3_DE]] --><span data-key="TAG3_DE" class="ph"></span></span></li>
       </ul>
       <p class="text-[var(--muted)] text-sm mb-3">40% mehr Anmeldungen nach Launch.</p>
-      <div class="mt-3 flex gap-3">
+      <div class="mt-3 flex gap-3 relative z-10">
         <a class="btn btn-outline" href="[[LIVE_URL_DE]]">Live</a>
         <a class="link inline-flex items-center gap-1" href="[[CODE_URL_DE]]">Code</a>
       </div>
+      <a class="btn btn-outline case-cta" href="/TurboSito/de/cases/landingpage-tech-startup.html">Case Study</a>
+      <a class="stretched-link" href="/TurboSito/de/cases/landingpage-tech-startup.html" aria-label="Zur Case Study: Landingpage für Tech-Startup"></a>
     </article>
     <article class="card group hover-lift">
       <picture>

--- a/de/portfolio.html
+++ b/de/portfolio.html
@@ -32,30 +32,28 @@
 
 <main id="content" class="max-w-6xl mx-auto px-4 py-20">
   <section class="section-lg mb-12 text-center">
-    <h1 class="font-display text-3xl md:text-4xl font-bold mb-6">Portfolio</h1>
-    <p>Auswahl aktueller Arbeiten und Projekte.</p>
+    <h1 class="font-display text-3xl md:text-4xl font-bold mb-6">Demo-Projekte</h1>
+    <p>Ehrliche Vorschau auf Stil und Prozess. Echte Case Studies folgen.</p>
   </section>
   <section class="section grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-    <article class="card group hover-lift case-card" data-slug="landingpage-tech-startup">
-      <a href="/TurboSito/de/cases/landingpage-tech-startup.html">
+    <article class="card group hover-lift">
+      <a href="/TurboSito/de/demos/saas-landing.html">
         <picture>
           <source srcset="/assets/portfolio/p1.webp" type="image/webp">
-          <img src="/TurboSito/assets/portfolio/p1.jpg" alt="Landingpage für Tech-Startup" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
+          <img src="/TurboSito/assets/portfolio/p1.jpg" alt="SaaS-Landing Demo" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
         </picture>
       </a>
-      <h3 class="font-semibold text-lg"><a href="/TurboSito/de/cases/landingpage-tech-startup.html">Landingpage für Tech-Startup</a></h3>
+      <h3 class="font-semibold text-lg"><a href="/TurboSito/de/demos/saas-landing.html"><span class="badge badge-demo">Demo</span> SaaS-Landing (Demo)</a></h3>
       <ul class="mt-2 flex flex-wrap gap-2">
         <li><span class="badge"><!-- [[TAG1_DE]] --><span data-key="TAG1_DE" class="ph"></span></span></li>
         <li><span class="badge"><!-- [[TAG2_DE]] --><span data-key="TAG2_DE" class="ph"></span></span></li>
         <li><span class="badge"><!-- [[TAG3_DE]] --><span data-key="TAG3_DE" class="ph"></span></span></li>
       </ul>
       <p class="text-[var(--muted)] text-sm mb-3">40% mehr Anmeldungen nach Launch.</p>
-      <div class="mt-3 flex gap-3 relative z-10">
-        <a class="btn btn-outline" href="[[LIVE_URL_DE]]">Live</a>
-        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_DE]]">Code</a>
+      <div class="mt-3 flex gap-3">
+        <a class="btn btn-outline" href="/TurboSito/de/demos/saas-landing.html">Demo ansehen</a>
       </div>
-      <a class="btn btn-outline case-cta" href="/TurboSito/de/cases/landingpage-tech-startup.html">Case Study</a>
-      <a class="stretched-link" href="/TurboSito/de/cases/landingpage-tech-startup.html" aria-label="Zur Case Study: Landingpage für Tech-Startup"></a>
+      <a class="stretched-link" href="/TurboSito/de/demos/saas-landing.html" aria-label="Zur Demo: SaaS-Landing (Demo)"></a>
     </article>
     <article class="card group hover-lift">
       <picture>

--- a/de/ueber-mich.html
+++ b/de/ueber-mich.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="de" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Über mich – TurboSito</title>
+  <meta name="description" content="Erfahren Sie mehr über TurboSito und die Person dahinter.">
+  <link rel="canonical" href="https://deine-domain.tld/de/ueber-mich.html">
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/ueber-mich.html">
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/about.html">
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/chi-sono.html">
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
+  <meta property="og:title" content="Über mich – TurboSito">
+  <meta property="og:description" content="Erfahren Sie mehr über TurboSito und die Person dahinter.">
+  <meta property="og:url" content="https://deine-domain.tld/de/ueber-mich.html">
+  <meta property="og:locale" content="de_DE">
+  <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+<style>
+  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+  .font-display{font-family:"Outfit", var(--font-sans)}
+  body{font-family:var(--font-sans)}
+</style>
+<link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+<script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
+<header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/de/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/de/">Start</a><a href="/TurboSito/de/ueber-mich.html">Über mich</a><a href="/TurboSito/de/leistungen.html">Leistungen</a><a href="/TurboSito/de/portfolio.html">Portfolio</a><a href="/TurboSito/de/kontakt.html">Kontakt</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Sprache"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button></div></div></header>
+
+<main id="content" role="main">
+  <section class="section-lg relative overflow-hidden">
+    <div class="container grid gap-10 md:grid-cols-12 items-center">
+      <div class="md:col-span-6 space-y-6">
+        <h1 class="font-display text-4xl md:text-5xl font-extrabold mb-6">Über mich</h1>
+        <p class="text-[var(--muted)] max-w-xl">Hier erfahren Sie mehr über mich.</p>
+      </div>
+      <div class="md:col-span-6">
+        <div class="ratio card mockup">
+          <div class="mockup-chrome"><span class="dot"></span><span class="dot"></span><span class="dot"></span></div>
+          <div class="mockup-body text-muted text-sm"><!-- [[ABOUT_IMG_ALT_DE]] --><span data-key="ABOUT_IMG_ALT_DE" class="ph"></span></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="container">
+      <h2 class="font-display text-3xl md:text-4xl font-bold mb-6">Kompetenzen</h2>
+      <ul class="flex flex-wrap gap-2">
+        <li><span class="badge">HTML</span></li>
+        <li><span class="badge">CSS</span></li>
+        <li><span class="badge">JS</span></li>
+        <li><span class="badge">Tailwind</span></li>
+        <li><span class="badge">SEO</span></li>
+      </ul>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="container card flex items-center justify-between gap-4 flex-col md:flex-row hover-lift">
+      <p class="text-muted m-0"><!-- [[ABOUT_CALLOUT_DE]] --><span data-key="ABOUT_CALLOUT_DE" class="ph"></span></p>
+      <div class="flex gap-3">
+        <a class="btn btn-lg" href="/TurboSito/de/kontakt.html">Kontakt</a>
+        <a class="btn btn-outline btn-lg" href="/TurboSito/de/portfolio.html">Portfolio</a>
+      </div>
+    </div>
+  </section>
+</main>
+<footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Kontakt: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/de/impressum.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Impressum</a>
+      <span class="mx-2">·</span>
+      <a href="/TurboSito/de/datenschutz.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Datenschutz</a>
+    </p>
+  </div>
+</footer>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+</body>
+</html>

--- a/de/ueber-mich.html
+++ b/de/ueber-mich.html
@@ -5,11 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Über mich – TurboSito</title>
   <meta name="description" content="Erfahren Sie mehr über TurboSito und die Person dahinter.">
-  <link rel="canonical" href="https://deine-domain.tld/de/ueber-mich.html">
-  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/ueber-mich.html">
-  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/about.html">
-  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/chi-sono.html">
-  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
+  <link rel="canonical" href="/TurboSito/de/ueber-mich.html">
+  <link rel="alternate" hreflang="de" href="/TurboSito/de/ueber-mich.html">
+  <link rel="alternate" hreflang="en" href="/TurboSito/en/about.html">
+  <link rel="alternate" hreflang="it" href="/TurboSito/it/chi-sono.html">
+  <link rel="alternate" hreflang="x-default" href="/TurboSito/en/">
   <meta property="og:title" content="Über mich – TurboSito">
   <meta property="og:description" content="Erfahren Sie mehr über TurboSito und die Person dahinter.">
   <meta property="og:url" content="https://deine-domain.tld/de/ueber-mich.html">
@@ -31,40 +31,54 @@
 <header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/de/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/de/">Start</a><a href="/TurboSito/de/ueber-mich.html">Über mich</a><a href="/TurboSito/de/leistungen.html">Leistungen</a><a href="/TurboSito/de/portfolio.html">Portfolio</a><a href="/TurboSito/de/kontakt.html">Kontakt</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Sprache"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button></div></div></header>
 
 <main id="content" role="main">
-  <section class="section-lg relative overflow-hidden">
-    <div class="container grid gap-10 md:grid-cols-12 items-center">
-      <div class="md:col-span-6 space-y-6">
-        <h1 class="font-display text-4xl md:text-5xl font-extrabold mb-6">Über mich</h1>
-        <p class="text-[var(--muted)] max-w-xl">Hier erfahren Sie mehr über mich.</p>
-      </div>
-      <div class="md:col-span-6">
-        <div class="ratio card mockup">
-          <div class="mockup-chrome"><span class="dot"></span><span class="dot"></span><span class="dot"></span></div>
-          <div class="mockup-body text-muted text-sm"><!-- [[ABOUT_IMG_ALT_DE]] --><span data-key="ABOUT_IMG_ALT_DE" class="ph"></span></div>
+  <section class="section">
+    <div class="container grid-2 hero-about">
+      <div>
+        <h1>Über mich</h1>
+        <p class="lead">Ich baue konvertierende Websites in <strong>48 Stunden</strong> – klar, schnell, messbar.</p>
+        <div class="badges" style="margin-top:18px">
+          <span class="badge brand">Next.js</span><span class="badge">Tailwind</span>
+          <span class="badge">Eleventy</span><span class="badge">SEO</span>
+        </div>
+        <div style="display:flex; gap:12px; margin-top:20px">
+          <a class="btn" href="/TurboSito/de/#quick-start">Projekt starten</a>
+          <a class="btn btn-outline" href="/TurboSito/de/portfolio.html">Portfolio ansehen</a>
         </div>
       </div>
+      <div style="display:flex;justify-content:center">
+        <img class="avatar" src="/TurboSito/assets/img/me.jpg" alt="Portrait">
+      </div>
     </div>
   </section>
-
+  <section class="section">
+    <div class="container card pad">
+      <h2>Kompetenzen</h2>
+      <p class="muted">Stack & Arbeitsweise</p>
+      <div class="badges" style="margin-top:8px">
+        <span class="badge">CRO</span><span class="badge">Performance</span>
+        <span class="badge">Accessibility</span><span class="badge">i18n</span>
+      </div>
+    </div>
+  </section>
   <section class="section">
     <div class="container">
-      <h2 class="font-display text-3xl md:text-4xl font-bold mb-6">Kompetenzen</h2>
-      <ul class="flex flex-wrap gap-2">
-        <li><span class="badge">HTML</span></li>
-        <li><span class="badge">CSS</span></li>
-        <li><span class="badge">JS</span></li>
-        <li><span class="badge">Tailwind</span></li>
-        <li><span class="badge">SEO</span></li>
-      </ul>
+      <h2>Timeline</h2>
+      <div class="timeline">
+        <div class="timeline-item"><strong>2025 – heute</strong><br>Freelance, Produktized Service „Website in 48h“</div>
+        <div class="timeline-item"><strong>2022 – 2024</strong><br>Frontend Lead (Landingpages & CRO)</div>
+        <div class="timeline-item"><strong>2019 – 2022</strong><br>Full-stack Projekte (Next.js, Headless CMS)</div>
+      </div>
     </div>
   </section>
-
   <section class="section">
-    <div class="container card flex items-center justify-between gap-4 flex-col md:flex-row hover-lift">
-      <p class="text-muted m-0"><!-- [[ABOUT_CALLOUT_DE]] --><span data-key="ABOUT_CALLOUT_DE" class="ph"></span></p>
-      <div class="flex gap-3">
-        <a class="btn btn-lg" href="/TurboSito/de/kontakt.html">Kontakt</a>
-        <a class="btn btn-outline btn-lg" href="/TurboSito/de/portfolio.html">Portfolio</a>
+    <div class="container card pad" style="display:flex;justify-content:space-between;align-items:center;gap:16px;flex-wrap:wrap">
+      <div>
+        <h3 style="margin:0 0 4px">Bereit, loszulegen?</h3>
+        <p class="muted" style="margin:0">Schick mir die wichtigsten Infos – ich melde mich heute noch.</p>
+      </div>
+      <div style="display:flex;gap:12px">
+        <a class="btn" href="/TurboSito/de/#quick-start">Projekt starten</a>
+        <a class="btn btn-outline" href="/TurboSito/de/portfolio.html">Portfolio</a>
       </div>
     </div>
   </section>

--- a/demos/apartment/index.html
+++ b/demos/apartment/index.html
@@ -1,336 +1,682 @@
+<!-- BEGIN PART 1/3 -->
 <!DOCTYPE html>
-<html lang="de" class="">
-
+<html data-language="de" lang="de">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <!-- Title updated to TurboSito brand -->
-    <title>Ferienwohnung Demo – TurboSito</title>
-    <link rel="preload" as="image" href="../../assets/img/apartment-hero-1920.jpg" fetchpriority="high">
-    <meta property="og:image" content="../../assets/img/apartment-hero-1920.jpg">
-    <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
-    <meta name="description" content="Demo Ferienwohnung: Wohnen nah am Zentrum. Alloggio vicino al centro.">
-    <meta property="og:title" content="Ferienwohnung Demo – Website in 48h">
-    <meta property="og:description" content="Wohnen nah am Zentrum. Alloggio vicino al centro.">
-    <meta property="og:image" content="../../assets/img/apartment-hero.jpg">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="{{URL}}/demos/apartment/">
-    <style>
-        [data-lang] {
-            display: none;
-        }
-
-        :root[data-language="de"] [data-lang="de"] {
-            display: block;
-        }
-
-        :root[data-language="it"] [data-lang="it"] {
-            display: block;
-        }
-
-        /* Scroll reveal animation */
-        /* Adjust scroll reveal values for a subtler fade-in */
-        .scroll-reveal { opacity: 0; transform: translateY(1rem); transition: opacity 0.6s ease-out, transform 0.6s ease-out; }
-        .scroll-reveal.revealed { opacity: 1; transform: translateY(0); }
-    </style>
-
-</head>
-
-<body class="font-sans text-gray-800 dark:text-gray-100 bg-white dark:bg-[#111827] transition-colors duration-300">
-    <header
-        class="sticky top-0 z-50 bg-white/80 dark:bg-gray-900/80 backdrop-blur border-b border-gray-200 dark:border-gray-700">
-        <div class="max-w-screen-xl mx-auto flex items-center justify-between p-4">
-            <!-- Logo with page name linking to the landing page -->
-            <a href="../../landing/" class="flex items-center gap-3">
-                <img src="../../assets/logo/turbosito-logo-ts-bars.svg" alt="TurboSito" class="h-7 w-auto">
-                <span class="text-lg font-bold" data-lang="de">Ferienwohnung&nbsp;Demo</span>
-                <span class="text-lg font-bold" data-lang="it">Demo&nbsp;Appartamento</span>
-            </a>
-            <div class="flex items-center space-x-4">
-                <button id="langDeA" class="text-sm font-medium hover:underline" onclick="setLang('de')"
-                    aria-label="Deutsch">DE</button>
-                <button id="langItA" class="text-sm font-medium hover:underline" onclick="setLang('it')"
-                    aria-label="Italiano">IT</button>
-                <button id="themeToggleA" class="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800"
-                    aria-label="Theme Toggle">
-                    <svg id="themeIconA" xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none"
-                        viewBox="0 0 24 24" stroke="currentColor">
-                        <path id="themeSunA" stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                            d="M12 3v2m0 14v2m8.66-8.66h-2m-12 0H3m15.364-5.364l-1.414 1.414m-10.95 10.95l-1.414 1.414m12.728 0l1.414 1.414m-12.728-12.728L5.636 4.636M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                        <path id="themeMoonA" class="hidden" stroke-linecap="round" stroke-linejoin="round"
-                            stroke-width="2" d="M20.354 15.354A9 9 0 118.646 3.646 7 7 0 0020.354 15.354z" />
-                    </svg>
-                </button>
-            </div>
-        </div>
-    </header>
-    <main>
-        <!-- Hero: increased minimum height for mobile and tablets -->
-        <!-- Increase hero height for mobile to avoid cramped text -->
-        <section class="relative overflow-hidden" style="min-height:90vh;">
-            <picture>
-              <source type="image/webp"
-                      srcset="../../assets/img/apartment-hero-1280.webp 1280w,
-                              ../../assets/img/apartment-hero-1920.webp 1920w"
-                      sizes="100vw">
-              <img src="../../assets/img/apartment-hero-1920.jpg"
-                   srcset="../../assets/img/apartment-hero-1280.jpg 1280w,
-                           ../../assets/img/apartment-hero-1920.jpg 1920w"
-                   sizes="100vw" width="1920" height="1080"
-                   alt="Gemütliches Wohn‑Esszimmer mit Kamin und Pflanzen"
-                   class="absolute inset-0 w-full h-full object-cover">
-            </picture>
-            <!-- Darker overlay to enhance text contrast against the bright apartment interior -->
-            <!-- Lighter overlay improves readability and lets the image shine -->
-            <div class="absolute inset-0 bg-black/50"></div>
-            <div class="relative z-10 flex flex-col items-center justify-center text-center h-full px-4 py-24 sm:py-32">
-              <h1 class="text-3xl sm:text-5xl font-extrabold text-white mb-4" data-lang="de">Wohnen nah am Zentrum.</h1>
-              <h1 class="text-3xl sm:text-5xl font-extrabold text-white mb-4" data-lang="it">Alloggio vicino al centro.</h1>
-              <p class="text-lg sm:text-xl text-white mb-8" data-lang="de">Gemütliches Apartment für Ihren Urlaub in der Stadt.</p>
-              <p class="text-lg sm:text-xl text-white mb-8" data-lang="it">Accogliente appartamento per la tua vacanza in città.</p>
-            </div>
-          </section>
-          
-        <!-- Highlights / Ausstattung -->
-        <section class="py-12 bg-gray-50 dark:bg-gray-800 scroll-reveal">
-            <div class="max-w-screen-md mx-auto px-4">
-                <h2 class="text-2xl font-bold mb-6" data-lang="de">Ausstattung</h2>
-                <h2 class="text-2xl font-bold mb-6" data-lang="it">Dotazioni</h2>
-                <ul class="space-y-2 list-disc list-inside">
-                    <li><span data-lang="de">2&nbsp;Schlafzimmer</span><span data-lang="it">2&nbsp;camere da
-                            letto</span></li>
-                    <li><span data-lang="de">Voll ausgestattete Küche</span><span data-lang="it">Cucina completa</span>
-                    </li>
-                    <li><span data-lang="de">Badezimmer mit Dusche</span><span data-lang="it">Bagno con doccia</span>
-                    </li>
-                    <li><span data-lang="de">Balkon mit Bergblick</span><span data-lang="it">Balcone con vista sulle
-                            montagne</span></li>
-                    <li><span data-lang="de">Parkplatz inklusive</span><span data-lang="it">Parcheggio incluso</span>
-                    </li>
-                    <li><span data-lang="de">Haustiere auf Anfrage</span><span data-lang="it">Animali su
-                            richiesta</span></li>
-                </ul>
-            </div>
-        </section>
-        <!-- Verfügbarkeit Widget Placeholder -->
-        <section class="py-12 scroll-reveal">
-            <div class="max-w-screen-md mx-auto px-4">
-                <h2 class="text-2xl font-bold mb-6" data-lang="de">Verfügbarkeit</h2>
-                <h2 class="text-2xl font-bold mb-6" data-lang="it">Disponibilità</h2>
-                <div class="bg-gray-50 dark:bg-gray-800 p-4 rounded shadow">
-                    <div class="grid grid-cols-7 gap-2 text-center text-sm">
-                        <div class="font-semibold" data-lang="de">Mo</div>
-                        <div class="font-semibold" data-lang="de">Di</div>
-                        <div class="font-semibold" data-lang="de">Mi</div>
-                        <div class="font-semibold" data-lang="de">Do</div>
-                        <div class="font-semibold" data-lang="de">Fr</div>
-                        <div class="font-semibold" data-lang="de">Sa</div>
-                        <div class="font-semibold" data-lang="de">So</div>
-                        <div class="font-semibold" data-lang="it">Lu</div>
-                        <div class="font-semibold" data-lang="it">Ma</div>
-                        <div class="font-semibold" data-lang="it">Me</div>
-                        <div class="font-semibold" data-lang="it">Gi</div>
-                        <div class="font-semibold" data-lang="it">Ve</div>
-                        <div class="font-semibold" data-lang="it">Sa</div>
-                        <div class="font-semibold" data-lang="it">Do</div>
-                        <!-- Example days (no logic) -->
-                        <div class="p-2 border rounded bg-green-100 dark:bg-green-900">1</div>
-                        <div class="p-2 border rounded bg-green-100 dark:bg-green-900">2</div>
-                        <div class="p-2 border rounded bg-red-100 dark:bg-red-900">3</div>
-                        <div class="p-2 border rounded bg-green-100 dark:bg-green-900">4</div>
-                        <div class="p-2 border rounded bg-green-100 dark:bg-green-900">5</div>
-                        <div class="p-2 border rounded bg-red-100 dark:bg-red-900">6</div>
-                        <div class="p-2 border rounded bg-green-100 dark:bg-green-900">7</div>
-                    </div>
-                    <p class="mt-4 text-xs text-gray-500" data-lang="de">Grün = verfügbar, Rot = belegt (Beispiel)</p>
-                    <p class="mt-4 text-xs text-gray-500" data-lang="it">Verde = disponibile, Rosso = occupato (esempio)
-                    </p>
-                </div>
-            </div>
-        </section>
-        <!-- Galerie -->
-        <section class="py-12 scroll-reveal">
-            <div class="max-w-screen-lg mx-auto px-4">
-                <h2 class="text-2xl font-bold mb-6" data-lang="de">Galerie</h2>
-                <h2 class="text-2xl font-bold mb-6" data-lang="it">Galleria</h2>
-                <div class="grid grid-cols-2 sm:grid-cols-3 gap-4">
-                    <img src="../../assets/img/apartment1-1200.jpg"
-     srcset="../../assets/img/apartment1-800.jpg 800w, ../../assets/img/apartment1-1200.jpg 1200w"
-     sizes="(max-width: 640px) 50vw, 33vw"
-     width="1200" height="800" loading="lazy"
-     alt="Helles Wohnzimmer mit Küche"
-     class="w-full h-40 object-cover rounded">
-
-     <img src="../../assets/img/apartment2-1200.jpg"
-     srcset="../../assets/img/apartment2-800.jpg 800w, ../../assets/img/apartment2-1200.jpg 1200w"
-     sizes="(max-width: 640px) 50vw, 33vw"
-     width="1200" height="800" loading="lazy"
-     alt="Helles Wohnzimmer mit Küche"
-     class="w-full h-40 object-cover rounded">
-
-                    <img src="../../assets/img/apartment3.jpg" alt="Küche" class="w-full h-40 object-cover rounded"
-                        loading="lazy" width="600" height="400">
-                    <img src="../../assets/img/apartment4.jpg" alt="Bad" class="w-full h-40 object-cover rounded"
-                        loading="lazy" width="600" height="400">
-                    <img src="../../assets/img/apartment5.jpg" alt="Balkon" class="w-full h-40 object-cover rounded"
-                        loading="lazy" width="600" height="400">
-                    <img src="../../assets/img/apartment6.jpg" alt="Aussicht" class="w-full h-40 object-cover rounded"
-                        loading="lazy" width="600" height="400">
-                </div>
-            </div>
-        </section>
-        <!-- Lage / Anreise -->
-        <section class="py-12 bg-gray-50 dark:bg-gray-800 scroll-reveal">
-            <div class="max-w-screen-md mx-auto px-4">
-                <h2 class="text-2xl font-bold mb-6" data-lang="de">Lage &amp; Anreise</h2>
-                <h2 class="text-2xl font-bold mb-6" data-lang="it">Posizione &amp; Arrivo</h2>
-                <p class="mb-4" data-lang="de">Unser Apartment liegt zentral in der Nähe aller Sehenswürdigkeiten. Eine
-                    Bushaltestelle befindet sich nur 100&nbsp;m entfernt.</p>
-                <p class="mb-4" data-lang="it">Il nostro appartamento è situato in posizione centrale vicino a tutte le
-                    attrazioni. Una fermata dell'autobus si trova a soli 100&nbsp;m.</p>
-                <div class="w-full h-64 bg-gray-200 dark:bg-gray-700 flex items-center justify-center rounded">
-                    <span class="text-gray-500" data-lang="de">Map‑Embed‑Platzhalter</span>
-                    <span class="text-gray-500" data-lang="it">Segnaposto mappa</span>
-                </div>
-            </div>
-        </section>
-        <!-- Hausregeln / FAQ -->
-        <section class="py-12 scroll-reveal">
-            <div class="max-w-screen-md mx-auto px-4">
-                <h2 class="text-2xl font-bold mb-6" data-lang="de">Hausregeln &amp; FAQ</h2>
-                <h2 class="text-2xl font-bold mb-6" data-lang="it">Regole della casa &amp; FAQ</h2>
-                <div class="space-y-4">
-                    <div>
-                        <h3 class="font-semibold" data-lang="de">Check‑in und Check‑out?</h3>
-                        <h3 class="font-semibold" data-lang="it">Check‑in e check‑out?</h3>
-                        <p class="text-sm text-gray-600 dark:text-gray-400" data-lang="de">Check‑in ab 15&nbsp;Uhr,
-                            Check‑out bis 10&nbsp;Uhr.</p>
-                        <p class="text-sm text-gray-600 dark:text-gray-400" data-lang="it">Check‑in dalle 15:00,
-                            check‑out entro le 10:00.</p>
-                    </div>
-                    <div>
-                        <h3 class="font-semibold" data-lang="de">Sind Haustiere erlaubt?</h3>
-                        <h3 class="font-semibold" data-lang="it">Animali ammessi?</h3>
-                        <p class="text-sm text-gray-600 dark:text-gray-400" data-lang="de">Auf Anfrage möglich, bitte
-                            kontaktieren Sie uns.</p>
-                        <p class="text-sm text-gray-600 dark:text-gray-400" data-lang="it">Su richiesta, contattaci.</p>
-                    </div>
-                    <div>
-                        <h3 class="font-semibold" data-lang="de">Wie erfolgt die Schlüsselübergabe?</h3>
-                        <h3 class="font-semibold" data-lang="it">Come avviene la consegna delle chiavi?</h3>
-                        <p class="text-sm text-gray-600 dark:text-gray-400" data-lang="de">Kontaktlos via
-                            Schlüsselkasten, Code senden wir per WhatsApp.</p>
-                        <p class="text-sm text-gray-600 dark:text-gray-400" data-lang="it">Autonomo tramite cassetta con
-                            codice inviato su WhatsApp.</p>
-                    </div>
-                </div>
-            </div>
-        </section>
-        <!-- Kontakt -->
-        <section class="py-12 text-center bg-gray-50 dark:bg-gray-800">
-            <div class="max-w-screen-md mx-auto px-4">
-                <h2 class="text-2xl font-bold mb-4" data-lang="de">Kontakt</h2>
-                <h2 class="text-2xl font-bold mb-4" data-lang="it">Contatto</h2>
-                <p class="mb-4" data-lang="de">Stellen Sie Ihre Anfrage oder buchen Sie direkt via WhatsApp.</p>
-                <p class="mb-4" data-lang="it">Invia la tua richiesta o prenota direttamente via WhatsApp.</p>
-                <a href="https://wa.me/PHONE?text=Ich%20habe%20eine%20Frage%20zum%20Apartment"
-                    class="inline-block px-6 py-3 bg-orange-500 text-white font-semibold rounded hover:bg-orange-600"
-                    target="_blank" rel="noopener" data-lang="de">WhatsApp schreiben</a>
-                <a href="https://wa.me/PHONE?text=Ho%20una%20domanda%20sull'appartamento"
-                    class="inline-block px-6 py-3 bg-orange-500 text-white font-semibold rounded hover:bg-orange-600"
-                    target="_blank" rel="noopener" data-lang="it">Scrivici su WhatsApp</a>
-                <!-- WhatsApp disclaimer -->
-                <p class="mt-2 text-xs text-gray-600 dark:text-gray-400" data-lang="de">Bei Klick werden Daten an WhatsApp/Meta übermittelt.</p>
-                <p class="mt-2 text-xs text-gray-600 dark:text-gray-400" data-lang="it">Cliccando, i dati verranno trasmessi a WhatsApp/Meta.</p>
-            </div>
-        </section>
-    </main>
-    <footer class="bg-gray-100 dark:bg-gray-800 py-6">
-        <div class="max-w-screen-lg mx-auto px-4 flex flex-col sm:flex-row justify-between items-center text-sm">
-            <div class="flex space-x-4 mb-4 sm:mb-0">
-                <a href="../../legal/impressum.html" class="underline" data-lang="de">Impressum</a>
-                <a href="../../legal/privacy.html" class="underline" data-lang="de">Datenschutz</a>
-                <a href="../../legal/impressum.html" class="underline" data-lang="it">Note legali</a>
-                <a href="../../legal/privacy.html" class="underline" data-lang="it">Privacy</a>
-            </div>
-            <div>
-                <small class="text-gray-500" data-lang="de">&copy; 2025 TurboSito – Demo&nbsp;Ferienwohnung</small>
-                <small class="text-gray-500" data-lang="it">&copy; 2025 TurboSito – Demo&nbsp;Appartamento</small>
-            </div>
-        </div>
-    </footer>
-    <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "LodgingBusiness",
-      "name": "Demo Ferienwohnung",
-      "description": "Wohnen nah am Zentrum. Alloggio vicino al centro.",
-      "image": "{{URL}}/assets/img/apartment-hero.jpg",
-      "telephone": "PHONE",
-      "address": {
-        "@type": "PostalAddress",
-        "streetAddress": "ADDRESS",
-        "addressLocality": "CITY",
-        "addressRegion": "REGION",
-        "addressCountry": "IT",
-        "postalCode": "ZIP"
-      },
-      "amenityFeature": [
-        {"@type": "LocationFeatureSpecification", "name": "2 Schlafzimmer", "value": true},
-        {"@type": "LocationFeatureSpecification", "name": "Küche", "value": true},
-        {"@type": "LocationFeatureSpecification", "name": "Balkon", "value": true}
-      ],
-      "sameAs": [
-        "SOCIAL_INSTAGRAM",
-        "SOCIAL_FACEBOOK"
-      ]
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Ferienwohnung Demo – TurboSito</title>
+  <link rel="preload" as="image"
+        href="../../assets/img/apartment-hero-1920.jpg"
+        fetchpriority="high">
+  <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+  <meta name="description"
+        content="Exklusive Ferienwohnung in zentraler Lage">
+  <meta property="og:title"
+        content="Ferienwohnung Demo – TurboSito">
+  <meta property="og:description"
+        content="Exklusive Ferienwohnung in zentraler Lage">
+  <meta property="og:image"
+        content="../../assets/img/apartment-hero-1920.jpg">
+  <meta property="og:type" content="website">
+  <script type="application/ld+json">
+{
+  "@context":"https://schema.org",
+  "@type":"Apartment",
+  "name":"Ferienwohnung Demo",
+  "image":"https://example.com/assets/img/apartment-hero-1920.jpg",
+  "address":{"@type":"PostalAddress","addressLocality":"Musterstadt"},
+  "offers":{"@type":"Offer","priceCurrency":"EUR"},
+  "areaServed":["DE","IT"],
+  "availableLanguage":["German","Italian"],
+  "contactPoint":{"@type":"ContactPoint","telephone":"+49123456",
+                  "contactType":"customer service"}
+}
+  </script>
+  <style>
+    [data-lang]{display:none}
+    :root[data-language="de"] [data-lang="de"]{display:block}
+    :root[data-language="it"] [data-lang="it"]{display:block}
+    .aurora{
+      background:
+        radial-gradient(at 20% 20%,rgba(91,92,225,.15),transparent 60%),
+        radial-gradient(at 80% 0%,rgba(6,182,212,.15),transparent 50%)
     }
-    </script>
-    <!-- Script for language/theme toggle -->
-    <script>
-        function setLang(lang) {
-            document.documentElement.dataset.language = lang;
-            localStorage.setItem('lang', lang);
+    .glass{backdrop-filter:blur(12px)}
+    @media (prefers-reduced-motion:no-preference){
+      .scroll-reveal{opacity:0;transform:translateY(.75rem);
+        transition:opacity .6s,transform .6s}
+      .scroll-reveal.show{opacity:1;transform:none}
+    }
+    #stickyBar{transition:transform .4s}
+    #stickyBar.hide{transform:translateY(100%)}
+    .day{position:relative}
+    .day::after{content:"";position:absolute;top:.25rem;right:.25rem;
+      width:.5rem;height:.5rem;border-radius:9999px}
+    .available{background:#16a34a;color:#fff}
+    .available::after{background:#fff}
+    .booked{background:#f43f5e;color:#fff}
+    .booked::after{background:#1f2937}
+    .maybe{background:#9ca3af;color:#fff}
+    .maybe::after{background:#1f2937}
+  </style>
+</head>
+<body class="font-sans text-gray-900 bg-white">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
+  <header class="sticky top-0 z-50 bg-white/80 backdrop-blur border-b">
+    <div class="max-w-6xl mx-auto flex items-center justify-between p-4">
+      <a href="/TurboSito/" class="text-xl font-semibold">TurboSito</a>
+      <div class="flex rounded-full border overflow-hidden"
+           role="group" aria-label="Language switch">
+        <button id="langDe" class="px-3 py-1 text-sm"
+                aria-pressed="true" data-set-lang="de">DE</button>
+        <button id="langIt" class="px-3 py-1 text-sm"
+                aria-pressed="false" data-set-lang="it">IT</button>
+      </div>
+    </div>
+    <nav aria-label="Breadcrumb"
+         class="max-w-6xl mx-auto px-4 pb-2 text-sm text-gray-600">
+      <ol class="flex gap-2">
+        <li><a href="/TurboSito/" class="underline">Start</a></li>
+        <li>/</li>
+        <li><a href="/TurboSito/demos" class="underline">Beispiele</a></li>
+        <li>/</li>
+        <li>Ferienwohnung</li>
+      </ol>
+    </nav>
+  </header>
+  <main id="content">
+    <section class="relative">
+      <picture>
+        <source type="image/webp"
+                srcset="../../assets/img/apartment-hero-1280.webp 1280w,
+                        ../../assets/img/apartment-hero-1920.webp 1920w"
+                sizes="100vw">
+        <img src="../../assets/img/apartment-hero-1920.jpg"
+             width="1920" height="1080"
+             alt="Moderne Ferienwohnung Fassade"
+             class="w-full h-[70vh] object-cover"
+             decoding="async">
+      </picture>
+      <div class="absolute inset-0 bg-gradient-to-t
+                  from-black/70 to-transparent"></div>
+      <div class="absolute inset-0 flex flex-col justify-center
+                  max-w-3xl mx-auto p-6 text-white">
+        <h1 class="text-4xl font-bold mb-4 leading-tight md:text-5xl"
+            data-lang="de">
+          Luxuriöse Ferienwohnung im Herzen der Stadt
+        </h1>
+        <h1 class="text-4xl font-bold mb-4 leading-tight md:text-5xl"
+            data-lang="it">
+          Appartamento di lusso nel cuore della città
+        </h1>
+        <ul class="flex flex-wrap gap-2 mb-6">
+          <li class="flex items-center gap-1 px-3 py-1 bg-white/20
+                     rounded-full text-sm">
+            <svg viewBox="0 0 24 24" fill="none"
+                 stroke="currentColor" class="w-4 h-4">
+              <path d="M3 7h18v10H3z"></path>
+              <path d="M3 7l9 6 9-6"></path>
+            </svg>
+            <span data-lang="de">2 Schlafzimmer</span>
+            <span data-lang="it">2 camere da letto</span>
+          </li>
+          <li class="flex items-center gap-1 px-3 py-1 bg-white/20
+                     rounded-full text-sm">
+            <svg viewBox="0 0 24 24" fill="none"
+                 stroke="currentColor" class="w-4 h-4">
+              <path d="M4 10h16v10H4z"></path>
+              <path d="M4 10V6h16v4"></path>
+            </svg>
+            <span data-lang="de">Balkon</span>
+            <span data-lang="it">Balcone</span>
+          </li>
+          <li class="flex items-center gap-1 px-3 py-1 bg-white/20
+                     rounded-full text-sm">
+            <svg viewBox="0 0 24 24" fill="none"
+                 stroke="currentColor" class="w-4 h-4">
+              <path d="M2 9h20v11H2z"></path>
+              <path d="M6 9V5h12v4"></path>
+            </svg>
+            <span data-lang="de">Parkplatz</span>
+            <span data-lang="it">Parcheggio</span>
+          </li>
+          <li class="flex items-center gap-1 px-3 py-1 bg-white/20
+                     rounded-full text-sm">
+            <svg viewBox="0 0 24 24" fill="none"
+                 stroke="currentColor" class="w-4 h-4">
+              <path d="M2 8h20"></path>
+              <path d="M5 12h14"></path>
+              <path d="M8 16h8"></path>
+            </svg>
+            <span data-lang="de">WLAN</span>
+            <span data-lang="it">Wi‑Fi</span>
+          </li>
+          <li class="flex items-center gap-1 px-3 py-1 bg-white/20
+                     rounded-full text-sm">
+            <svg viewBox="0 0 24 24" fill="none"
+                 stroke="currentColor" class="w-4 h-4">
+              <path d="M5 5h14v14H5z"></path>
+              <path d="M9 9h6v6H9z"></path>
+            </svg>
+            <span data-lang="de">Haustiere?</span>
+            <span data-lang="it">Animali?</span>
+          </li>
+        </ul>
+        <div class="flex gap-4">
+          <a href="#cta"
+             class="px-5 py-3 rounded-2xl bg-indigo-600 hover:bg-indigo-500
+                    focus-visible:ring">
+            <span data-lang="de">Anfrage senden</span>
+            <span data-lang="it">Invia richiesta</span>
+          </a>
+          <a href="#map"
+             class="px-5 py-3 rounded-2xl bg-white/20 hover:bg-white/30
+                    focus-visible:ring">
+            <span data-lang="de">Lage ansehen</span>
+            <span data-lang="it">Vedi posizione</span>
+          </a>
+        </div>
+      </div>
+      <div class="absolute top-6 right-6 z-10 glass bg-white/80 rounded-2xl
+                  p-4 shadow text-gray-900 max-w-xs">
+        <p class="text-yellow-500 text-lg mb-1">★★★★★</p>
+        <p class="text-sm mb-1" data-lang="de">Fantastische Unterkunft!</p>
+        <p class="text-sm mb-1" data-lang="it">Alloggio fantastico!</p>
+      </div>
+    </section>
+    <div id="stickyBar"
+         class="fixed bottom-0 inset-x-0 z-40 md:hidden bg-white/90 border-t
+                px-2 pt-2 flex gap-2
+                pb-[calc(env(safe-area-inset-bottom)+.5rem)]">
+      <a href="#availability"
+         class="flex-1 px-4 py-3 rounded-xl bg-indigo-600 text-white text-center
+                focus-visible:ring">
+        <span data-lang="de">Verfügbarkeit prüfen</span>
+        <span data-lang="it">Verifica disponibilità</span>
+      </a>
+      <a href="https://wa.me/123456"
+         class="flex-1 px-4 py-3 rounded-xl bg-green-500 text-white text-center
+                focus-visible:ring">
+        <span data-lang="de">WhatsApp schreiben</span>
+        <span data-lang="it">Scrivi su WhatsApp</span>
+      </a>
+    </div>
+    <section class="py-16 aurora scroll-reveal" id="highlights">
+      <div class="max-w-6xl mx-auto px-4 grid gap-6 md:grid-cols-2
+                  xl:grid-cols-4">
+        <div class="glass bg-white/80 rounded-2xl p-6 shadow">
+          <div class="mb-2">
+            <svg viewBox="0 0 24 24" stroke="currentColor" fill="none"
+                 class="w-6 h-6">
+              <path d="M12 2l7 7-7 7-7-7z"></path>
+            </svg>
+          </div>
+          <h2 class="font-semibold mb-1" data-lang="de">Top Lage</h2>
+          <h2 class="font-semibold mb-1" data-lang="it">Posizione top</h2>
+          <p class="text-sm" data-lang="de">Altstadt und Strand zu Fuß</p>
+          <p class="text-sm" data-lang="it">Centro e spiaggia a piedi</p>
+        </div>
+        <div class="glass bg-white/80 rounded-2xl p-6 shadow">
+          <div class="mb-2">
+            <svg viewBox="0 0 24 24" stroke="currentColor" fill="none"
+                 class="w-6 h-6">
+              <path d="M3 3h18v18H3z"></path>
+            </svg>
+          </div>
+          <h2 class="font-semibold mb-1" data-lang="de">Premium Ausstattung</h2>
+          <h2 class="font-semibold mb-1" data-lang="it">Dotazioni premium</h2>
+          <p class="text-sm" data-lang="de">Designmöbel und Küche</p>
+          <p class="text-sm" data-lang="it">Arredi di design e cucina</p>
+        </div>
+        <div class="glass bg-white/80 rounded-2xl p-6 shadow">
+          <div class="mb-2">
+            <svg viewBox="0 0 24 24" stroke="currentColor" fill="none"
+                 class="w-6 h-6">
+              <path d="M9 3h6v4H9z"></path>
+              <path d="M5 7h14v14H5z"></path>
+            </svg>
+          </div>
+          <h2 class="font-semibold mb-1" data-lang="de">Selbst Check‑in</h2>
+          <h2 class="font-semibold mb-1" data-lang="it">Self check‑in</h2>
+          <p class="text-sm" data-lang="de">Anreise rund um die Uhr</p>
+          <p class="text-sm" data-lang="it">Arrivo a ogni ora</p>
+        </div>
+        <div class="glass bg-white/80 rounded-2xl p-6 shadow">
+          <div class="mb-2">
+            <svg viewBox="0 0 24 24" stroke="currentColor" fill="none"
+                 class="w-6 h-6">
+              <path d="M2 12h20"></path>
+              <path d="M6 16h12"></path>
+            </svg>
+          </div>
+          <h2 class="font-semibold mb-1" data-lang="de">Schnelles WLAN</h2>
+          <h2 class="font-semibold mb-1" data-lang="it">Wi‑Fi veloce</h2>
+          <p class="text-sm" data-lang="de">Streaming ohne Limits</p>
+          <p class="text-sm" data-lang="it">Streaming senza limiti</p>
+        </div>
+      </div>
+    </section>
+<!-- END PART 1/3 -->
+<!-- BEGIN PART 2/3 -->
+    <section class="py-16 scroll-reveal" id="amenities">
+      <div class="max-w-6xl mx-auto px-4 grid gap-6 md:grid-cols-2
+                  lg:grid-cols-3">
+        <ul class="space-y-2">
+          <li class="flex items-start gap-2">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                 class="w-5 h-5 mt-1">
+              <path d="M5 13l4 4L19 7"></path>
+            </svg>
+            <span data-lang="de">Voll ausgestattete Küche</span>
+            <span data-lang="it">Cucina completamente attrezzata</span>
+          </li>
+          <li class="flex items-start gap-2">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                 class="w-5 h-5 mt-1">
+              <path d="M4 4h16v16H4z"></path>
+            </svg>
+            <span data-lang="de">Badezimmer mit Dusche</span>
+            <span data-lang="it">Bagno con doccia</span>
+          </li>
+          <li class="flex items-start gap-2">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                 class="w-5 h-5 mt-1">
+              <path d="M2 8h20"></path>
+              <path d="M5 12h14"></path>
+              <path d="M8 16h8"></path>
+            </svg>
+            <span data-lang="de">WLAN & TV</span>
+            <span data-lang="it">Wi‑Fi e TV</span>
+          </li>
+        </ul>
+        <ul class="space-y-2">
+          <li class="flex items-start gap-2">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                 class="w-5 h-5 mt-1">
+              <path d="M5 5h14v14H5z"></path>
+              <path d="M9 9h6v6H9z"></path>
+            </svg>
+            <span data-lang="de">Haustiere auf Anfrage</span>
+            <span data-lang="it">Animali su richiesta</span>
+          </li>
+          <li class="flex items-start gap-2">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                 class="w-5 h-5 mt-1">
+              <path d="M2 9h20v11H2z"></path>
+              <path d="M6 9V5h12v4"></path>
+            </svg>
+            <span data-lang="de">Privater Parkplatz</span>
+            <span data-lang="it">Parcheggio privato</span>
+          </li>
+          <li class="flex items-start gap-2">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                 class="w-5 h-5 mt-1">
+              <path d="M4 10h16v10H4z"></path>
+              <path d="M4 10V6h16v4"></path>
+            </svg>
+            <span data-lang="de">Balkon mit Aussicht</span>
+            <span data-lang="it">Balcone con vista</span>
+          </li>
+        </ul>
+        <ul class="space-y-2 hidden lg:block">
+          <li class="flex items-start gap-2">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                 class="w-5 h-5 mt-1">
+              <path d="M3 3h18v18H3z"></path>
+            </svg>
+            <span data-lang="de">Waschmaschine</span>
+            <span data-lang="it">Lavatrice</span>
+          </li>
+          <li class="flex items-start gap-2">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                 class="w-5 h-5 mt-1">
+              <path d="M2 2h20v20H2z"></path>
+            </svg>
+            <span data-lang="de">Kaffeemaschine</span>
+            <span data-lang="it">Macchina del caffè</span>
+          </li>
+          <li class="flex items-start gap-2">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                 class="w-5 h-5 mt-1">
+              <path d="M6 6h12v12H6z"></path>
+            </svg>
+            <span data-lang="de">Bügelset</span>
+            <span data-lang="it">Ferro da stiro</span>
+          </li>
+        </ul>
+      </div>
+    </section>
+    <section class="py-16 aurora scroll-reveal" id="gallery">
+      <div class="max-w-6xl mx-auto px-4 grid gap-4 md:grid-cols-2
+                  xl:grid-cols-3">
+        <figure class="aspect-[4/3] overflow-hidden rounded-2xl cursor-pointer">
+          <picture>
+            <source type="image/webp"
+                    srcset="../../assets/img/apartment1-800.webp 800w,
+                            ../../assets/img/apartment1-1200.webp 1200w"
+                    sizes="(min-width:768px) 50vw, 100vw">
+            <img src="../../assets/img/apartment1-800.jpg"
+                 width="800" height="600"
+                 loading="lazy" decoding="async"
+                 alt="Wohnzimmer mit Sofa"
+                 class="object-cover w-full h-full lightbox-img">
+          </picture>
+        </figure>
+        <figure class="aspect-[4/3] overflow-hidden rounded-2xl cursor-pointer">
+          <picture>
+            <source type="image/webp"
+                    srcset="../../assets/img/apartment2-800.webp 800w,
+                            ../../assets/img/apartment2-1200.webp 1200w"
+                    sizes="(min-width:768px) 50vw, 100vw">
+            <img src="../../assets/img/apartment2-800.jpg"
+                 width="800" height="600"
+                 loading="lazy" decoding="async"
+                 alt="Schlafzimmer mit Doppelbett"
+                 class="object-cover w-full h-full lightbox-img">
+          </picture>
+        </figure>
+        <figure class="aspect-[4/3] overflow-hidden rounded-2xl cursor-pointer">
+          <picture>
+            <source type="image/webp"
+                    srcset="../../assets/img/apartment3.jpg 800w"
+                    sizes="(min-width:768px) 50vw, 100vw">
+            <img src="../../assets/img/apartment3.jpg"
+                 width="800" height="600"
+                 loading="lazy" decoding="async"
+                 alt="Küche mit Insel"
+                 class="object-cover w-full h-full lightbox-img">
+          </picture>
+        </figure>
+      </div>
+    </section>
+    <section id="availability" class="py-16 scroll-reveal">
+      <div class="max-w-md mx-auto glass bg-white/80 rounded-2xl p-6 shadow">
+        <h2 class="text-xl font-semibold mb-4" data-lang="de">
+          Verfügbarkeit
+        </h2>
+        <h2 class="text-xl font-semibold mb-4" data-lang="it">
+          Disponibilità
+        </h2>
+        <div id="weekdays"
+             class="grid grid-cols-7 text-center text-sm mb-2"></div>
+        <div id="calendar"
+             class="grid grid-cols-7 gap-1 text-sm"
+             role="grid"></div>
+        <p class="mt-4 text-xs" data-lang="de">
+          Grün = verfügbar, Rot = belegt (Beispiel)
+        </p>
+        <p class="mt-4 text-xs" data-lang="it">
+          Verde = libero, Rosso = occupato (esempio)
+        </p>
+        <a href="#cta"
+           class="mt-4 inline-block px-5 py-2 rounded-xl bg-indigo-600
+                  text-white focus-visible:ring">
+          <span data-lang="de">Verfügbarkeit anfragen</span>
+          <span data-lang="it">Richiedi disponibilità</span>
+        </a>
+      </div>
+    </section>
+    <section id="map" class="py-16 aurora scroll-reveal">
+      <div class="max-w-3xl mx-auto px-4 text-center">
+        <p class="mb-4" data-lang="de">
+          Die Unterkunft liegt nahe dem historischen Hafen.
+        </p>
+        <p class="mb-4" data-lang="it">
+          L'alloggio è vicino al porto storico.
+        </p>
+        <div class="relative aspect-[16/9] rounded-2xl overflow-hidden mb-4
+                    bg-gradient-to-br from-indigo-50/40 via-white/30
+                    to-rose-50/40">
+          <img src="../../assets/img/apartment2-blur-800.jpg"
+               width="800" height="600"
+               alt="" aria-label="Kartenplatzhalter"
+               class="absolute inset-0 w-full h-full object-cover
+                      [mask-image:radial-gradient(circle_at_center,white,transparent)]">
+        </div>
+        <a href="https://maps.google.com" target="_blank" rel="noopener"
+           class="px-5 py-3 rounded-2xl bg-cyan-500 text-white
+                  focus-visible:ring">
+          <span data-lang="de">Route in Google Maps öffnen</span>
+          <span data-lang="it">Apri percorso in Google Maps</span>
+        </a>
+      </div>
+    </section>
+    <section id="faq" class="py-16 scroll-reveal">
+      <div class="max-w-3xl mx-auto px-4 space-y-4">
+        <details class="p-4 border rounded-xl">
+          <summary class="cursor-pointer focus-visible:ring"
+                   data-lang="de">Check‑in / Check‑out</summary>
+          <summary class="cursor-pointer focus-visible:ring"
+                   data-lang="it">Check‑in / Check‑out</summary>
+          <p class="mt-2 text-sm" data-lang="de">
+            Check‑in ab 15:00, Check‑out bis 10:00.
+          </p>
+          <p class="mt-2 text-sm" data-lang="it">
+            Check‑in dalle 15:00, check‑out entro le 10:00.
+          </p>
+        </details>
+        <details class="p-4 border rounded-xl">
+          <summary class="cursor-pointer focus-visible:ring"
+                   data-lang="de">Haustiere</summary>
+          <summary class="cursor-pointer focus-visible:ring"
+                   data-lang="it">Animali</summary>
+          <p class="mt-2 text-sm" data-lang="de">
+            Auf Anfrage erlaubt.
+          </p>
+          <p class="mt-2 text-sm" data-lang="it">
+            Consentiti su richiesta.
+          </p>
+        </details>
+      </div>
+    </section>
+    <section id="reviews" class="py-16 aurora scroll-reveal">
+      <h2 class="text-center text-2xl font-semibold mb-6" data-lang="de">
+        Gäste Stimmen
+      </h2>
+      <h2 class="text-center text-2xl font-semibold mb-6" data-lang="it">
+        Recensioni ospiti
+      </h2>
+      <div class="max-w-6xl mx-auto px-4 flex gap-4 overflow-x-auto
+                  snap-x snap-mandatory" aria-label="Reviews">
+        <article class="min-w-[16rem] snap-center glass bg-white/80 rounded-2xl
+                        p-4 shadow flex-shrink-0">
+          <p class="text-yellow-500 mb-1">★★★★★</p>
+          <p class="text-sm mb-2">Anna · 2024</p>
+          <p class="text-sm" data-lang="de">Tolle Wohnung, wir kommen wieder.</p>
+          <p class="text-sm" data-lang="it">
+            Appartamento fantastico, torneremo.
+          </p>
+        </article>
+        <article class="min-w-[16rem] snap-center glass bg-white/80 rounded-2xl
+                        p-4 shadow flex-shrink-0">
+          <p class="text-yellow-500 mb-1">★★★★★</p>
+          <p class="text-sm mb-2">Luca · 2024</p>
+          <p class="text-sm" data-lang="de">Perfekte Lage und Ausstattung.</p>
+          <p class="text-sm" data-lang="it">
+            Posizione e dotazioni perfette.
+          </p>
+        </article>
+        <article class="min-w-[16rem] snap-center glass bg-white/80 rounded-2xl
+                        p-4 shadow flex-shrink-0">
+          <p class="text-yellow-500 mb-1">★★★★☆</p>
+          <p class="text-sm mb-2">Marie · 2023</p>
+          <p class="text-sm" data-lang="de">Sehr sauber und gemütlich.</p>
+          <p class="text-sm" data-lang="it">
+            Molto pulito e accogliente.
+          </p>
+        </article>
+      </div>
+    </section>
+<!-- END PART 2/3 -->
+<!-- BEGIN PART 3/3 -->
+    <section id="cta" class="py-16 scroll-reveal">
+      <div class="max-w-md mx-auto glass bg-white/80 rounded-2xl p-6 text-center
+                  shadow">
+        <h2 class="text-2xl font-semibold mb-4" data-lang="de">
+          Interesse? Jetzt anfragen.
+        </h2>
+        <h2 class="text-2xl font-semibold mb-4" data-lang="it">
+          Interessato? Contattaci.
+        </h2>
+        <div class="flex flex-col gap-4">
+          <a href="https://wa.me/123456"
+             class="px-5 py-3 rounded-2xl bg-green-500 text-white
+                    focus-visible:ring">
+            <span data-lang="de">WhatsApp schreiben</span>
+            <span data-lang="it">Scrivi su WhatsApp</span>
+          </a>
+          <a href="mailto:info@example.com"
+             class="px-5 py-3 rounded-2xl bg-indigo-600 text-white
+                    focus-visible:ring">
+            <span data-lang="de">E‑Mail senden</span>
+            <span data-lang="it">Invia e‑mail</span>
+          </a>
+        </div>
+        <p class="mt-4 text-xs" data-lang="de">
+          Mit Klick auf WhatsApp stimmen Sie der Datenübermittlung zu.
+        </p>
+        <p class="mt-4 text-xs" data-lang="it">
+          Cliccando WhatsApp acconsenti al trasferimento dei dati.
+        </p>
+      </div>
+    </section>
+  </main>
+  <footer class="py-6 text-center text-sm">
+    <p class="mb-2">
+      <a href="/TurboSito/legal/impressum.html" class="underline">Impressum</a> ·
+      <a href="/TurboSito/legal/privacy.html" class="underline">Datenschutz</a>
+    </p>
+    <p>&copy; TurboSito</p>
+  </footer>
+  <dialog id="lightbox" class="p-0 bg-transparent" aria-modal="true">
+    <div class="relative">
+      <img id="lightboxImg" src="" alt="" class="max-h-screen rounded-xl">
+      <button id="prevImg"
+              class="absolute top-1/2 -translate-y-1/2 -left-3 bg-white/80
+                     rounded-full p-2 pointer-events-auto focus-visible:ring">
+        <svg viewBox="0 0 24 24" stroke="currentColor" fill="none"
+             class="w-5 h-5">
+          <path d="M15 18l-6-6 6-6"></path>
+        </svg>
+      </button>
+      <button id="nextImg"
+              class="absolute top-1/2 -translate-y-1/2 -right-3 bg-white/80
+                     rounded-full p-2 pointer-events-auto focus-visible:ring">
+        <svg viewBox="0 0 24 24" stroke="currentColor" fill="none"
+             class="w-5 h-5">
+          <path d="M9 6l6 6-6 6"></path>
+        </svg>
+      </button>
+      <button id="closeImg"
+              class="absolute top-2 right-2 bg-white/80 rounded-full p-2
+                     focus-visible:ring">
+        <svg viewBox="0 0 24 24" stroke="currentColor" fill="none"
+             class="w-5 h-5">
+          <path d="M6 6l12 12"></path>
+          <path d="M6 18L18 6"></path>
+        </svg>
+      </button>
+    </div>
+  </dialog>
+  <script>
+    const langBtns=document.querySelectorAll('[data-set-lang]')
+    const weekRow=document.getElementById('weekdays')
+    const cal=document.getElementById('calendar')
+    const weekdays={de:['Mo','Di','Mi','Do','Fr','Sa','So'],
+                    it:['Lu','Ma','Me','Gi','Ve','Sa','Do']}
+    const booked=[5,12,18,25]
+    const maybe=[7,21]
+    function renderWeekdays(){
+      const lang=document.documentElement.dataset.language||'de'
+      weekRow.innerHTML=weekdays[lang].map(d=>`<div>${d}</div>`).join('')
+    }
+    function buildCalendar(){
+      const lang=document.documentElement.dataset.language||'de'
+      cal.innerHTML=''
+      for(let i=1;i<=35;i++){
+        const day=i<=30?i:''
+        const c=document.createElement('div')
+        c.textContent=day
+        let status='available'
+        if(booked.includes(i)){status='booked'}
+        if(maybe.includes(i)){status='maybe'}
+        c.className=day?'day '+status:'p-2'
+        const label=lang==='de'
+          ?{available:'verfügbar',booked:'belegt',maybe:'blockiert'}
+          :{available:'libero',booked:'occupato',maybe:'bloccato'}
+        if(day){
+          c.setAttribute('aria-label',day+' '+label[status])
+          c.setAttribute('role','gridcell')
         }
-        function setTheme(theme) {
-            if (theme === 'dark') {
-                document.documentElement.classList.add('dark');
-                document.getElementById('themeSunA').classList.add('hidden');
-                document.getElementById('themeMoonA').classList.remove('hidden');
-            } else {
-                document.documentElement.classList.remove('dark');
-                document.getElementById('themeSunA').classList.remove('hidden');
-                document.getElementById('themeMoonA').classList.add('hidden');
-            }
-            localStorage.setItem('theme', theme);
-        }
-        document.getElementById('themeToggleA').addEventListener('click', function () {
-            const isDark = document.documentElement.classList.contains('dark');
-            setTheme(isDark ? 'light' : 'dark');
-        });
-        document.addEventListener('DOMContentLoaded', () => {
-            const savedLang = localStorage.getItem('lang') || 'de';
-            setLang(savedLang);
-            const savedTheme = localStorage.getItem('theme') || 'light';
-            setTheme(savedTheme);
-        });
-    </script>
-    <!-- Scroll reveal script: reveals sections on scroll -->
-    <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            const observer = new IntersectionObserver((entries) => {
-                entries.forEach(entry => {
-                    if (entry.isIntersecting) {
-                        entry.target.classList.add('revealed');
-                        observer.unobserve(entry.target);
-                    }
-                });
-            }, { threshold: 0.1 });
-            document.querySelectorAll('.scroll-reveal').forEach(el => {
-                observer.observe(el);
-            });
-        });
-    </script>
+        cal.appendChild(c)
+      }
+    }
+    langBtns.forEach(btn=>{
+      btn.addEventListener('click',()=>{
+        document.documentElement.dataset.language=btn.dataset.setLang
+        document.documentElement.lang=btn.dataset.setLang
+        localStorage.setItem('lang',btn.dataset.setLang)
+        langBtns.forEach(b=>b.setAttribute('aria-pressed',b===btn))
+        document.title=btn.dataset.setLang==='de'
+          ?'Ferienwohnung Demo – TurboSito'
+          :'Appartamento Demo – TurboSito'
+        renderWeekdays()
+        buildCalendar()
+      })
+    })
+    const saved=localStorage.getItem('lang')
+    if(saved){
+      document.getElementById('lang'+saved.charAt(0).toUpperCase()+
+        saved.slice(1)).click()
+    }else{
+      renderWeekdays()
+      buildCalendar()
+    }
+    const observer=new IntersectionObserver(entries=>{
+      entries.forEach(e=>{if(e.isIntersecting)e.target.classList.add('show')})
+    },{threshold:.1})
+    document.querySelectorAll('.scroll-reveal')
+      .forEach(el=>observer.observe(el))
+    const stickyBar=document.getElementById('stickyBar')
+    const endObs=new IntersectionObserver(entries=>{
+      entries.forEach(e=>{
+        if(e.isIntersecting){stickyBar.classList.add('hide')}
+        else{stickyBar.classList.remove('hide')}
+      })
+    })
+    endObs.observe(document.getElementById('cta'))
+    endObs.observe(document.querySelector('footer'))
+    const imgs=[...document.querySelectorAll('.lightbox-img')]
+    const dialog=document.getElementById('lightbox')
+    const imgEl=document.getElementById('lightboxImg')
+    let idx=0
+    function show(i){
+      idx=(i+imgs.length)%imgs.length
+      imgEl.src=imgs[idx].src
+      imgEl.alt=imgs[idx].alt
+      dialog.showModal()
+    }
+    imgs.forEach((img,i)=>{img.addEventListener('click',()=>show(i))})
+    document.getElementById('prevImg')
+      .addEventListener('click',()=>show(idx-1))
+    document.getElementById('nextImg')
+      .addEventListener('click',()=>show(idx+1))
+    document.getElementById('closeImg')
+      .addEventListener('click',()=>dialog.close())
+    dialog.addEventListener('click',e=>{
+      if(e.target===dialog){dialog.close()}
+    })
+    document.addEventListener('keydown',e=>{
+      if(e.key==='Escape'){dialog.close()}
+      if(dialog.open&&e.key==='ArrowRight'){show(idx+1)}
+      if(dialog.open&&e.key==='ArrowLeft'){show(idx-1)}
+    })
+  </script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
 </body>
-
 </html>
+<!-- END PART 3/3 -->

--- a/demos/barber/index.html
+++ b/demos/barber/index.html
@@ -25,6 +25,7 @@
     </style>
 </head>
 <body class="font-sans text-gray-800 dark:text-gray-100 bg-white dark:bg-[#111827] transition-colors duration-300">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
     <header class="sticky top-0 z-50 bg-white/80 dark:bg-gray-900/80 backdrop-blur border-b border-gray-200 dark:border-gray-700">
         <div class="max-w-screen-xl mx-auto flex items-center justify-between p-4">
             <!-- Logo with page name: link back to landing page -->
@@ -46,7 +47,7 @@
             </div>
         </div>
     </header>
-    <main>
+    <main id="content">
         <!-- Hero -->
         <!-- Hero section with more height on mobile for better spacing -->
         <!-- Increase hero height to allow headings and CTA to breathe on mobile -->
@@ -263,5 +264,10 @@
             });
         });
     </script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
 </body>
 </html>

--- a/demos/restaurant/index.html
+++ b/demos/restaurant/index.html
@@ -27,6 +27,7 @@
     </style>
 </head>
 <body class="font-sans text-gray-800 dark:text-gray-100 bg-white dark:bg-[#111827] transition-colors duration-300">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
     <header class="sticky top-0 z-50 bg-white/80 dark:bg-gray-900/80 backdrop-blur border-b border-gray-200 dark:border-gray-700">
         <div class="max-w-screen-xl mx-auto flex items-center justify-between p-4">
             <!-- Logo with page name: link back to landing page -->
@@ -50,7 +51,7 @@
             </div>
         </div>
     </header>
-    <main>
+    <main id="content">
         <!-- Hero Section -->
         <!-- Hero section: give more breathing room on mobile devices -->
         <!-- Taller hero for improved mobile spacing -->
@@ -280,5 +281,10 @@
             });
         });
     </script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
 </body>
 </html>

--- a/en/_partials/footer.html
+++ b/en/_partials/footer.html
@@ -1,0 +1,8 @@
+<footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Contact: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/en/legal.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Legal</a>
+    </p>
+  </div>
+</footer>

--- a/en/_partials/header.html
+++ b/en/_partials/header.html
@@ -1,0 +1,26 @@
+<header id="site-header">
+  <div class="container flex items-center justify-between gap-4">
+    <nav class="site-nav">
+      <a class="brand" href="/TurboSito/en/">TurboSito</a>
+      <a href="/TurboSito/en/about.html">About</a>
+      <a href="/TurboSito/en/services.html">Services</a>
+      <a href="/TurboSito/en/portfolio.html">Portfolio</a>
+      <a href="/TurboSito/en/contact.html">Contact</a>
+    </nav>
+    <div class="header-right flex items-center gap-2">
+    <nav class="lang-switch" aria-label="Language switch">
+      <a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a>
+      <a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a>
+      <a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a>
+    </nav>
+    <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü">
+      <span aria-hidden="true"></span>
+    </button>
+    <button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false">
+      <span class="icon sun" aria-hidden="true">☀️</span>
+      <span class="icon moon" aria-hidden="true">🌙</span>
+      <span>Theme</span>
+    </button>
+  </div>
+  </div>
+</header>

--- a/en/about.html
+++ b/en/about.html
@@ -5,11 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>About – TurboSito</title>
   <meta name="description" content="Learn more about TurboSito and the person behind it.">
-  <link rel="canonical" href="https://deine-domain.tld/en/about.html">
-  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/ueber-mich.html">
-  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/about.html">
-  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/chi-sono.html">
-  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
+  <link rel="canonical" href="/TurboSito/en/about.html">
+  <link rel="alternate" hreflang="de" href="/TurboSito/de/ueber-mich.html">
+  <link rel="alternate" hreflang="en" href="/TurboSito/en/about.html">
+  <link rel="alternate" hreflang="it" href="/TurboSito/it/chi-sono.html">
+  <link rel="alternate" hreflang="x-default" href="/TurboSito/en/">
   <meta property="og:title" content="About – TurboSito">
   <meta property="og:description" content="Learn more about TurboSito and the person behind it.">
   <meta property="og:url" content="https://deine-domain.tld/en/about.html">
@@ -31,9 +31,56 @@
 <header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/en/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/en/">Home</a><a href="/TurboSito/en/about.html">About</a><a href="/TurboSito/en/services.html">Services</a><a href="/TurboSito/en/portfolio.html">Portfolio</a><a href="/TurboSito/en/contact.html">Contact</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Language"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Toggle theme" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button></div></div></header>
 
 <main id="content" role="main">
-  <section class="section-lg max-w-screen-xl mx-auto px-4 py-20 text-center">
-    <h1 class="font-display text-3xl md:text-4xl font-bold mb-6">About</h1>
-    <p>Learn more about me here.</p>
+  <section class="section">
+    <div class="container grid-2 hero-about">
+      <div>
+        <h1>About</h1>
+        <p class="lead">I build converting websites in <strong>48 hours</strong> – clear, fast, measurable.</p>
+        <div class="badges" style="margin-top:18px">
+          <span class="badge brand">Next.js</span><span class="badge">Tailwind</span>
+          <span class="badge">Eleventy</span><span class="badge">SEO</span>
+        </div>
+        <div style="display:flex; gap:12px; margin-top:20px">
+          <a class="btn" href="/TurboSito/en/#quick-start">Start project</a>
+          <a class="btn btn-outline" href="/TurboSito/en/portfolio.html">View portfolio</a>
+        </div>
+      </div>
+      <div style="display:flex;justify-content:center">
+        <img class="avatar" src="/TurboSito/assets/img/me.jpg" alt="Portrait">
+      </div>
+    </div>
+  </section>
+  <section class="section">
+    <div class="container card pad">
+      <h2>Skills</h2>
+      <p class="muted">Stack & workflow</p>
+      <div class="badges" style="margin-top:8px">
+        <span class="badge">CRO</span><span class="badge">Performance</span>
+        <span class="badge">Accessibility</span><span class="badge">i18n</span>
+      </div>
+    </div>
+  </section>
+  <section class="section">
+    <div class="container">
+      <h2>Timeline</h2>
+      <div class="timeline">
+        <div class="timeline-item"><strong>2025 – today</strong><br>Freelance, productized service "Website in 48h"</div>
+        <div class="timeline-item"><strong>2022 – 2024</strong><br>Frontend Lead (Landing pages & CRO)</div>
+        <div class="timeline-item"><strong>2019 – 2022</strong><br>Full-stack projects (Next.js, Headless CMS)</div>
+      </div>
+    </div>
+  </section>
+  <section class="section">
+    <div class="container card pad" style="display:flex;justify-content:space-between;align-items:center;gap:16px;flex-wrap:wrap">
+      <div>
+        <h3 style="margin:0 0 4px">Ready to start?</h3>
+        <p class="muted" style="margin:0">Send me the basics – I’ll reply today.</p>
+      </div>
+      <div style="display:flex;gap:12px">
+        <a class="btn" href="/TurboSito/en/#quick-start">Start project</a>
+        <a class="btn btn-outline" href="/TurboSito/en/portfolio.html">Portfolio</a>
+      </div>
+    </div>
   </section>
 </main>
 <footer class="border-t border-white/10">

--- a/en/about.html
+++ b/en/about.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>About – TurboSito</title>
+  <meta name="description" content="Learn more about TurboSito and the person behind it.">
+  <link rel="canonical" href="https://deine-domain.tld/en/about.html">
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/ueber-mich.html">
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/about.html">
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/chi-sono.html">
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
+  <meta property="og:title" content="About – TurboSito">
+  <meta property="og:description" content="Learn more about TurboSito and the person behind it.">
+  <meta property="og:url" content="https://deine-domain.tld/en/about.html">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+<style>
+  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+  .font-display{font-family:"Outfit", var(--font-sans)}
+  body{font-family:var(--font-sans)}
+</style>
+<link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+<script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
+<header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/en/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/en/">Home</a><a href="/TurboSito/en/about.html">About</a><a href="/TurboSito/en/services.html">Services</a><a href="/TurboSito/en/portfolio.html">Portfolio</a><a href="/TurboSito/en/contact.html">Contact</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Language"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Toggle theme" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button></div></div></header>
+
+<main id="content" role="main">
+  <section class="section-lg max-w-screen-xl mx-auto px-4 py-20 text-center">
+    <h1 class="font-display text-3xl md:text-4xl font-bold mb-6">About</h1>
+    <p>Learn more about me here.</p>
+  </section>
+</main>
+<footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Contact: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/en/legal.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Legal</a>
+    </p>
+  </div>
+</footer>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+</body>
+</html>

--- a/en/cases/landingpage-tech-startup.html
+++ b/en/cases/landingpage-tech-startup.html
@@ -1,80 +1,108 @@
-<!doctype html>
-<html lang="en">
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
 <head>
-  <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Landing page for tech startup – Case Study</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Landing page for tech startup – Case study</title>
   <meta name="description" content="40% more signups after launch. Approach, solution and results.">
-  <link rel="canonical" href="/TurboSito/en/cases/landingpage-tech-startup.html">
-  <link rel="alternate" hreflang="de" href="/TurboSito/de/cases/landingpage-tech-startup.html">
-  <link rel="alternate" hreflang="en" href="/TurboSito/en/cases/landingpage-tech-startup.html">
-  <link rel="alternate" hreflang="it" href="/TurboSito/it/cases/landingpage-tech-startup.html">
+  <link rel="canonical" href="https://deine-domain.tld/en/cases/landingpage-tech-startup.html">
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/cases/landingpage-tech-startup.html">
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/cases/landingpage-tech-startup.html">
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/cases/landingpage-tech-startup.html">
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+<style>
+  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+  .font-display{font-family:"Outfit", var(--font-sans)}
+  body{font-family:var(--font-sans)}
+</style>
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+  <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
 </head>
-<body>
-<header class="section" style="padding-block:24px"><div class="container" style="display:flex;justify-content:space-between;align-items:center;gap:16px">
-  <a class="badge brand" href="/TurboSito/en/">TurboSito</a>
-  <nav style="display:flex;gap:14px"><a href="/TurboSito/en/portfolio.html">Portfolio</a><a href="/TurboSito/en/about.html">About</a></nav>
-</div></header>
-
-<section class="section">
-  <div class="container">
-    <div class="badges" style="margin-bottom:12px">
-      <span class="badge brand">Case study</span><span class="badge">Landing page</span><span class="badge">Tailwind</span><span class="badge">A/B</span>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
+<header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/en/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/en/">Home</a><a href="/TurboSito/en/about.html">About</a><a href="/TurboSito/en/services.html">Services</a><a href="/TurboSito/en/portfolio.html" aria-current="page" class="text-indigo-600 font-semibold">Portfolio</a><a href="/TurboSito/en/contact.html">Contact</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Language"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Toggle theme" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button></div></div></header>
+<main id="content">
+  <section class="section">
+    <div class="container">
+      <nav class="breadcrumbs"><a href="/TurboSito/en/portfolio.html">Portfolio</a> · <span>Case study</span></nav>
+      <div class="badges mb-3">
+        <span class="badge brand">Case study</span><span class="badge">Landing page</span><span class="badge">Tailwind</span><span class="badge">A/B</span>
+      </div>
+      <h1 class="mb-2">Landing page for tech startup</h1>
+      <p class="muted mb-4">From zero to launch in 48h – clear structure, fast performance, measurable uplift.</p>
+      <div class="gallery mt-3">
+        <img class="case-hero" src="/TurboSito/assets/img/cases/startup-hero.jpg" alt="Hero view" width="1200" height="675" loading="lazy" decoding="async">
+      </div>
     </div>
-    <h1 style="margin:0 0 8px">Landing page for tech startup</h1>
-    <p class="muted" style="margin:0 0 16px">From zero to launch in 48h – clear structure, fast performance, measurable lift.</p>
-    <div class="gallery" style="margin-top:12px">
-      <img class="span-12" src="/TurboSito/assets/img/cases/startup-hero.jpg" alt="Hero view">
+  </section>
+  <section class="section">
+    <div class="container grid gap-4 md:grid-cols-3">
+      <div class="card kpi"><big>+40%</big><span>Signups</span></div>
+      <div class="card kpi"><big>1.1s</big><span>LCP (mobile)</span></div>
+      <div class="card kpi"><big>48h</big><span>Time to launch</span></div>
     </div>
-  </div>
-</section>
-
-<section class="section">
-  <div class="container" style="display:grid; gap:16px; grid-template-columns: repeat(3, 1fr);">
-    <div class="kpi"><div class="num">+40%</div><div class="lbl">Signups</div></div>
-    <div class="kpi"><div class="num">1.1s</div><div class="lbl">LCP (mobile)</div></div>
-    <div class="kpi"><div class="num">48h</div><div class="lbl">Time to launch</div></div>
-  </div>
-</section>
-
-<section class="section">
-  <div class="container grid-2">
-    <div class="card pad">
-      <h2 style="margin-top:0">Problem</h2>
-      <p>The landing page produced too few signups, slow load times, unclear message.</p>
-      <h3>Hypotheses</h3>
-      <ul><li>Clearer value proposition</li><li>Faster LCP</li><li>Stronger CTA placement</li></ul>
+  </section>
+  <section class="section">
+    <div class="container grid-2">
+      <div class="card pad">
+        <h2>Problem</h2>
+        <p>Landing page drove too few signups, slow loads, unclear messaging.</p>
+        <h3>Hypotheses</h3>
+        <ul><li>Clearer value proposition</li><li>Faster LCP</li><li>Stronger CTA placement</li></ul>
+      </div>
+      <div class="card pad">
+        <h2>Approach &amp; solution</h2>
+        <ul>
+          <li>Wireframe → lean hero, social proof, precise benefits</li>
+          <li>Static export + Tailwind, image optimization, lazy images</li>
+          <li>A/B test CTA variants</li>
+        </ul>
+        <h3>Stack</h3>
+        <div class="badges"><span class="badge">Eleventy</span><span class="badge">Tailwind</span><span class="badge">Alpine</span><span class="badge">Plausible</span></div>
+      </div>
     </div>
-    <div class="card pad">
-      <h2 style="margin-top:0">Approach &amp; solution</h2>
-      <ul>
-        <li>Wireframe → lean hero structure, social proof, precise benefits</li>
-        <li>Tech: static export + Tailwind, image optimization, lazy images</li>
-        <li>A/B test CTA variants</li>
-      </ul>
-      <h3>Stack</h3>
-      <div class="badges"><span class="badge">Eleventy</span><span class="badge">Tailwind</span><span class="badge">Alpine</span><span class="badge">Plausible</span></div>
+  </section>
+  <section class="section">
+    <div class="container gallery">
+      <img class="span-6" src="/TurboSito/assets/img/cases/startup-section.jpg" alt="Section" width="800" height="600" loading="lazy" decoding="async">
+      <img class="span-6" src="/TurboSito/assets/img/cases/startup-mobile.jpg" alt="Mobile" width="800" height="600" loading="lazy" decoding="async">
+      <img class="span-12" src="/TurboSito/assets/img/cases/startup-graph.jpg" alt="Result graph" width="1200" height="675" loading="lazy" decoding="async">
     </div>
+  </section>
+  <section class="section">
+    <div class="container card pad flex justify-between items-center gap-3 flex-wrap">
+      <div><strong>Live:</strong> <a href="#" rel="noopener">View project</a> · <strong>Code:</strong> <a href="#" rel="noopener">GitHub</a></div>
+      <a class="btn" href="/TurboSito/en/#quick-start">Start a similar project</a>
+    </div>
+  </section>
+  <section class="section">
+    <div class="container card pad flex justify-between items-center gap-4 flex-wrap">
+      <div>
+        <h3 class="m-0 mb-1">Ready to get started?</h3>
+        <p class="muted m-0">Send me the key info – I'll reply today.</p>
+      </div>
+      <div class="flex gap-3">
+        <a class="btn" href="/TurboSito/en/#quick-start">Start project</a>
+        <a class="btn btn-outline" href="/TurboSito/en/portfolio.html">More projects</a>
+      </div>
+    </div>
+  </section>
+</main>
+<footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Contact: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/en/legal.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Legal</a>
+    </p>
   </div>
-</section>
-
-<section class="section">
-  <div class="container gallery">
-    <img class="span-6" src="/TurboSito/assets/img/cases/startup-section.jpg" alt="Section">
-    <img class="span-6" src="/TurboSito/assets/img/cases/startup-mobile.jpg" alt="Mobile">
-    <img class="span-12" src="/TurboSito/assets/img/cases/startup-graph.jpg" alt="Result graph">
-  </div>
-</section>
-
-<section class="section">
-  <div class="container card pad" style="display:flex;justify-content:space-between;align-items:center;gap:12px">
-    <div><strong>Live:</strong> <a href="#" rel="noopener">Project</a> · <strong>Code:</strong> <a href="#" rel="noopener">GitHub</a></div>
-    <a class="btn" href="/TurboSito/en/#quick-start">Start similar project</a>
-  </div>
-</section>
-
-<footer class="section"><div class="container" style="display:flex;gap:12px">
-  <a href="/TurboSito/en/portfolio.html">Back to portfolio</a>
-</div></footer>
+</footer>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
 </body>
 </html>

--- a/en/cases/landingpage-tech-startup.html
+++ b/en/cases/landingpage-tech-startup.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Landing page for tech startup – Case Study</title>
+  <meta name="description" content="40% more signups after launch. Approach, solution and results.">
+  <link rel="canonical" href="/TurboSito/en/cases/landingpage-tech-startup.html">
+  <link rel="alternate" hreflang="de" href="/TurboSito/de/cases/landingpage-tech-startup.html">
+  <link rel="alternate" hreflang="en" href="/TurboSito/en/cases/landingpage-tech-startup.html">
+  <link rel="alternate" hreflang="it" href="/TurboSito/it/cases/landingpage-tech-startup.html">
+  <link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+</head>
+<body>
+<header class="section" style="padding-block:24px"><div class="container" style="display:flex;justify-content:space-between;align-items:center;gap:16px">
+  <a class="badge brand" href="/TurboSito/en/">TurboSito</a>
+  <nav style="display:flex;gap:14px"><a href="/TurboSito/en/portfolio.html">Portfolio</a><a href="/TurboSito/en/about.html">About</a></nav>
+</div></header>
+
+<section class="section">
+  <div class="container">
+    <div class="badges" style="margin-bottom:12px">
+      <span class="badge brand">Case study</span><span class="badge">Landing page</span><span class="badge">Tailwind</span><span class="badge">A/B</span>
+    </div>
+    <h1 style="margin:0 0 8px">Landing page for tech startup</h1>
+    <p class="muted" style="margin:0 0 16px">From zero to launch in 48h – clear structure, fast performance, measurable lift.</p>
+    <div class="gallery" style="margin-top:12px">
+      <img class="span-12" src="/TurboSito/assets/img/cases/startup-hero.jpg" alt="Hero view">
+    </div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container" style="display:grid; gap:16px; grid-template-columns: repeat(3, 1fr);">
+    <div class="kpi"><div class="num">+40%</div><div class="lbl">Signups</div></div>
+    <div class="kpi"><div class="num">1.1s</div><div class="lbl">LCP (mobile)</div></div>
+    <div class="kpi"><div class="num">48h</div><div class="lbl">Time to launch</div></div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container grid-2">
+    <div class="card pad">
+      <h2 style="margin-top:0">Problem</h2>
+      <p>The landing page produced too few signups, slow load times, unclear message.</p>
+      <h3>Hypotheses</h3>
+      <ul><li>Clearer value proposition</li><li>Faster LCP</li><li>Stronger CTA placement</li></ul>
+    </div>
+    <div class="card pad">
+      <h2 style="margin-top:0">Approach &amp; solution</h2>
+      <ul>
+        <li>Wireframe → lean hero structure, social proof, precise benefits</li>
+        <li>Tech: static export + Tailwind, image optimization, lazy images</li>
+        <li>A/B test CTA variants</li>
+      </ul>
+      <h3>Stack</h3>
+      <div class="badges"><span class="badge">Eleventy</span><span class="badge">Tailwind</span><span class="badge">Alpine</span><span class="badge">Plausible</span></div>
+    </div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container gallery">
+    <img class="span-6" src="/TurboSito/assets/img/cases/startup-section.jpg" alt="Section">
+    <img class="span-6" src="/TurboSito/assets/img/cases/startup-mobile.jpg" alt="Mobile">
+    <img class="span-12" src="/TurboSito/assets/img/cases/startup-graph.jpg" alt="Result graph">
+  </div>
+</section>
+
+<section class="section">
+  <div class="container card pad" style="display:flex;justify-content:space-between;align-items:center;gap:12px">
+    <div><strong>Live:</strong> <a href="#" rel="noopener">Project</a> · <strong>Code:</strong> <a href="#" rel="noopener">GitHub</a></div>
+    <a class="btn" href="/TurboSito/en/#quick-start">Start similar project</a>
+  </div>
+</section>
+
+<footer class="section"><div class="container" style="display:flex;gap:12px">
+  <a href="/TurboSito/en/portfolio.html">Back to portfolio</a>
+</div></footer>
+</body>
+</html>

--- a/en/contact.html
+++ b/en/contact.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Contact – TurboSito</title>
+  <meta name="description" content="I'll reply within 24–48h.">
+  <link rel="canonical" href="https://deine-domain.tld/en/contact.html">
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/kontakt.html">
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/contact.html">
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/contatti.html">
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
+  <meta property="og:title" content="Contact – TurboSito">
+  <meta property="og:description" content="I'll reply within 24–48h.">
+  <meta property="og:url" content="https://deine-domain.tld/en/contact.html">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+<style>
+  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+  .font-display{font-family:"Outfit", var(--font-sans)}
+  body{font-family:var(--font-sans)}
+</style>
+<link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+<script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
+<header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/en/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/en/">Home</a><a href="/TurboSito/en/about.html">About</a><a href="/TurboSito/en/services.html">Services</a><a href="/TurboSito/en/portfolio.html">Portfolio</a><a href="/TurboSito/en/contact.html">Contact</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Language"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Toggle theme" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button></div></div></header>
+
+<main id="content">
+  <section class="section-lg max-w-3xl mx-auto px-4 py-20">
+    <h1 class="font-display text-3xl md:text-4xl font-bold mb-6">Contact</h1>
+    <p class="mb-8">I'll reply within 24–48&nbsp;hours.</p>
+    <div class="card max-w-2xl">
+      <form id="contact-form" name="contact" method="post" data-netlify="true" netlify-honeypot="bot-field" class="space-y-4" action="/TurboSito/en/thanks.html">
+        <input type="hidden" name="form-name" value="contact">
+        <div class="hidden" aria-hidden="true"><label>Don’t fill<input name="bot-field"></label></div>
+        <div>
+          <label for="name" class="label">Name</label>
+          <input id="name" name="name" required aria-invalid="false" class="input">
+        </div>
+        <div>
+          <label for="email" class="label">Email</label>
+          <input id="email" name="email" type="email" required aria-invalid="false" class="input">
+        </div>
+        <div>
+          <label for="message" class="label">Message</label>
+          <textarea id="message" name="message" required aria-invalid="false" class="input h-32"></textarea>
+        </div>
+        <div class="flex items-start gap-2">
+          <input id="consent" name="consent" type="checkbox" required class="mt-1 rounded border-white/15">
+          <label for="consent" class="label text-[var(--muted)]">I agree to the processing of my data according to the <a href="/TurboSito/en/legal.html" class="underline">legal notice</a>.</label>
+        </div>
+        <button type="submit" class="btn mt-3" aria-label="Send message">Send message</button>
+      </form>
+    </div>
+  </section>
+</main>
+<footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Contact: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/en/legal.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Legal</a>
+    </p>
+  </div>
+</footer>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+</body>
+</html>

--- a/en/index.html
+++ b/en/index.html
@@ -68,10 +68,18 @@
           <div class="kicker badge inline-block"></div>
           <h1 class="font-display text-4xl md:text-6xl font-extrabold tracking-tight"><span class="text-gradient">Website in 48 hours</span></h1>
           <p class="mt-4 text-lg hero-subtitle text-[var(--fg)]">Fixed price. More inquiries – no calls.</p>
-          <div class="mt-10 flex flex-wrap gap-4 items-center">
-            <a class="btn btn-lg" href="/TurboSito/en/contact.html">Contact us</a>
-            <a class="btn btn-outline btn-lg" href="/TurboSito/en/portfolio.html">View portfolio</a>
+          <div class="cta-hero">
+            <a class="btn btn-contact" data-cta="contact" href="#quick-start">Contact us</a>
+            <a class="btn btn-primary" data-cta="primary" href="#quick-start" data-open-form>Start project</a>
+            <a class="btn btn-outline" data-cta="portfolio" href="/TurboSito/en/portfolio.html">View portfolio</a>
           </div>
+          <form id="micro-start" class="micro-start" novalidate>
+            <label class="sr-only" for="micro-email">Email</label>
+            <input id="micro-email" name="email" type="email"
+                   placeholder="Enter email" inputmode="email"
+                   autocomplete="email" required>
+            <button class="btn" type="submit">Let's go</button>
+          </form>
         </div>
         <div class="md:col-span-6 mt-10 md:mt-0">
           <div class="ratio card mockup">
@@ -192,5 +200,6 @@
   <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
   <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
   <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+  <script src="/TurboSito/assets/js/sticky-cta.js" defer></script>
 </body>
 </html>

--- a/en/index.html
+++ b/en/index.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>TurboSito – Website in 48 hours</title>
+  <meta name="description" content="Website in 48 hours. Fixed price. More inquiries – no calls.">
+  <link rel="canonical" href="https://deine-domain.tld/en/">
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/">
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/">
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/">
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
+  <meta property="og:title" content="TurboSito – Website in 48 hours">
+  <meta property="og:description" content="Website in 48 hours. Fixed price. More inquiries – no calls.">
+  <meta property="og:url" content="https://deine-domain.tld/en/">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "name": "Max Mustermann",
+  "url": "https://deine-domain.tld",
+  "sameAs": [
+    "https://github.com/example",
+    "https://www.linkedin.com/in/example"
+  ],
+  "worksFor": {
+    "@type": "Organization",
+    "name": "TurboSito"
+  }
+}
+</script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": "TurboSito",
+  "url": "https://deine-domain.tld",
+  "inLanguage": "en",
+  "potentialAction": {
+    "@type": "SearchAction",
+    "target": "https://deine-domain.tld/en/?s={search_term_string}",
+    "query-input": "required name=search_term_string"
+  }
+}
+</script>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+<style>
+  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+  .font-display{font-family:"Outfit", var(--font-sans)}
+  body{font-family:var(--font-sans)}
+</style>
+<link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+<script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
+  <header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/en/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/en/">Home</a><a href="/TurboSito/en/about.html">About</a><a href="/TurboSito/en/services.html">Services</a><a href="/TurboSito/en/portfolio.html">Portfolio</a><a href="/TurboSito/en/contact.html">Contact</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Language"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Toggle theme" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button></div></div></header>
+
+  <main id="content" role="main">
+    <section class="relative overflow-hidden section-lg section-hero-tight">
+      <div aria-hidden="true" class="orb -top-40 -left-40"></div>
+      <div class="container grid gap-10 md:grid-cols-12 items-center">
+        <div class="md:col-span-6 space-y-6">
+          <div class="kicker badge inline-block"></div>
+          <h1 class="font-display text-4xl md:text-6xl font-extrabold tracking-tight"><span class="text-gradient">Website in 48 hours</span></h1>
+          <p class="mt-4 text-lg hero-subtitle text-[var(--fg)]">Fixed price. More inquiries – no calls.</p>
+          <div class="mt-10 flex flex-wrap gap-4 items-center">
+            <a class="btn btn-lg" href="/TurboSito/en/contact.html">Contact us</a>
+            <a class="btn btn-outline btn-lg" href="/TurboSito/en/portfolio.html">View portfolio</a>
+          </div>
+        </div>
+        <div class="md:col-span-6 mt-10 md:mt-0">
+          <div class="ratio card mockup">
+            <div class="mockup-chrome">
+              <span class="dot" aria-hidden="true"></span>
+              <span class="dot" aria-hidden="true"></span>
+              <span class="dot" aria-hidden="true"></span>
+            </div>
+            <div class="mockup-body text-muted text-sm"></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <div class="kicker mb-4">Trusted by</div>
+        <div class="grid grid-cols-2 md:grid-cols-5 gap-6 items-center opacity-80">
+          <div class="logo-pill"></div>
+          <div class="logo-pill"></div>
+          <div class="logo-pill"></div>
+          <div class="logo-pill"></div>
+          <div class="logo-pill"></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <h2 class="font-display text-3xl md:text-4xl font-bold mb-8 text-[var(--fg)]">Benefits</h2>
+        <div class="grid gap-6 md:grid-cols-3">
+          <article class="card hover-lift reveal">
+            <div class="badge inline-flex items-center gap-2 mb-3">
+              <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24"><path fill="currentColor" d="M5 12h14M5 6h14M5 18h14"/></svg>
+              <span>Fast online</span>
+            </div>
+            <p class="text-[var(--muted)]">Design, build &amp; launch within 48 hours.</p>
+          </article>
+          <article class="card hover-lift reveal">
+            <div class="badge inline-flex items-center gap-2 mb-3">
+              <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24"><path fill="currentColor" d="M12 2l3 7h7l-5.5 4 2.5 7-7-4.5L5.5 20 8 13 3 9h7z"/></svg>
+              <span>Fixed price</span>
+            </div>
+            <p class="text-[var(--muted)]">Transparent, no surprises.</p>
+          </article>
+          <article class="card hover-lift reveal">
+            <div class="badge inline-flex items-center gap-2 mb-3">
+              <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24"><path fill="currentColor" d="M4 12h16v2H4zM4 6h16v2H4zM4 18h16v2H4z"/></svg>
+              <span>Outcome-driven</span>
+            </div>
+            <p class="text-[var(--muted)]">Structure, copy &amp; CTAs that convert.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <h2 class="font-display text-3xl md:text-4xl font-bold mb-8 text-[var(--fg)]">Process</h2>
+        <ol class="space-y-6">
+          <li class="flex gap-4 items-start reveal">
+            <span class="badge inline-flex items-center justify-center w-8 h-8 rounded-full">1</span>
+            <div>
+              <h3 class="font-semibold text-[var(--fg)]">Kickoff</h3>
+              <p class="text-[var(--muted)]">10-minute form — goals, style &amp; examples.</p>
+            </div>
+          </li>
+          <li class="flex gap-4 items-start reveal">
+            <span class="badge inline-flex items-center justify-center w-8 h-8 rounded-full">2</span>
+            <div>
+              <h3 class="font-semibold text-[var(--fg)]">Design &amp; build</h3>
+              <p class="text-[var(--muted)]">Homepage and inner pages in your look &amp; feel.</p>
+            </div>
+          </li>
+          <li class="flex gap-4 items-start reveal">
+            <span class="badge inline-flex items-center justify-center w-8 h-8 rounded-full">3</span>
+            <div>
+              <h3 class="font-semibold text-[var(--fg)]">Review</h3>
+              <p class="text-[var(--muted)]">Polish together with quick iterations.</p>
+            </div>
+          </li>
+          <li class="flex gap-4 items-start reveal">
+            <span class="badge inline-flex items-center justify-center w-8 h-8 rounded-full">4</span>
+            <div>
+              <h3 class="font-semibold text-[var(--fg)]">Go-live</h3>
+              <p class="text-[var(--muted)]">Domain, tracking &amp; hand-over.</p>
+            </div>
+          </li>
+        </ol>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container card hover-lift flex flex-col md:flex-row items-center justify-between gap-4 reveal">
+        <div>
+          <h2 class="font-display text-2xl md:text-3xl font-bold text-[var(--fg)]">Ready to start?</h2>
+          <p class="text-muted">Send a few details — I’ll reply today.</p>
+        </div>
+        <div class="flex gap-3">
+          <a class="btn" href="/TurboSito/en/contact.html">Contact us</a>
+          <a class="btn btn-outline" href="/TurboSito/en/portfolio.html">View portfolio</a>
+        </div>
+      </div>
+    </section>
+  </main>
+  <footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Contact: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/en/legal.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Legal</a>
+    </p>
+  </div>
+</footer>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+</body>
+</html>

--- a/en/legal.html
+++ b/en/legal.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Legal Notice & Privacy – TurboSito</title>
+  <meta name="description" content="Legal notice and privacy information.">
+  <link rel="canonical" href="https://deine-domain.tld/en/legal.html">
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/impressum.html">
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/legal.html">
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/note-legali.html">
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
+  <meta property="og:title" content="Legal Notice & Privacy – TurboSito">
+  <meta property="og:description" content="Legal notice and privacy information.">
+  <meta property="og:url" content="https://deine-domain.tld/en/legal.html">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+<style>
+  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+  .font-display{font-family:"Outfit", var(--font-sans)}
+  body{font-family:var(--font-sans)}
+</style>
+<link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+<script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
+<header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/en/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/en/">Home</a><a href="/TurboSito/en/about.html">About</a><a href="/TurboSito/en/services.html">Services</a><a href="/TurboSito/en/portfolio.html">Portfolio</a><a href="/TurboSito/en/contact.html">Contact</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Language"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Toggle theme" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button></div></div></header>
+
+<main id="content" class="max-w-3xl mx-auto px-4 py-12 space-y-6">
+  <h1 class="text-3xl font-bold mb-6">Legal Notice & Privacy</h1>
+  <section>
+    <h2 class="text-2xl font-semibold mb-2">Imprint</h2>
+    <p>Placeholder for imprint details.</p>
+  </section>
+  <section>
+    <h2 class="text-2xl font-semibold mb-2">Privacy Policy</h2>
+    <p>Placeholder for privacy information.</p>
+  </section>
+  <p><a href="/TurboSito/en/contact.html" class="text-indigo-600 hover:underline">Back to contact page</a></p>
+</main>
+<footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Contact: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/en/legal.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Legal</a>
+    </p>
+  </div>
+</footer>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+</body>
+</html>

--- a/en/portfolio.html
+++ b/en/portfolio.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Portfolio – TurboSito</title>
+  <meta name="description" content="Selection of recent work and projects.">
+  <link rel="canonical" href="https://deine-domain.tld/en/portfolio.html">
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio.html">
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio.html">
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio.html">
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
+  <meta property="og:title" content="Portfolio – TurboSito">
+  <meta property="og:description" content="Selection of recent work and projects.">
+  <meta property="og:url" content="https://deine-domain.tld/en/portfolio.html">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+<style>
+  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+  .font-display{font-family:"Outfit", var(--font-sans)}
+  body{font-family:var(--font-sans)}
+</style>
+<link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+<script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
+<header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/en/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/en/">Home</a><a href="/TurboSito/en/about.html">About</a><a href="/TurboSito/en/services.html">Services</a><a href="/TurboSito/en/portfolio.html">Portfolio</a><a href="/TurboSito/en/contact.html">Contact</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Language"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Toggle theme" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button></div></div></header>
+
+<main id="content" class="max-w-6xl mx-auto px-4 py-20">
+  <section class="section-lg mb-12 text-center">
+    <h1 class="font-display text-3xl md:text-4xl font-bold mb-6">Portfolio</h1>
+    <p>A selection of recent work and projects.</p>
+  </section>
+  <section class="section grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+    <article class="card group hover-lift">
+      <picture>
+        <source srcset="/assets/portfolio/p1.webp" type="image/webp">
+        <img src="/TurboSito/assets/portfolio/p1.jpg" alt="Landing page for tech startup" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
+      </picture>
+      <h3 class="font-semibold text-lg">Landing page for tech startup</h3>
+      <ul class="mt-2 flex flex-wrap gap-2">
+        <li><span class="badge"><!-- [[TAG1_EN]] --><span data-key="TAG1_EN" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG2_EN]] --><span data-key="TAG2_EN" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG3_EN]] --><span data-key="TAG3_EN" class="ph"></span></span></li>
+      </ul>
+      <p class="text-[var(--muted)] text-sm mb-3">Boosted signups by 40%.</p>
+      <div class="mt-3 flex gap-3">
+        <a class="btn btn-outline" href="[[LIVE_URL_EN]]">Live</a>
+        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_EN]]">Code</a>
+      </div>
+      <a class="link inline-flex items-center gap-1" href="/TurboSito/en/cases/startup-landing.html">View details
+        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M13 5l7 7-7 7v-4H4v-6h9V5z"/></svg>
+      </a>
+    </article>
+    <article class="card group hover-lift">
+      <picture>
+        <source srcset="/assets/portfolio/p2.webp" type="image/webp">
+        <img src="/TurboSito/assets/portfolio/p2.jpg" alt="Corporate site for consulting firm" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
+      </picture>
+      <h3 class="font-semibold text-lg">Corporate site for consulting firm</h3>
+      <ul class="mt-2 flex flex-wrap gap-2">
+        <li><span class="badge"><!-- [[TAG1_EN]] --><span data-key="TAG1_EN" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG2_EN]] --><span data-key="TAG2_EN" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG3_EN]] --><span data-key="TAG3_EN" class="ph"></span></span></li>
+      </ul>
+      <p class="text-[var(--muted)] text-sm mb-3">Leads increased by 30%.</p>
+      <div class="mt-3 flex gap-3">
+        <a class="btn btn-outline" href="[[LIVE_URL_EN]]">Live</a>
+        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_EN]]">Code</a>
+      </div>
+      <a class="link inline-flex items-center gap-1" href="/TurboSito/en/cases/consulting-corp-site.html">View details
+        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M13 5l7 7-7 7v-4H4v-6h9V5z"/></svg>
+      </a>
+    </article>
+    <article class="card group hover-lift">
+      <picture>
+        <source srcset="/assets/portfolio/p3.webp" type="image/webp">
+        <img src="/TurboSito/assets/portfolio/p3.jpg" alt="Online store for fashion brand" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
+      </picture>
+      <h3 class="font-semibold text-lg">Online store for fashion brand</h3>
+      <ul class="mt-2 flex flex-wrap gap-2">
+        <li><span class="badge"><!-- [[TAG1_EN]] --><span data-key="TAG1_EN" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG2_EN]] --><span data-key="TAG2_EN" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG3_EN]] --><span data-key="TAG3_EN" class="ph"></span></span></li>
+      </ul>
+      <p class="text-[var(--muted)] text-sm mb-3">Revenue doubled in three months.</p>
+      <div class="mt-3 flex gap-3">
+        <a class="btn btn-outline" href="[[LIVE_URL_EN]]">Live</a>
+        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_EN]]">Code</a>
+      </div>
+      <a class="link inline-flex items-center gap-1" href="/TurboSito/en/cases/fashion-shop.html">View details
+        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M13 5l7 7-7 7v-4H4v-6h9V5z"/></svg>
+      </a>
+    </article>
+    <article class="card group hover-lift">
+      <picture>
+        <source srcset="/assets/portfolio/p4.webp" type="image/webp">
+        <img src="/TurboSito/assets/portfolio/p4.jpg" alt="Portfolio site for photographer" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
+      </picture>
+      <h3 class="font-semibold text-lg">Portfolio site for photographer</h3>
+      <ul class="mt-2 flex flex-wrap gap-2">
+        <li><span class="badge"><!-- [[TAG1_EN]] --><span data-key="TAG1_EN" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG2_EN]] --><span data-key="TAG2_EN" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG3_EN]] --><span data-key="TAG3_EN" class="ph"></span></span></li>
+      </ul>
+      <p class="text-[var(--muted)] text-sm mb-3">More bookings through strong online presence.</p>
+      <div class="mt-3 flex gap-3">
+        <a class="btn btn-outline" href="[[LIVE_URL_EN]]">Live</a>
+        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_EN]]">Code</a>
+      </div>
+      <a class="link inline-flex items-center gap-1" href="/TurboSito/en/cases/photographer-portfolio.html">View details
+        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M13 5l7 7-7 7v-4H4v-6h9V5z"/></svg>
+      </a>
+    </article>
+    <article class="card group hover-lift">
+      <picture>
+        <source srcset="/assets/portfolio/p5.webp" type="image/webp">
+        <img src="/TurboSito/assets/portfolio/p5.jpg" alt="Event microsite" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
+      </picture>
+      <h3 class="font-semibold text-lg">Event microsite</h3>
+      <ul class="mt-2 flex flex-wrap gap-2">
+        <li><span class="badge"><!-- [[TAG1_EN]] --><span data-key="TAG1_EN" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG2_EN]] --><span data-key="TAG2_EN" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG3_EN]] --><span data-key="TAG3_EN" class="ph"></span></span></li>
+      </ul>
+      <p class="text-[var(--muted)] text-sm mb-3">2k registrations in one week.</p>
+      <div class="mt-3 flex gap-3">
+        <a class="btn btn-outline" href="[[LIVE_URL_EN]]">Live</a>
+        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_EN]]">Code</a>
+      </div>
+      <a class="link inline-flex items-center gap-1" href="/TurboSito/en/cases/event-microsite.html">View details
+        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M13 5l7 7-7 7v-4H4v-6h9V5z"/></svg>
+      </a>
+    </article>
+    <article class="card group hover-lift">
+      <picture>
+        <source srcset="/assets/portfolio/p6.webp" type="image/webp">
+        <img src="/TurboSito/assets/portfolio/p6.jpg" alt="Multilingual hotel site" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
+      </picture>
+      <h3 class="font-semibold text-lg">Multilingual hotel site</h3>
+      <ul class="mt-2 flex flex-wrap gap-2">
+        <li><span class="badge"><!-- [[TAG1_EN]] --><span data-key="TAG1_EN" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG2_EN]] --><span data-key="TAG2_EN" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG3_EN]] --><span data-key="TAG3_EN" class="ph"></span></span></li>
+      </ul>
+      <p class="text-[var(--muted)] text-sm mb-3">International bookings up 25%.</p>
+      <div class="mt-3 flex gap-3">
+        <a class="btn btn-outline" href="[[LIVE_URL_EN]]">Live</a>
+        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_EN]]">Code</a>
+      </div>
+      <a class="link inline-flex items-center gap-1" href="/TurboSito/en/cases/hotel-multilingual.html">View details
+        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M13 5l7 7-7 7v-4H4v-6h9V5z"/></svg>
+      </a>
+    </article>
+  </section>
+</main>
+<footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Contact: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/en/legal.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Legal</a>
+    </p>
+  </div>
+</footer>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+</body>
+</html>

--- a/en/portfolio.html
+++ b/en/portfolio.html
@@ -36,25 +36,26 @@
     <p>A selection of recent work and projects.</p>
   </section>
   <section class="section grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-    <article class="card group hover-lift">
-      <picture>
-        <source srcset="/assets/portfolio/p1.webp" type="image/webp">
-        <img src="/TurboSito/assets/portfolio/p1.jpg" alt="Landing page for tech startup" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
-      </picture>
-      <h3 class="font-semibold text-lg">Landing page for tech startup</h3>
+    <article class="card group hover-lift case-card" data-slug="landingpage-tech-startup">
+      <a href="/TurboSito/en/cases/landingpage-tech-startup.html">
+        <picture>
+          <source srcset="/assets/portfolio/p1.webp" type="image/webp">
+          <img src="/TurboSito/assets/portfolio/p1.jpg" alt="Landing page for tech startup" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
+        </picture>
+      </a>
+      <h3 class="font-semibold text-lg"><a href="/TurboSito/en/cases/landingpage-tech-startup.html">Landing page for tech startup</a></h3>
       <ul class="mt-2 flex flex-wrap gap-2">
         <li><span class="badge"><!-- [[TAG1_EN]] --><span data-key="TAG1_EN" class="ph"></span></span></li>
         <li><span class="badge"><!-- [[TAG2_EN]] --><span data-key="TAG2_EN" class="ph"></span></span></li>
         <li><span class="badge"><!-- [[TAG3_EN]] --><span data-key="TAG3_EN" class="ph"></span></span></li>
       </ul>
       <p class="text-[var(--muted)] text-sm mb-3">Boosted signups by 40%.</p>
-      <div class="mt-3 flex gap-3">
+      <div class="mt-3 flex gap-3 relative z-10">
         <a class="btn btn-outline" href="[[LIVE_URL_EN]]">Live</a>
         <a class="link inline-flex items-center gap-1" href="[[CODE_URL_EN]]">Code</a>
       </div>
-      <a class="link inline-flex items-center gap-1" href="/TurboSito/en/cases/startup-landing.html">View details
-        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M13 5l7 7-7 7v-4H4v-6h9V5z"/></svg>
-      </a>
+      <a class="btn btn-outline case-cta" href="/TurboSito/en/cases/landingpage-tech-startup.html">Read case</a>
+      <a class="stretched-link" href="/TurboSito/en/cases/landingpage-tech-startup.html" aria-label="Read case: Landing page for tech startup"></a>
     </article>
     <article class="card group hover-lift">
       <picture>

--- a/en/services.html
+++ b/en/services.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Services – TurboSito</title>
+  <meta name="description" content="Web services that drive results. Rapid delivery focused on your goals.">
+  <link rel="canonical" href="https://deine-domain.tld/en/services.html">
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/leistungen.html">
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/services.html">
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/servizi.html">
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
+  <meta property="og:title" content="Services – TurboSito">
+  <meta property="og:description" content="Web services that drive results. Rapid delivery focused on your goals.">
+  <meta property="og:url" content="https://deine-domain.tld/en/services.html">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+<style>
+  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+  .font-display{font-family:"Outfit", var(--font-sans)}
+  body{font-family:var(--font-sans)}
+</style>
+<link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+<script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
+<header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/en/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/en/">Home</a><a href="/TurboSito/en/about.html">About</a><a href="/TurboSito/en/services.html">Services</a><a href="/TurboSito/en/portfolio.html">Portfolio</a><a href="/TurboSito/en/contact.html">Contact</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Language"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Toggle theme" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button></div></div></header>
+
+  <main id="content">
+    <section class="section-lg max-w-5xl mx-auto px-4 py-20 text-center">
+      <h1 class="font-display text-3xl md:text-4xl font-bold mb-6">Services</h1>
+      <p class="mb-6">Our services get your project online fast. Every package is built for measurable outcomes.</p>
+      <a href="/TurboSito/en/contact.html" class="btn" aria-label="Free consultation">Free consultation</a>
+    </section>
+    <section class="section max-w-6xl mx-auto px-4 py-12">
+      <h2 class="font-display text-3xl md:text-4xl font-bold mb-6">Services</h2>
+      <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <article class="card hover-lift">
+          <h3 class="font-semibold text-xl mb-2">Lightning-fast landing pages</h3>
+          <p class="text-[var(--muted)] mb-3">Start capturing leads within 48 hours.</p>
+          <ul class="space-y-1 text-sm text-[var(--muted)] list-disc pl-5">
+            <li>Custom design</li>
+            <li>Responsive layout</li>
+            <li>Basic SEO</li>
+            <li>Contact form</li>
+          </ul>
+          <p class="text-sm text-[var(--muted)] mt-3">from €1,200</p>
+          <div class="mt-4"><a class="btn btn-outline" href="/TurboSito/en/contact.html">Request</a></div>
+        </article>
+        <article class="card hover-lift">
+          <h3 class="font-semibold text-xl mb-2">Multilingual business sites</h3>
+          <p class="text-[var(--muted)] mb-3">Reach clients in multiple languages without extra effort.</p>
+          <ul class="space-y-1 text-sm text-[var(--muted)] list-disc pl-5">
+            <li>Structured pages</li>
+            <li>Language switcher</li>
+            <li>SEO setup</li>
+            <li>Performance optimization</li>
+            <li>Hosting setup</li>
+          </ul>
+          <p class="text-sm text-[var(--muted)] mt-3">from €2,500</p>
+          <div class="mt-4"><a class="btn btn-outline" href="/TurboSito/en/contact.html">Request</a></div>
+        </article>
+        <article class="card hover-lift">
+          <h3 class="font-semibold text-xl mb-2">Maintenance &amp; optimization</h3>
+          <p class="text-[var(--muted)] mb-3">Stay fast and secure after launch.</p>
+          <ul class="space-y-1 text-sm text-[var(--muted)] list-disc pl-5">
+            <li>Updates</li>
+            <li>Backups</li>
+            <li>Monitoring</li>
+            <li>Performance tuning</li>
+          </ul>
+          <p class="text-sm text-[var(--muted)] mt-3">from €150/mo</p>
+          <div class="mt-4"><a class="btn btn-outline" href="/TurboSito/en/contact.html">Request</a></div>
+        </article>
+      </div>
+    </section>
+  </main>
+  <footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Contact: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/en/legal.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Legal</a>
+    </p>
+  </div>
+</footer>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+</body>
+</html>

--- a/en/thanks.html
+++ b/en/thanks.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Thank you – TurboSito</title>
+  <meta name="description" content="Thank you for your message.">
+  <link rel="canonical" href="https://deine-domain.tld/en/thanks.html">
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/danke.html">
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/thanks.html">
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/grazie.html">
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/thanks.html">
+  <meta property="og:title" content="Thank you – TurboSito">
+  <meta property="og:description" content="Thank you for your message.">
+  <meta property="og:url" content="https://deine-domain.tld/en/thanks.html">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+<style>
+  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+  .font-display{font-family:"Outfit", var(--font-sans)}
+  body{font-family:var(--font-sans)}
+</style>
+<link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+<script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
+<header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/en/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/en/">Home</a><a href="/TurboSito/en/about.html">About</a><a href="/TurboSito/en/services.html">Services</a><a href="/TurboSito/en/portfolio.html">Portfolio</a><a href="/TurboSito/en/contact.html">Contact</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Language"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Toggle theme" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button></div></div></header>
+
+<main id="content" class="max-w-3xl mx-auto px-4 py-20 text-center">
+  <h1 class="text-4xl font-bold mb-4">Thank you!</h1>
+  <p class="mb-6">Your message has been sent.</p>
+  <a href="/TurboSito/en/" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Back to home</a>
+</main>
+<footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Contact: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/en/legal.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Legal</a>
+    </p>
+  </div>
+</footer>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Willkommen – TurboSito</title>
+  <meta name="description" content="Choose your language">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+  <style>
+    :root{--font-sans:"Inter",system-ui,-apple-system,Segoe UI,Roboto,Arial,"Noto Sans","Liberation Sans","Helvetica Neue",sans-serif}
+    .font-display{font-family:"Outfit",var(--font-sans)}
+    body{font-family:var(--font-sans)}
+  </style>
+  <link rel="alternate" hreflang="de" href="/TurboSito/de/">
+  <link rel="alternate" hreflang="en" href="/TurboSito/en/">
+  <link rel="alternate" hreflang="it" href="/TurboSito/it/">
+  <link rel="alternate" hreflang="x-default" href="/TurboSito/en/">
+  <link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+  <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <div class="container" style="display:flex;justify-content:flex-end;padding-top:1rem">
+  <nav class="lang-switch" aria-label="Language switch">
+    <a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a>
+    <a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a>
+    <a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a>
+  </nav>
+</div>
+  <main class="container section-lg text-center">
+    <h1 class="text-4xl font-bold mb-6">Choose your language</h1>
+    <nav class="flex flex-wrap justify-center gap-4">
+      <a class="btn" href="/TurboSito/de/" data-lang="de">DE</a>
+      <a class="btn btn-outline" href="/TurboSito/en/" data-lang="en">EN</a>
+      <a class="btn btn-outline" href="/TurboSito/it/" data-lang="it">IT</a>
+    </nav>
+  </main>
+    <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+    <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script>
+(() => {
+  const BASE='/' + 'TurboSito';
+  const KEY='site-lang';
+  const saved = localStorage.getItem(KEY);
+  const go = (code) => { location.replace(`${BASE}/${code}/`); };
+  document.querySelectorAll('a[data-lang]').forEach(a => {
+    a.addEventListener('click', () => localStorage.setItem(KEY, a.dataset.lang));
+  });
+  if (!saved) {
+    const pick = (nav) => {
+      const m = { de:'de', 'de-at':'de','de-de':'de','de-ch':'de',
+                  en:'en','en-us':'en','en-gb':'en',
+                  it:'it','it-it':'it' };
+      const n = (nav || 'en').toLowerCase();
+      return m[n] || m[n.split('-')[0]] || 'en';
+    };
+    const code = pick((navigator.languages && navigator.languages[0]) || navigator.language);
+    go(code);
+  }
+})();
+  </script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
+</body>
+</html>

--- a/it/_partials/footer.html
+++ b/it/_partials/footer.html
@@ -1,0 +1,10 @@
+<footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Contatto: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/it/note-legali.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Note legali</a>
+      <span class="mx-2">·</span>
+      <a href="/TurboSito/it/privacy.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Privacy</a>
+    </p>
+  </div>
+</footer>

--- a/it/_partials/header.html
+++ b/it/_partials/header.html
@@ -1,0 +1,26 @@
+<header id="site-header">
+  <div class="container flex items-center justify-between gap-4">
+    <nav class="site-nav">
+      <a class="brand" href="/TurboSito/it/">TurboSito</a>
+      <a href="/TurboSito/it/chi-sono.html">Chi sono</a>
+      <a href="/TurboSito/it/servizi.html">Servizi</a>
+      <a href="/TurboSito/it/portfolio.html">Portfolio</a>
+      <a href="/TurboSito/it/contatti.html">Contatti</a>
+    </nav>
+    <div class="header-right flex items-center gap-2">
+    <nav class="lang-switch" aria-label="Selettore lingua">
+      <a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a>
+      <a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a>
+      <a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a>
+    </nav>
+    <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü">
+      <span aria-hidden="true"></span>
+    </button>
+    <button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false">
+      <span class="icon sun" aria-hidden="true">☀️</span>
+      <span class="icon moon" aria-hidden="true">🌙</span>
+      <span>Theme</span>
+    </button>
+  </div>
+  </div>
+</header>

--- a/it/cases/landingpage-tech-startup.html
+++ b/it/cases/landingpage-tech-startup.html
@@ -1,80 +1,110 @@
-<!doctype html>
-<html lang="it">
+<!DOCTYPE html>
+<html lang="it" class="scroll-smooth">
 <head>
-  <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Landing page per startup tecnologica – Case study</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Landing page per startup tech – Caso studio</title>
   <meta name="description" content="+40% di iscrizioni dopo il lancio. Approccio, soluzione e risultati.">
-  <link rel="canonical" href="/TurboSito/it/cases/landingpage-tech-startup.html">
-  <link rel="alternate" hreflang="de" href="/TurboSito/de/cases/landingpage-tech-startup.html">
-  <link rel="alternate" hreflang="en" href="/TurboSito/en/cases/landingpage-tech-startup.html">
-  <link rel="alternate" hreflang="it" href="/TurboSito/it/cases/landingpage-tech-startup.html">
+  <link rel="canonical" href="https://deine-domain.tld/it/cases/landingpage-tech-startup.html">
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/cases/landingpage-tech-startup.html">
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/cases/landingpage-tech-startup.html">
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/cases/landingpage-tech-startup.html">
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+<style>
+  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+  .font-display{font-family:"Outfit", var(--font-sans)}
+  body{font-family:var(--font-sans)}
+</style>
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+  <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
 </head>
-<body>
-<header class="section" style="padding-block:24px"><div class="container" style="display:flex;justify-content:space-between;align-items:center;gap:16px">
-  <a class="badge brand" href="/TurboSito/it/">TurboSito</a>
-  <nav style="display:flex;gap:14px"><a href="/TurboSito/it/portfolio.html">Portfolio</a><a href="/TurboSito/it/chi-sono.html">Chi sono</a></nav>
-</div></header>
-
-<section class="section">
-  <div class="container">
-    <div class="badges" style="margin-bottom:12px">
-      <span class="badge brand">Case study</span><span class="badge">Landing page</span><span class="badge">Tailwind</span><span class="badge">A/B</span>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Salta al contenuto</a>
+<header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/it/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/it/">Home</a><a href="/TurboSito/it/chi-sono.html">Chi sono</a><a href="/TurboSito/it/servizi.html">Servizi</a><a href="/TurboSito/it/portfolio.html" aria-current="page" class="text-indigo-600 font-semibold">Portfolio</a><a href="/TurboSito/it/contatti.html">Contatti</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Lingua"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Cambia tema" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button></div></div></header>
+<main id="content">
+  <section class="section">
+    <div class="container">
+      <nav class="breadcrumbs"><a href="/TurboSito/it/portfolio.html">Portfolio</a> · <span>Caso studio</span></nav>
+      <div class="badges mb-3">
+        <span class="badge brand">Caso studio</span><span class="badge">Landing page</span><span class="badge">Tailwind</span><span class="badge">A/B</span>
+      </div>
+      <h1 class="mb-2">Landing page per startup tech</h1>
+      <p class="muted mb-4">Da zero al lancio in 48h – struttura chiara, performance rapida, crescita misurabile.</p>
+      <div class="gallery mt-3">
+        <img class="case-hero" src="/TurboSito/assets/img/cases/startup-hero.jpg" alt="Vista hero" width="1200" height="675" loading="lazy" decoding="async">
+      </div>
     </div>
-    <h1 style="margin:0 0 8px">Landing page per startup tecnologica</h1>
-    <p class="muted" style="margin:0 0 16px">Da zero al lancio in 48h – struttura chiara, performance rapide, crescita misurabile.</p>
-    <div class="gallery" style="margin-top:12px">
-      <img class="span-12" src="/TurboSito/assets/img/cases/startup-hero.jpg" alt="Vista hero">
+  </section>
+  <section class="section">
+    <div class="container grid gap-4 md:grid-cols-3">
+      <div class="card kpi"><big>+40%</big><span>Iscrizioni</span></div>
+      <div class="card kpi"><big>1.1s</big><span>LCP (mobile)</span></div>
+      <div class="card kpi"><big>48h</big><span>Time-to-launch</span></div>
     </div>
-  </div>
-</section>
-
-<section class="section">
-  <div class="container" style="display:grid; gap:16px; grid-template-columns: repeat(3, 1fr);">
-    <div class="kpi"><div class="num">+40%</div><div class="lbl">Iscrizioni</div></div>
-    <div class="kpi"><div class="num">1.1s</div><div class="lbl">LCP (mobile)</div></div>
-    <div class="kpi"><div class="num">48h</div><div class="lbl">Tempo al lancio</div></div>
-  </div>
-</section>
-
-<section class="section">
-  <div class="container grid-2">
-    <div class="card pad">
-      <h2 style="margin-top:0">Problema</h2>
-      <p>La landing page generava poche iscrizioni, caricamento lento, messaggio poco chiaro.</p>
-      <h3>Ipotesi</h3>
-      <ul><li>Value proposition più chiara</li><li>LCP più veloce</li><li>CTA più evidente</li></ul>
+  </section>
+  <section class="section">
+    <div class="container grid-2">
+      <div class="card pad">
+        <h2>Problema</h2>
+        <p>La landing generava poche iscrizioni, caricava lentamente, messaggio poco chiaro.</p>
+        <h3>Ipotesi</h3>
+        <ul><li>Value proposition più chiara</li><li>LCP più veloce</li><li>CTA più evidente</li></ul>
+      </div>
+      <div class="card pad">
+        <h2>Approccio &amp; soluzione</h2>
+        <ul>
+          <li>Wireframe → hero snello, social proof, benefit precisi</li>
+          <li>Static export + Tailwind, ottimizzazione immagini, lazy images</li>
+          <li>A/B test varianti CTA</li>
+        </ul>
+        <h3>Stack</h3>
+        <div class="badges"><span class="badge">Eleventy</span><span class="badge">Tailwind</span><span class="badge">Alpine</span><span class="badge">Plausible</span></div>
+      </div>
     </div>
-    <div class="card pad">
-      <h2 style="margin-top:0">Approccio &amp; soluzione</h2>
-      <ul>
-        <li>Wireframe → hero snello, social proof, benefit precisi</li>
-        <li>Tecnica: static export + Tailwind, ottimizzazione immagini, lazy images</li>
-        <li>A/B test varianti CTA</li>
-      </ul>
-      <h3>Stack</h3>
-      <div class="badges"><span class="badge">Eleventy</span><span class="badge">Tailwind</span><span class="badge">Alpine</span><span class="badge">Plausible</span></div>
+  </section>
+  <section class="section">
+    <div class="container gallery">
+      <img class="span-6" src="/TurboSito/assets/img/cases/startup-section.jpg" alt="Sezione" width="800" height="600" loading="lazy" decoding="async">
+      <img class="span-6" src="/TurboSito/assets/img/cases/startup-mobile.jpg" alt="Mobile" width="800" height="600" loading="lazy" decoding="async">
+      <img class="span-12" src="/TurboSito/assets/img/cases/startup-graph.jpg" alt="Grafico risultati" width="1200" height="675" loading="lazy" decoding="async">
     </div>
+  </section>
+  <section class="section">
+    <div class="container card pad flex justify-between items-center gap-3 flex-wrap">
+      <div><strong>Live:</strong> <a href="#" rel="noopener">Vai al progetto</a> · <strong>Code:</strong> <a href="#" rel="noopener">GitHub</a></div>
+      <a class="btn" href="/TurboSito/it/#quick-start">Avvia un progetto simile</a>
+    </div>
+  </section>
+  <section class="section">
+    <div class="container card pad flex justify-between items-center gap-4 flex-wrap">
+      <div>
+        <h3 class="m-0 mb-1">Pronto a iniziare?</h3>
+        <p class="muted m-0">Inviami le info principali — ti rispondo oggi.</p>
+      </div>
+      <div class="flex gap-3">
+        <a class="btn" href="/TurboSito/it/#quick-start">Avvia il progetto</a>
+        <a class="btn btn-outline" href="/TurboSito/it/portfolio.html">Altri progetti</a>
+      </div>
+    </div>
+  </section>
+</main>
+<footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Contatto: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/it/note-legali.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Note legali</a>
+      <span class="mx-2">·</span>
+      <a href="/TurboSito/it/privacy.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Privacy</a>
+    </p>
   </div>
-</section>
-
-<section class="section">
-  <div class="container gallery">
-    <img class="span-6" src="/TurboSito/assets/img/cases/startup-section.jpg" alt="Sezione">
-    <img class="span-6" src="/TurboSito/assets/img/cases/startup-mobile.jpg" alt="Mobile">
-    <img class="span-12" src="/TurboSito/assets/img/cases/startup-graph.jpg" alt="Grafico risultato">
-  </div>
-</section>
-
-<section class="section">
-  <div class="container card pad" style="display:flex;justify-content:space-between;align-items:center;gap:12px">
-    <div><strong>Live:</strong> <a href="#" rel="noopener">Progetto</a> · <strong>Code:</strong> <a href="#" rel="noopener">GitHub</a></div>
-    <a class="btn" href="/TurboSito/it/#quick-start">Avvia un progetto simile</a>
-  </div>
-</section>
-
-<footer class="section"><div class="container" style="display:flex;gap:12px">
-  <a href="/TurboSito/it/portfolio.html">Torna al portfolio</a>
-</div></footer>
+</footer>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
 </body>
 </html>

--- a/it/cases/landingpage-tech-startup.html
+++ b/it/cases/landingpage-tech-startup.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="it">
+<head>
+  <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Landing page per startup tecnologica – Case study</title>
+  <meta name="description" content="+40% di iscrizioni dopo il lancio. Approccio, soluzione e risultati.">
+  <link rel="canonical" href="/TurboSito/it/cases/landingpage-tech-startup.html">
+  <link rel="alternate" hreflang="de" href="/TurboSito/de/cases/landingpage-tech-startup.html">
+  <link rel="alternate" hreflang="en" href="/TurboSito/en/cases/landingpage-tech-startup.html">
+  <link rel="alternate" hreflang="it" href="/TurboSito/it/cases/landingpage-tech-startup.html">
+  <link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+</head>
+<body>
+<header class="section" style="padding-block:24px"><div class="container" style="display:flex;justify-content:space-between;align-items:center;gap:16px">
+  <a class="badge brand" href="/TurboSito/it/">TurboSito</a>
+  <nav style="display:flex;gap:14px"><a href="/TurboSito/it/portfolio.html">Portfolio</a><a href="/TurboSito/it/chi-sono.html">Chi sono</a></nav>
+</div></header>
+
+<section class="section">
+  <div class="container">
+    <div class="badges" style="margin-bottom:12px">
+      <span class="badge brand">Case study</span><span class="badge">Landing page</span><span class="badge">Tailwind</span><span class="badge">A/B</span>
+    </div>
+    <h1 style="margin:0 0 8px">Landing page per startup tecnologica</h1>
+    <p class="muted" style="margin:0 0 16px">Da zero al lancio in 48h – struttura chiara, performance rapide, crescita misurabile.</p>
+    <div class="gallery" style="margin-top:12px">
+      <img class="span-12" src="/TurboSito/assets/img/cases/startup-hero.jpg" alt="Vista hero">
+    </div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container" style="display:grid; gap:16px; grid-template-columns: repeat(3, 1fr);">
+    <div class="kpi"><div class="num">+40%</div><div class="lbl">Iscrizioni</div></div>
+    <div class="kpi"><div class="num">1.1s</div><div class="lbl">LCP (mobile)</div></div>
+    <div class="kpi"><div class="num">48h</div><div class="lbl">Tempo al lancio</div></div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container grid-2">
+    <div class="card pad">
+      <h2 style="margin-top:0">Problema</h2>
+      <p>La landing page generava poche iscrizioni, caricamento lento, messaggio poco chiaro.</p>
+      <h3>Ipotesi</h3>
+      <ul><li>Value proposition più chiara</li><li>LCP più veloce</li><li>CTA più evidente</li></ul>
+    </div>
+    <div class="card pad">
+      <h2 style="margin-top:0">Approccio &amp; soluzione</h2>
+      <ul>
+        <li>Wireframe → hero snello, social proof, benefit precisi</li>
+        <li>Tecnica: static export + Tailwind, ottimizzazione immagini, lazy images</li>
+        <li>A/B test varianti CTA</li>
+      </ul>
+      <h3>Stack</h3>
+      <div class="badges"><span class="badge">Eleventy</span><span class="badge">Tailwind</span><span class="badge">Alpine</span><span class="badge">Plausible</span></div>
+    </div>
+  </div>
+</section>
+
+<section class="section">
+  <div class="container gallery">
+    <img class="span-6" src="/TurboSito/assets/img/cases/startup-section.jpg" alt="Sezione">
+    <img class="span-6" src="/TurboSito/assets/img/cases/startup-mobile.jpg" alt="Mobile">
+    <img class="span-12" src="/TurboSito/assets/img/cases/startup-graph.jpg" alt="Grafico risultato">
+  </div>
+</section>
+
+<section class="section">
+  <div class="container card pad" style="display:flex;justify-content:space-between;align-items:center;gap:12px">
+    <div><strong>Live:</strong> <a href="#" rel="noopener">Progetto</a> · <strong>Code:</strong> <a href="#" rel="noopener">GitHub</a></div>
+    <a class="btn" href="/TurboSito/it/#quick-start">Avvia un progetto simile</a>
+  </div>
+</section>
+
+<footer class="section"><div class="container" style="display:flex;gap:12px">
+  <a href="/TurboSito/it/portfolio.html">Torna al portfolio</a>
+</div></footer>
+</body>
+</html>

--- a/it/chi-sono.html
+++ b/it/chi-sono.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="it" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Chi sono – TurboSito</title>
+  <meta name="description" content="Scopri di più su TurboSito e chi lo realizza.">
+  <link rel="canonical" href="https://deine-domain.tld/it/chi-sono.html">
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/ueber-mich.html">
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/about.html">
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/chi-sono.html">
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
+  <meta property="og:title" content="Chi sono – TurboSito">
+  <meta property="og:description" content="Scopri di più su TurboSito e chi lo realizza.">
+  <meta property="og:url" content="https://deine-domain.tld/it/chi-sono.html">
+  <meta property="og:locale" content="it_IT">
+  <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+<style>
+  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+  .font-display{font-family:"Outfit", var(--font-sans)}
+  body{font-family:var(--font-sans)}
+</style>
+<link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+<script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
+<header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/it/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/it/">Home</a><a href="/TurboSito/it/chi-sono.html">Chi sono</a><a href="/TurboSito/it/servizi.html">Servizi</a><a href="/TurboSito/it/portfolio.html">Portfolio</a><a href="/TurboSito/it/contatti.html">Contatti</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Lingue"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Cambia tema" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button></div></div></header>
+
+<main id="content" role="main">
+  <section class="section-lg max-w-screen-xl mx-auto px-4 py-20 text-center">
+    <h1 class="font-display text-3xl md:text-4xl font-bold mb-6">Chi sono</h1>
+    <p>Scopri di più su di me.</p>
+  </section>
+</main>
+<footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Contatto: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/it/note-legali.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Note legali</a>
+      <span class="mx-2">·</span>
+      <a href="/TurboSito/it/privacy.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Privacy</a>
+    </p>
+  </div>
+</footer>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+</body>
+</html>

--- a/it/chi-sono.html
+++ b/it/chi-sono.html
@@ -5,11 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Chi sono – TurboSito</title>
   <meta name="description" content="Scopri di più su TurboSito e chi lo realizza.">
-  <link rel="canonical" href="https://deine-domain.tld/it/chi-sono.html">
-  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/ueber-mich.html">
-  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/about.html">
-  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/chi-sono.html">
-  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
+  <link rel="canonical" href="/TurboSito/it/chi-sono.html">
+  <link rel="alternate" hreflang="de" href="/TurboSito/de/ueber-mich.html">
+  <link rel="alternate" hreflang="en" href="/TurboSito/en/about.html">
+  <link rel="alternate" hreflang="it" href="/TurboSito/it/chi-sono.html">
+  <link rel="alternate" hreflang="x-default" href="/TurboSito/en/">
   <meta property="og:title" content="Chi sono – TurboSito">
   <meta property="og:description" content="Scopri di più su TurboSito e chi lo realizza.">
   <meta property="og:url" content="https://deine-domain.tld/it/chi-sono.html">
@@ -31,9 +31,56 @@
 <header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/it/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/it/">Home</a><a href="/TurboSito/it/chi-sono.html">Chi sono</a><a href="/TurboSito/it/servizi.html">Servizi</a><a href="/TurboSito/it/portfolio.html">Portfolio</a><a href="/TurboSito/it/contatti.html">Contatti</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Lingue"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Cambia tema" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button></div></div></header>
 
 <main id="content" role="main">
-  <section class="section-lg max-w-screen-xl mx-auto px-4 py-20 text-center">
-    <h1 class="font-display text-3xl md:text-4xl font-bold mb-6">Chi sono</h1>
-    <p>Scopri di più su di me.</p>
+  <section class="section">
+    <div class="container grid-2 hero-about">
+      <div>
+        <h1>Chi sono</h1>
+        <p class="lead">Realizzo siti che convertono in <strong>48 ore</strong> – chiari, rapidi, misurabili.</p>
+        <div class="badges" style="margin-top:18px">
+          <span class="badge brand">Next.js</span><span class="badge">Tailwind</span>
+          <span class="badge">Eleventy</span><span class="badge">SEO</span>
+        </div>
+        <div style="display:flex; gap:12px; margin-top:20px">
+          <a class="btn" href="/TurboSito/it/#quick-start">Avvia il progetto</a>
+          <a class="btn btn-outline" href="/TurboSito/it/portfolio.html">Guarda il portfolio</a>
+        </div>
+      </div>
+      <div style="display:flex;justify-content:center">
+        <img class="avatar" src="/TurboSito/assets/img/me.jpg" alt="Ritratto">
+      </div>
+    </div>
+  </section>
+  <section class="section">
+    <div class="container card pad">
+      <h2>Competenze</h2>
+      <p class="muted">Stack & modo di lavoro</p>
+      <div class="badges" style="margin-top:8px">
+        <span class="badge">CRO</span><span class="badge">Performance</span>
+        <span class="badge">Accessibility</span><span class="badge">i18n</span>
+      </div>
+    </div>
+  </section>
+  <section class="section">
+    <div class="container">
+      <h2>Timeline</h2>
+      <div class="timeline">
+        <div class="timeline-item"><strong>2025 – oggi</strong><br>Freelance, servizio "Website in 48h"</div>
+        <div class="timeline-item"><strong>2022 – 2024</strong><br>Frontend Lead (Landing page & CRO)</div>
+        <div class="timeline-item"><strong>2019 – 2022</strong><br>Progetti full-stack (Next.js, Headless CMS)</div>
+      </div>
+    </div>
+  </section>
+  <section class="section">
+    <div class="container card pad" style="display:flex;justify-content:space-between;align-items:center;gap:16px;flex-wrap:wrap">
+      <div>
+        <h3 style="margin:0 0 4px">Pronto a iniziare?</h3>
+        <p class="muted" style="margin:0">Inviami le info principali – ti rispondo oggi.</p>
+      </div>
+      <div style="display:flex;gap:12px">
+        <a class="btn" href="/TurboSito/it/#quick-start">Avvia il progetto</a>
+        <a class="btn btn-outline" href="/TurboSito/it/portfolio.html">Portfolio</a>
+      </div>
+    </div>
   </section>
 </main>
 <footer class="border-t border-white/10">

--- a/it/contatti.html
+++ b/it/contatti.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="it" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Contatti – TurboSito</title>
+  <meta name="description" content="Rispondo entro 24–48 ore.">
+  <link rel="canonical" href="https://deine-domain.tld/it/contatti.html">
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/kontakt.html">
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/contact.html">
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/contatti.html">
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
+  <meta property="og:title" content="Contatti – TurboSito">
+  <meta property="og:description" content="Rispondo entro 24–48 ore.">
+  <meta property="og:url" content="https://deine-domain.tld/it/contatti.html">
+  <meta property="og:locale" content="it_IT">
+  <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+<style>
+  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+  .font-display{font-family:"Outfit", var(--font-sans)}
+  body{font-family:var(--font-sans)}
+</style>
+<link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+<script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
+<header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/it/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/it/">Home</a><a href="/TurboSito/it/chi-sono.html">Chi sono</a><a href="/TurboSito/it/servizi.html">Servizi</a><a href="/TurboSito/it/portfolio.html">Portfolio</a><a href="/TurboSito/it/contatti.html">Contatti</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Lingue"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Cambia tema" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button></div></div></header>
+
+<main id="content">
+  <section class="section-lg max-w-3xl mx-auto px-4 py-20">
+    <h1 class="font-display text-3xl md:text-4xl font-bold mb-6">Contatti</h1>
+    <p class="mb-8">Rispondo entro 24–48&nbsp;ore.</p>
+    <div class="card max-w-2xl">
+      <form id="contact-form" name="contact" method="post" data-netlify="true" netlify-honeypot="bot-field" class="space-y-4" action="/TurboSito/it/grazie.html">
+        <input type="hidden" name="form-name" value="contact">
+        <div class="hidden" aria-hidden="true"><label>Lascia vuoto<input name="bot-field"></label></div>
+        <div>
+          <label for="name" class="label">Nome</label>
+          <input id="name" name="name" required aria-invalid="false" class="input">
+        </div>
+        <div>
+          <label for="email" class="label">Email</label>
+          <input id="email" name="email" type="email" required aria-invalid="false" class="input">
+        </div>
+        <div>
+          <label for="message" class="label">Messaggio</label>
+          <textarea id="message" name="message" required aria-invalid="false" class="input h-32"></textarea>
+        </div>
+        <div class="flex items-start gap-2">
+          <input id="consent" name="consent" type="checkbox" required class="mt-1 rounded border-white/15">
+          <label for="consent" class="label text-[var(--muted)]">Acconsento al trattamento dei miei dati secondo la <a href="/TurboSito/it/privacy.html" class="underline">privacy</a>.</label>
+        </div>
+        <button type="submit" class="btn mt-3" aria-label="Invia messaggio">Invia messaggio</button>
+      </form>
+    </div>
+  </section>
+</main>
+<footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Contatto: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/it/note-legali.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Note legali</a>
+      <span class="mx-2">·</span>
+      <a href="/TurboSito/it/privacy.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Privacy</a>
+    </p>
+  </div>
+</footer>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+</body>
+</html>

--- a/it/grazie.html
+++ b/it/grazie.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="it" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Grazie – TurboSito</title>
+  <meta name="description" content="Grazie per il tuo messaggio.">
+  <link rel="canonical" href="https://deine-domain.tld/it/grazie.html">
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/danke.html">
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/thanks.html">
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/grazie.html">
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/thanks.html">
+  <meta property="og:title" content="Grazie – TurboSito">
+  <meta property="og:description" content="Grazie per il tuo messaggio.">
+  <meta property="og:url" content="https://deine-domain.tld/it/grazie.html">
+  <meta property="og:locale" content="it_IT">
+  <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+<style>
+  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+  .font-display{font-family:"Outfit", var(--font-sans)}
+  body{font-family:var(--font-sans)}
+</style>
+<link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+<script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
+<header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/it/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/it/">Home</a><a href="/TurboSito/it/chi-sono.html">Chi sono</a><a href="/TurboSito/it/servizi.html">Servizi</a><a href="/TurboSito/it/portfolio.html">Portfolio</a><a href="/TurboSito/it/contatti.html">Contatti</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Lingue"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Cambia tema" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button></div></div></header>
+
+<main id="content" class="max-w-3xl mx-auto px-4 py-20 text-center">
+  <h1 class="text-4xl font-bold mb-4">Grazie!</h1>
+  <p class="mb-6">Il tuo messaggio è stato inviato.</p>
+  <a href="/TurboSito/it/" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Torna alla home</a>
+</main>
+<footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Contatto: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/it/note-legali.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Note legali</a>
+      <span class="mx-2">·</span>
+      <a href="/TurboSito/it/privacy.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Privacy</a>
+    </p>
+  </div>
+</footer>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+</body>
+</html>

--- a/it/index.html
+++ b/it/index.html
@@ -68,10 +68,18 @@
           <div class="kicker badge inline-block"></div>
           <h1 class="font-display text-4xl md:text-6xl font-extrabold tracking-tight"><span class="text-gradient">Sito web in 48 ore</span></h1>
           <p class="mt-4 text-lg hero-subtitle text-[var(--fg)]">Prezzo fisso. Più richieste – senza telefonate.</p>
-          <div class="mt-10 flex flex-wrap gap-4 items-center">
-            <a class="btn btn-lg" href="/TurboSito/it/contatti.html">Contattaci</a>
-            <a class="btn btn-outline btn-lg" href="/TurboSito/it/portfolio.html">Guarda il portfolio</a>
+          <div class="cta-hero">
+            <a class="btn btn-contact" data-cta="contact" href="#quick-start">Contattaci</a>
+            <a class="btn btn-primary" data-cta="primary" href="#quick-start" data-open-form>Avvia progetto</a>
+            <a class="btn btn-outline" data-cta="portfolio" href="/TurboSito/it/portfolio.html">Guarda il portfolio</a>
           </div>
+          <form id="micro-start" class="micro-start" novalidate>
+            <label class="sr-only" for="micro-email">Email</label>
+            <input id="micro-email" name="email" type="email"
+                   placeholder="Inserisci email" inputmode="email"
+                   autocomplete="email" required>
+            <button class="btn" type="submit">Vai</button>
+          </form>
         </div>
         <div class="md:col-span-6 mt-10 md:mt-0">
           <div class="ratio card mockup">
@@ -194,5 +202,6 @@
   <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
   <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
   <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+  <script src="/TurboSito/assets/js/sticky-cta.js" defer></script>
 </body>
 </html>

--- a/it/index.html
+++ b/it/index.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html lang="it" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>TurboSito – Sito web in 48 ore</title>
+  <meta name="description" content="Sito web in 48 ore. Prezzo fisso. Più richieste – senza telefonate.">
+  <link rel="canonical" href="https://deine-domain.tld/it/">
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/">
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/">
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/">
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
+  <meta property="og:title" content="TurboSito – Sito web in 48 ore">
+  <meta property="og:description" content="Sito web in 48 ore. Prezzo fisso. Più richieste – senza telefonate.">
+  <meta property="og:url" content="https://deine-domain.tld/it/">
+  <meta property="og:locale" content="it_IT">
+  <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "name": "Max Mustermann",
+  "url": "https://deine-domain.tld",
+  "sameAs": [
+    "https://github.com/example",
+    "https://www.linkedin.com/in/example"
+  ],
+  "worksFor": {
+    "@type": "Organization",
+    "name": "TurboSito"
+  }
+}
+</script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": "TurboSito",
+  "url": "https://deine-domain.tld",
+  "inLanguage": "it",
+  "potentialAction": {
+    "@type": "SearchAction",
+    "target": "https://deine-domain.tld/it/?s={search_term_string}",
+    "query-input": "required name=search_term_string"
+  }
+}
+</script>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+<style>
+  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+  .font-display{font-family:"Outfit", var(--font-sans)}
+  body{font-family:var(--font-sans)}
+</style>
+<link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+<script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
+  <header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/it/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/it/">Home</a><a href="/TurboSito/it/chi-sono.html">Chi sono</a><a href="/TurboSito/it/servizi.html">Servizi</a><a href="/TurboSito/it/portfolio.html">Portfolio</a><a href="/TurboSito/it/contatti.html">Contatti</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Lingue"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Cambia tema" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button></div></div></header>
+
+  <main id="content" role="main">
+    <section class="relative overflow-hidden section-lg section-hero-tight">
+      <div aria-hidden="true" class="orb -top-40 -left-40"></div>
+      <div class="container grid gap-10 md:grid-cols-12 items-center">
+        <div class="md:col-span-6 space-y-6">
+          <div class="kicker badge inline-block"></div>
+          <h1 class="font-display text-4xl md:text-6xl font-extrabold tracking-tight"><span class="text-gradient">Sito web in 48 ore</span></h1>
+          <p class="mt-4 text-lg hero-subtitle text-[var(--fg)]">Prezzo fisso. Più richieste – senza telefonate.</p>
+          <div class="mt-10 flex flex-wrap gap-4 items-center">
+            <a class="btn btn-lg" href="/TurboSito/it/contatti.html">Contattaci</a>
+            <a class="btn btn-outline btn-lg" href="/TurboSito/it/portfolio.html">Guarda il portfolio</a>
+          </div>
+        </div>
+        <div class="md:col-span-6 mt-10 md:mt-0">
+          <div class="ratio card mockup">
+            <div class="mockup-chrome">
+              <span class="dot" aria-hidden="true"></span>
+              <span class="dot" aria-hidden="true"></span>
+              <span class="dot" aria-hidden="true"></span>
+            </div>
+            <div class="mockup-body text-muted text-sm"></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <div class="kicker mb-4">Scelto da</div>
+        <div class="grid grid-cols-2 md:grid-cols-5 gap-6 items-center opacity-80">
+          <div class="logo-pill"></div>
+          <div class="logo-pill"></div>
+          <div class="logo-pill"></div>
+          <div class="logo-pill"></div>
+          <div class="logo-pill"></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <h2 class="font-display text-3xl md:text-4xl font-bold mb-8 text-[var(--fg)]">Vantaggi</h2>
+        <div class="grid gap-6 md:grid-cols-3">
+          <article class="card hover-lift reveal">
+            <div class="badge inline-flex items-center gap-2 mb-3">
+              <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24"><path fill="currentColor" d="M5 12h14M5 6h14M5 18h14"/></svg>
+              <span>Online in fretta</span>
+            </div>
+            <p class="text-[var(--muted)]">Design, sviluppo e lancio in 48 ore.</p>
+          </article>
+          <article class="card hover-lift reveal">
+            <div class="badge inline-flex items-center gap-2 mb-3">
+              <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24"><path fill="currentColor" d="M12 2l3 7h7l-5.5 4 2.5 7-7-4.5L5.5 20 8 13 3 9h7z"/></svg>
+              <span>Prezzo fisso</span>
+            </div>
+            <p class="text-[var(--muted)]">Trasparente, senza sorprese.</p>
+          </article>
+          <article class="card hover-lift reveal">
+            <div class="badge inline-flex items-center gap-2 mb-3">
+              <svg aria-hidden="true" width="20" height="20" viewBox="0 0 24 24"><path fill="currentColor" d="M4 12h16v2H4zM4 6h16v2H4zM4 18h16v2H4z"/></svg>
+              <span>Orientato ai risultati</span>
+            </div>
+            <p class="text-[var(--muted)]">Struttura, testi e CTA che convertono.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <h2 class="font-display text-3xl md:text-4xl font-bold mb-8 text-[var(--fg)]">Procedura</h2>
+        <ol class="space-y-6">
+          <li class="flex gap-4 items-start reveal">
+            <span class="badge inline-flex items-center justify-center w-8 h-8 rounded-full">1</span>
+            <div>
+              <h3 class="font-semibold text-[var(--fg)]">Kickoff</h3>
+              <p class="text-[var(--muted)]">Modulo di 10 minuti — obiettivi, stile, esempi.</p>
+            </div>
+          </li>
+          <li class="flex gap-4 items-start reveal">
+            <span class="badge inline-flex items-center justify-center w-8 h-8 rounded-full">2</span>
+            <div>
+              <h3 class="font-semibold text-[var(--fg)]">Design &amp; sviluppo</h3>
+              <p class="text-[var(--muted)]">Homepage e pagine interne nel tuo stile.</p>
+            </div>
+          </li>
+          <li class="flex gap-4 items-start reveal">
+            <span class="badge inline-flex items-center justify-center w-8 h-8 rounded-full">3</span>
+            <div>
+              <h3 class="font-semibold text-[var(--fg)]">Revisione</h3>
+              <p class="text-[var(--muted)]">Finiture insieme, iterazioni rapide.</p>
+            </div>
+          </li>
+          <li class="flex gap-4 items-start reveal">
+            <span class="badge inline-flex items-center justify-center w-8 h-8 rounded-full">4</span>
+            <div>
+              <h3 class="font-semibold text-[var(--fg)]">Go-live</h3>
+              <p class="text-[var(--muted)]">Dominio, tracking e hand-over.</p>
+            </div>
+          </li>
+        </ol>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container card hover-lift flex flex-col md:flex-row items-center justify-between gap-4 reveal">
+        <div>
+          <h2 class="font-display text-2xl md:text-3xl font-bold text-[var(--fg)]">Pronto a iniziare?</h2>
+          <p class="text-muted">Inviami le info principali — ti rispondo oggi.</p>
+        </div>
+        <div class="flex gap-3">
+          <a class="btn" href="/TurboSito/it/contatti.html">Contattaci</a>
+          <a class="btn btn-outline" href="/TurboSito/it/portfolio.html">Guarda il portfolio</a>
+        </div>
+      </div>
+    </section>
+  </main>
+  <footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Contatto: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/it/note-legali.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Note legali</a>
+      <span class="mx-2">·</span>
+      <a href="/TurboSito/it/privacy.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Privacy</a>
+    </p>
+  </div>
+</footer>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+</body>
+</html>

--- a/it/note-legali.html
+++ b/it/note-legali.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="it" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Note legali – TurboSito</title>
+  <meta name="description" content="Informazioni legali del fornitore.">
+  <link rel="canonical" href="https://deine-domain.tld/it/note-legali.html">
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/impressum.html">
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/legal.html">
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/note-legali.html">
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
+  <meta property="og:title" content="Note legali – TurboSito">
+  <meta property="og:description" content="Informazioni legali del fornitore.">
+  <meta property="og:url" content="https://deine-domain.tld/it/note-legali.html">
+  <meta property="og:locale" content="it_IT">
+  <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+<style>
+  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+  .font-display{font-family:"Outfit", var(--font-sans)}
+  body{font-family:var(--font-sans)}
+</style>
+<link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+<script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
+<a href="#main" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:bg-white focus:text-indigo-600 focus:px-3 focus:py-2 focus:rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500">Salta al contenuto</a>
+<header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/it/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/it/">Home</a><a href="/TurboSito/it/chi-sono.html">Chi sono</a><a href="/TurboSito/it/servizi.html">Servizi</a><a href="/TurboSito/it/portfolio.html">Portfolio</a><a href="/TurboSito/it/contatti.html">Contatti</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Lingue"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Cambia tema" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button></div></div></header>
+
+<main id="content" class="max-w-3xl mx-auto px-4 py-12">
+  <h1 class="text-3xl font-bold mb-6">Note legali</h1>
+  <p class="mb-4"><strong>Nome:</strong> <!-- [[IMPR_NAME]] --><span data-key="IMPR_NAME" class="ph"></span></p>
+  <p class="mb-4"><strong>Indirizzo:</strong> <!-- [[IMPR_ADRESSE]] --><span data-key="IMPR_ADRESSE" class="ph"></span></p>
+  <p class="mb-4"><strong>E-mail:</strong> <a href="mailto:[[IMPR_EMAIL]]" class="underline"><!-- [[IMPR_EMAIL]] --><span data-key="IMPR_EMAIL" class="ph"></span></a></p>
+  <p class="mb-8"><strong>Partita IVA:</strong> <!-- [[IMPR_STEUERNR]] --><span data-key="IMPR_STEUERNR" class="ph"></span></p>
+  <p><a href="/TurboSito/it/contatti.html" class="text-indigo-600 hover:underline">Torna alla pagina contatti</a></p>
+</main>
+<footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Contatto: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/it/note-legali.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Note legali</a>
+      <span class="mx-2">·</span>
+      <a href="/TurboSito/it/privacy.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Privacy</a>
+    </p>
+  </div>
+</footer>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+</body>
+</html>

--- a/it/portfolio.html
+++ b/it/portfolio.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="it" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Portfolio – TurboSito</title>
+  <meta name="description" content="Selezione di lavori e progetti recenti.">
+  <link rel="canonical" href="https://deine-domain.tld/it/portfolio.html">
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio.html">
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio.html">
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio.html">
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
+  <meta property="og:title" content="Portfolio – TurboSito">
+  <meta property="og:description" content="Selezione di lavori e progetti recenti.">
+  <meta property="og:url" content="https://deine-domain.tld/it/portfolio.html">
+  <meta property="og:locale" content="it_IT">
+  <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+<style>
+  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+  .font-display{font-family:"Outfit", var(--font-sans)}
+  body{font-family:var(--font-sans)}
+</style>
+<link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+<script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
+<header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/it/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/it/">Home</a><a href="/TurboSito/it/chi-sono.html">Chi sono</a><a href="/TurboSito/it/servizi.html">Servizi</a><a href="/TurboSito/it/portfolio.html">Portfolio</a><a href="/TurboSito/it/contatti.html">Contatti</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Lingue"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Cambia tema" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button></div></div></header>
+
+<main id="content" class="max-w-6xl mx-auto px-4 py-20">
+  <section class="section-lg mb-12 text-center">
+    <h1 class="font-display text-3xl md:text-4xl font-bold mb-6">Portfolio</h1>
+    <p>Selezione di lavori e progetti recenti.</p>
+  </section>
+  <section class="section grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+    <article class="card group hover-lift">
+      <picture>
+        <source srcset="/assets/portfolio/p1.webp" type="image/webp">
+        <img src="/TurboSito/assets/portfolio/p1.jpg" alt="Landing page per startup tecnologica" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
+      </picture>
+      <h3 class="font-semibold text-lg">Landing page per startup tecnologica</h3>
+      <ul class="mt-2 flex flex-wrap gap-2">
+        <li><span class="badge"><!-- [[TAG1_IT]] --><span data-key="TAG1_IT" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG2_IT]] --><span data-key="TAG2_IT" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG3_IT]] --><span data-key="TAG3_IT" class="ph"></span></span></li>
+      </ul>
+      <p class="text-[var(--muted)] text-sm mb-3">Iscrizioni aumentate del 40%.</p>
+      <div class="mt-3 flex gap-3">
+        <a class="btn btn-outline" href="[[LIVE_URL_IT]]">Live</a>
+        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_IT]]">Code</a>
+      </div>
+      <a class="link inline-flex items-center gap-1" href="/TurboSito/it/casi/startup-landing.html">Vedi dettagli
+        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M13 5l7 7-7 7v-4H4v-6h9V5z"/></svg>
+      </a>
+    </article>
+    <article class="card group hover-lift">
+      <picture>
+        <source srcset="/assets/portfolio/p2.webp" type="image/webp">
+        <img src="/TurboSito/assets/portfolio/p2.jpg" alt="Sito corporate per società di consulenza" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
+      </picture>
+      <h3 class="font-semibold text-lg">Sito corporate per società di consulenza</h3>
+      <ul class="mt-2 flex flex-wrap gap-2">
+        <li><span class="badge"><!-- [[TAG1_IT]] --><span data-key="TAG1_IT" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG2_IT]] --><span data-key="TAG2_IT" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG3_IT]] --><span data-key="TAG3_IT" class="ph"></span></span></li>
+      </ul>
+      <p class="text-[var(--muted)] text-sm mb-3">Lead aumentati del 30%.</p>
+      <div class="mt-3 flex gap-3">
+        <a class="btn btn-outline" href="[[LIVE_URL_IT]]">Live</a>
+        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_IT]]">Code</a>
+      </div>
+      <a class="link inline-flex items-center gap-1" href="/TurboSito/it/casi/consulting-corp-site.html">Vedi dettagli
+        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M13 5l7 7-7 7v-4H4v-6h9V5z"/></svg>
+      </a>
+    </article>
+    <article class="card group hover-lift">
+      <picture>
+        <source srcset="/assets/portfolio/p3.webp" type="image/webp">
+        <img src="/TurboSito/assets/portfolio/p3.jpg" alt="E-commerce per brand di moda" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
+      </picture>
+      <h3 class="font-semibold text-lg">E-commerce per brand di moda</h3>
+      <ul class="mt-2 flex flex-wrap gap-2">
+        <li><span class="badge"><!-- [[TAG1_IT]] --><span data-key="TAG1_IT" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG2_IT]] --><span data-key="TAG2_IT" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG3_IT]] --><span data-key="TAG3_IT" class="ph"></span></span></li>
+      </ul>
+      <p class="text-[var(--muted)] text-sm mb-3">Fatturato raddoppiato in tre mesi.</p>
+      <div class="mt-3 flex gap-3">
+        <a class="btn btn-outline" href="[[LIVE_URL_IT]]">Live</a>
+        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_IT]]">Code</a>
+      </div>
+      <a class="link inline-flex items-center gap-1" href="/TurboSito/it/casi/fashion-shop.html">Vedi dettagli
+        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M13 5l7 7-7 7v-4H4v-6h9V5z"/></svg>
+      </a>
+    </article>
+    <article class="card group hover-lift">
+      <picture>
+        <source srcset="/assets/portfolio/p4.webp" type="image/webp">
+        <img src="/TurboSito/assets/portfolio/p4.jpg" alt="Sito portfolio per fotografa" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
+      </picture>
+      <h3 class="font-semibold text-lg">Sito portfolio per fotografa</h3>
+      <ul class="mt-2 flex flex-wrap gap-2">
+        <li><span class="badge"><!-- [[TAG1_IT]] --><span data-key="TAG1_IT" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG2_IT]] --><span data-key="TAG2_IT" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG3_IT]] --><span data-key="TAG3_IT" class="ph"></span></span></li>
+      </ul>
+      <p class="text-[var(--muted)] text-sm mb-3">Più prenotazioni grazie alla presenza online.</p>
+      <div class="mt-3 flex gap-3">
+        <a class="btn btn-outline" href="[[LIVE_URL_IT]]">Live</a>
+        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_IT]]">Code</a>
+      </div>
+      <a class="link inline-flex items-center gap-1" href="/TurboSito/it/casi/photographer-portfolio.html">Vedi dettagli
+        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M13 5l7 7-7 7v-4H4v-6h9V5z"/></svg>
+      </a>
+    </article>
+    <article class="card group hover-lift">
+      <picture>
+        <source srcset="/assets/portfolio/p5.webp" type="image/webp">
+        <img src="/TurboSito/assets/portfolio/p5.jpg" alt="Microsito per evento" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
+      </picture>
+      <h3 class="font-semibold text-lg">Microsito per evento</h3>
+      <ul class="mt-2 flex flex-wrap gap-2">
+        <li><span class="badge"><!-- [[TAG1_IT]] --><span data-key="TAG1_IT" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG2_IT]] --><span data-key="TAG2_IT" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG3_IT]] --><span data-key="TAG3_IT" class="ph"></span></span></li>
+      </ul>
+      <p class="text-[var(--muted)] text-sm mb-3">2.000 registrazioni in una settimana.</p>
+      <div class="mt-3 flex gap-3">
+        <a class="btn btn-outline" href="[[LIVE_URL_IT]]">Live</a>
+        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_IT]]">Code</a>
+      </div>
+      <a class="link inline-flex items-center gap-1" href="/TurboSito/it/casi/event-microsite.html">Vedi dettagli
+        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M13 5l7 7-7 7v-4H4v-6h9V5z"/></svg>
+      </a>
+    </article>
+    <article class="card group hover-lift">
+      <picture>
+        <source srcset="/assets/portfolio/p6.webp" type="image/webp">
+        <img src="/TurboSito/assets/portfolio/p6.jpg" alt="Sito multilingue per hotel" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
+      </picture>
+      <h3 class="font-semibold text-lg">Sito multilingue per hotel</h3>
+      <ul class="mt-2 flex flex-wrap gap-2">
+        <li><span class="badge"><!-- [[TAG1_IT]] --><span data-key="TAG1_IT" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG2_IT]] --><span data-key="TAG2_IT" class="ph"></span></span></li>
+        <li><span class="badge"><!-- [[TAG3_IT]] --><span data-key="TAG3_IT" class="ph"></span></span></li>
+      </ul>
+      <p class="text-[var(--muted)] text-sm mb-3">Prenotazioni internazionali +25%.</p>
+      <div class="mt-3 flex gap-3">
+        <a class="btn btn-outline" href="[[LIVE_URL_IT]]">Live</a>
+        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_IT]]">Code</a>
+      </div>
+      <a class="link inline-flex items-center gap-1" href="/TurboSito/it/casi/hotel-multilingual.html">Vedi dettagli
+        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M13 5l7 7-7 7v-4H4v-6h9V5z"/></svg>
+      </a>
+    </article>
+  </section>
+</main>
+<footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Contatto: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/it/note-legali.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Note legali</a>
+      <span class="mx-2">·</span>
+      <a href="/TurboSito/it/privacy.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Privacy</a>
+    </p>
+  </div>
+</footer>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+</body>
+</html>

--- a/it/portfolio.html
+++ b/it/portfolio.html
@@ -36,25 +36,26 @@
     <p>Selezione di lavori e progetti recenti.</p>
   </section>
   <section class="section grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-    <article class="card group hover-lift">
-      <picture>
-        <source srcset="/assets/portfolio/p1.webp" type="image/webp">
-        <img src="/TurboSito/assets/portfolio/p1.jpg" alt="Landing page per startup tecnologica" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
-      </picture>
-      <h3 class="font-semibold text-lg">Landing page per startup tecnologica</h3>
+    <article class="card group hover-lift case-card" data-slug="landingpage-tech-startup">
+      <a href="/TurboSito/it/cases/landingpage-tech-startup.html">
+        <picture>
+          <source srcset="/assets/portfolio/p1.webp" type="image/webp">
+          <img src="/TurboSito/assets/portfolio/p1.jpg" alt="Landing page per startup tecnologica" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
+        </picture>
+      </a>
+      <h3 class="font-semibold text-lg"><a href="/TurboSito/it/cases/landingpage-tech-startup.html">Landing page per startup tecnologica</a></h3>
       <ul class="mt-2 flex flex-wrap gap-2">
         <li><span class="badge"><!-- [[TAG1_IT]] --><span data-key="TAG1_IT" class="ph"></span></span></li>
         <li><span class="badge"><!-- [[TAG2_IT]] --><span data-key="TAG2_IT" class="ph"></span></span></li>
         <li><span class="badge"><!-- [[TAG3_IT]] --><span data-key="TAG3_IT" class="ph"></span></span></li>
       </ul>
       <p class="text-[var(--muted)] text-sm mb-3">Iscrizioni aumentate del 40%.</p>
-      <div class="mt-3 flex gap-3">
+      <div class="mt-3 flex gap-3 relative z-10">
         <a class="btn btn-outline" href="[[LIVE_URL_IT]]">Live</a>
         <a class="link inline-flex items-center gap-1" href="[[CODE_URL_IT]]">Code</a>
       </div>
-      <a class="link inline-flex items-center gap-1" href="/TurboSito/it/casi/startup-landing.html">Vedi dettagli
-        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M13 5l7 7-7 7v-4H4v-6h9V5z"/></svg>
-      </a>
+      <a class="btn btn-outline case-cta" href="/TurboSito/it/cases/landingpage-tech-startup.html">Caso studio</a>
+      <a class="stretched-link" href="/TurboSito/it/cases/landingpage-tech-startup.html" aria-label="Caso studio: Landing page per startup tecnologica"></a>
     </article>
     <article class="card group hover-lift">
       <picture>

--- a/it/privacy.html
+++ b/it/privacy.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="it" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Informativa privacy – TurboSito</title>
+  <meta name="description" content="Informativa sulla protezione dei dati.">
+  <link rel="canonical" href="https://deine-domain.tld/it/privacy.html">
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/datenschutz.html">
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/legal.html">
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/privacy.html">
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
+  <meta property="og:title" content="Informativa privacy – TurboSito">
+  <meta property="og:description" content="Informativa sulla protezione dei dati.">
+  <meta property="og:url" content="https://deine-domain.tld/it/privacy.html">
+  <meta property="og:locale" content="it_IT">
+  <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+<style>
+  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+  .font-display{font-family:"Outfit", var(--font-sans)}
+  body{font-family:var(--font-sans)}
+</style>
+<link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+<script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
+<a href="#main" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:bg-white focus:text-indigo-600 focus:px-3 focus:py-2 focus:rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500">Salta al contenuto</a>
+<header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/it/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/it/">Home</a><a href="/TurboSito/it/chi-sono.html">Chi sono</a><a href="/TurboSito/it/servizi.html">Servizi</a><a href="/TurboSito/it/portfolio.html">Portfolio</a><a href="/TurboSito/it/contatti.html">Contatti</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Lingue"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Cambia tema" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button></div></div></header>
+
+<main id="content" class="max-w-3xl mx-auto px-4 py-12 space-y-6">
+  <h1 class="text-3xl font-bold mb-6">Informativa privacy</h1>
+  <section>
+    <h2 class="text-2xl font-semibold mb-2">Titolare del trattamento</h2>
+    <p>Testo segnaposto sul titolare.</p>
+  </section>
+  <section>
+    <h2 class="text-2xl font-semibold mb-2">Tipi di dati</h2>
+    <p>Testo segnaposto sui tipi di dati trattati.</p>
+  </section>
+  <section>
+    <h2 class="text-2xl font-semibold mb-2">Finalità</h2>
+    <p>Testo segnaposto sulle finalità della raccolta.</p>
+  </section>
+  <section>
+    <h2 class="text-2xl font-semibold mb-2">Basi giuridiche</h2>
+    <p>Testo segnaposto sulle basi giuridiche.</p>
+  </section>
+  <section>
+    <h2 class="text-2xl font-semibold mb-2">Contatto</h2>
+    <p>Testo segnaposto per i contatti.</p>
+  </section>
+  <p><a href="/TurboSito/it/contatti.html" class="text-indigo-600 hover:underline">Torna alla pagina contatti</a></p>
+</main>
+<footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Contatto: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/it/note-legali.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Note legali</a>
+      <span class="mx-2">·</span>
+      <a href="/TurboSito/it/privacy.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Privacy</a>
+    </p>
+  </div>
+</footer>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+</body>
+</html>

--- a/it/servizi.html
+++ b/it/servizi.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="it" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Servizi – TurboSito</title>
+  <meta name="description" content="Servizi web orientati ai risultati. Consegna rapida e mirata.">
+  <link rel="canonical" href="https://deine-domain.tld/it/servizi.html">
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/leistungen.html">
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/services.html">
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/servizi.html">
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
+  <meta property="og:title" content="Servizi – TurboSito">
+  <meta property="og:description" content="Servizi web orientati ai risultati. Consegna rapida e mirata.">
+  <meta property="og:url" content="https://deine-domain.tld/it/servizi.html">
+  <meta property="og:locale" content="it_IT">
+  <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+<style>
+  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+  .font-display{font-family:"Outfit", var(--font-sans)}
+  body{font-family:var(--font-sans)}
+</style>
+<link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+<script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
+<header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/it/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/it/">Home</a><a href="/TurboSito/it/chi-sono.html">Chi sono</a><a href="/TurboSito/it/servizi.html">Servizi</a><a href="/TurboSito/it/portfolio.html">Portfolio</a><a href="/TurboSito/it/contatti.html">Contatti</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Lingue"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Cambia tema" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button></div></div></header>
+
+  <main id="content">
+    <section class="section-lg max-w-5xl mx-auto px-4 py-20 text-center">
+      <h1 class="font-display text-3xl md:text-4xl font-bold mb-6">Servizi</h1>
+      <p class="mb-6">Con i nostri servizi metti online il tuo progetto rapidamente. Ogni pacchetto è orientato a risultati misurabili.</p>
+      <a href="/TurboSito/it/contatti.html" class="btn" aria-label="Consulenza gratuita">Consulenza gratuita</a>
+    </section>
+    <section class="section max-w-6xl mx-auto px-4 py-12">
+      <h2 class="font-display text-3xl md:text-4xl font-bold mb-6">Servizi</h2>
+      <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <article class="card hover-lift">
+          <h3 class="font-semibold text-xl mb-2">Landing page lampo</h3>
+          <p class="text-[var(--muted)] mb-3">Ottieni contatti in 48 ore.</p>
+          <ul class="space-y-1 text-sm text-[var(--muted)] list-disc pl-5">
+            <li>Design personalizzato</li>
+            <li>Layout responsive</li>
+            <li>SEO di base</li>
+            <li>Modulo di contatto</li>
+          </ul>
+          <p class="text-sm text-[var(--muted)] mt-3">da € 1.200</p>
+          <div class="mt-4"><a class="btn btn-outline" href="/TurboSito/it/contatti.html">Richiedi</a></div>
+        </article>
+        <article class="card hover-lift">
+          <h3 class="font-semibold text-xl mb-2">Siti aziendali multilingue</h3>
+          <p class="text-[var(--muted)] mb-3">Raggiungi clienti in più lingue senza sforzo.</p>
+          <ul class="space-y-1 text-sm text-[var(--muted)] list-disc pl-5">
+            <li>Pagine strutturate</li>
+            <li>Selettore lingua</li>
+            <li>Configurazione SEO</li>
+            <li>Ottimizzazione performance</li>
+            <li>Setup hosting</li>
+          </ul>
+          <p class="text-sm text-[var(--muted)] mt-3">da € 2.500</p>
+          <div class="mt-4"><a class="btn btn-outline" href="/TurboSito/it/contatti.html">Richiedi</a></div>
+        </article>
+        <article class="card hover-lift">
+          <h3 class="font-semibold text-xl mb-2">Manutenzione e ottimizzazione</h3>
+          <p class="text-[var(--muted)] mb-3">Rimani veloce e sicuro online.</p>
+          <ul class="space-y-1 text-sm text-[var(--muted)] list-disc pl-5">
+            <li>Aggiornamenti</li>
+            <li>Backup</li>
+            <li>Monitoraggio</li>
+            <li>Ottimizzazione performance</li>
+          </ul>
+          <p class="text-sm text-[var(--muted)] mt-3">da € 150/mese</p>
+          <div class="mt-4"><a class="btn btn-outline" href="/TurboSito/it/contatti.html">Richiedi</a></div>
+        </article>
+      </div>
+    </section>
+  </main>
+  <footer class="border-t border-white/10">
+  <div class="container section text-center text-sm">
+    <p>Contatto: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
+    <p class="mt-2">
+      <a href="/TurboSito/it/note-legali.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Note legali</a>
+      <span class="mx-2">·</span>
+      <a href="/TurboSito/it/privacy.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Privacy</a>
+    </p>
+  </div>
+</footer>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+</body>
+</html>

--- a/landing/index.html
+++ b/landing/index.html
@@ -430,13 +430,22 @@
     }]
   }
   </script>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+<style>
+  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+  .font-display{font-family:"Outfit", var(--font-sans)}
+  body{font-family:var(--font-sans)}
+</style>
+<link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
 </head>
 
 <body class="font-sans text-gray-800 bg-white">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
     <!-- Header -->
     <header class="sticky top-0 z-50 h-14 bg-white/70 backdrop-blur border-b border-gray-200 transition-shadow">
         <div class="max-w-screen-xl mx-auto h-full flex items-center justify-between px-4">
-            <a href="/" class="flex items-center gap-3">
+            <a href="/TurboSito/" class="flex items-center gap-3">
                 <img src="../assets/logo/turbosito-logo-ts-bars.svg" alt="TurboSito" class="h-7 w-auto">
             </a>
             <div class="hidden sm:flex items-center gap-2 text-sm font-semibold">
@@ -451,7 +460,7 @@
         </div>
     </header>
 
-    <main>
+    <main id="content">
         <!-- HERO -->
         <section id="hero" class="relative min-h-[78svh] sm:min-h-[calc(100vh-3.5rem)] overflow-hidden isolate">
             <!-- Aurora Background -->
@@ -1211,6 +1220,11 @@
 
     </script>
 
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
 </body>
 
 </html>

--- a/legal/impressum.html
+++ b/legal/impressum.html
@@ -5,8 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Impressum</title>
     <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+<style>
+  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+  .font-display{font-family:"Outfit", var(--font-sans)}
+  body{font-family:var(--font-sans)}
+</style>
+<link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
 </head>
 <body class="font-sans text-gray-800 bg-white">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
     <div class="max-w-screen-md mx-auto p-6">
         <h1 class="text-3xl font-bold mb-4">Impressum / Note legali</h1>
         <h2 class="text-xl font-semibold mt-4 mb-2">Angaben gemäß § 5 TMG</h2>
@@ -25,5 +34,10 @@
         <p>Umsatzsteuer-ID: IT1234567890</p>
         <p class="text-sm text-gray-500 mt-6">Dies ist eine Muster-Impressumseite ohne rechtliche Gültigkeit. Bitte ersetzen Sie die Angaben durch Ihre eigenen.</p>
     </div>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
 </body>
 </html>

--- a/legal/privacy.html
+++ b/legal/privacy.html
@@ -5,13 +5,27 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Datenschutz / Privacy</title>
     <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+<style>
+  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+  .font-display{font-family:"Outfit", var(--font-sans)}
+  body{font-family:var(--font-sans)}
+</style>
+<link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
 </head>
 <body class="font-sans text-gray-800 bg-white">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
     <div class="max-w-screen-md mx-auto p-6">
         <h1 class="text-3xl font-bold mb-4">Datenschutzerklärung / Informativa sulla privacy</h1>
         <p>Der Schutz Ihrer persönlichen Daten ist uns wichtig. Diese Webseite dient als Demo und enthält keine realen Datenerfassungsprozesse. Bitte fügen Sie hier Ihre eigene Datenschutzerklärung gemäß DSGVO ein.</p>
         <p class="mt-4">La protezione dei tuoi dati personali è importante per noi. Questo sito web è una demo e non raccoglie dati reali. Si prega di inserire qui la propria informativa sulla privacy conforme al GDPR.</p>
         <p class="text-sm text-gray-500 mt-6">Hinweis: Dies ist nur ein Beispieltext. Für eine rechtskonforme Datenschutzerklärung konsultieren Sie bitte eine Rechtsberatung.</p>
     </div>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "turbosito",
+  "private": true,
+  "scripts": {
+    "build": "node scripts/build.js"
+  },
+  "devDependencies": {
+    "fast-glob": "^3.3.2",
+    "fs-extra": "^11.2.0",
+    "posthtml": "^0.16.6",
+    "posthtml-include": "^2.0.1"
+  }
+}

--- a/robots.txt
+++ b/robots.txt
@@ -1,5 +1,3 @@
 User-agent: *
 Allow: /
-
-# Point crawlers to the sitemap
-Sitemap: {{URL}}/sitemap.xml
+Sitemap: https://deine-domain.tld/sitemap.xml

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,0 +1,35 @@
+const fse = require('fs-extra');
+const fg = require('fast-glob');
+const path = require('path');
+const posthtml = require('posthtml');
+const include = require('posthtml-include');
+
+const SRC = '.';
+const OUT = 'dist';
+(async () => {
+  // Clean dist
+  await fse.remove(OUT);
+  await fse.ensureDir(OUT);
+
+  // 1) Assets & sonstige Dateien kopieren (alles außer .html, node_modules, dist, .git)
+  const assets = await fg(['**/*', '!**/*.html', '!node_modules/**', '!dist/**', '!.git/**']);
+  await Promise.all(assets.map(async (p) => {
+    const dest = path.join(OUT, p);
+    await fse.ensureDir(path.dirname(dest));
+    await fse.copy(p, dest);
+  }));
+
+  // 2) HTML-Dateien rendern (Partials zusammenführen)
+  const htmlFiles = await fg(['**/*.html', '!node_modules/**', '!dist/**', '!.git/**']);
+  for (const file of htmlFiles) {
+    const src = await fse.readFile(file, 'utf8');
+    const { html } = await posthtml([ include({ root: '.' }) ]).process(src, { from: file });
+    const dest = path.join(OUT, file);
+    await fse.ensureDir(path.dirname(dest));
+    await fse.writeFile(dest, html, 'utf8');
+  }
+
+  // 3) .nojekyll ins dist (Pages ignoriert _-Ordner sonst)
+  await fse.writeFile(path.join(OUT, '.nojekyll'), '');
+  console.log('Build complete → dist/');
+})();

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,31 +1,162 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <!-- Main landing page -->
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml">
   <url>
-    <loc>{{URL}}/landing/</loc>
-  </url>
-  <!-- Demo pages -->
-  <url>
-    <loc>{{URL}}/demos/restaurant/</loc>
-  </url>
-  <url>
-    <loc>{{URL}}/demos/barber/</loc>
+    <loc>https://deine-domain.tld/de/</loc>
+    <xhtml:link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/"/>
   </url>
   <url>
-    <loc>{{URL}}/demos/apartment/</loc>
-  </url>
-  <!-- Legal pages -->
-  <url>
-    <loc>{{URL}}/legal/impressum.html</loc>
-  </url>
-  <url>
-    <loc>{{URL}}/legal/privacy.html</loc>
-  </url>
-  <!-- Payment feedback pages -->
-  <url>
-    <loc>{{URL}}/thanks.html</loc>
+    <loc>https://deine-domain.tld/en/</loc>
+    <xhtml:link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/"/>
   </url>
   <url>
-    <loc>{{URL}}/cancel.html</loc>
+    <loc>https://deine-domain.tld/it/</loc>
+    <xhtml:link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/"/>
+  </url>
+  <url>
+    <loc>https://deine-domain.tld/de/ueber-mich.html</loc>
+    <xhtml:link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/ueber-mich.html"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/about.html"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/chi-sono.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/about.html"/>
+  </url>
+  <url>
+    <loc>https://deine-domain.tld/en/about.html</loc>
+    <xhtml:link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/ueber-mich.html"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/about.html"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/chi-sono.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/about.html"/>
+  </url>
+  <url>
+    <loc>https://deine-domain.tld/it/chi-sono.html</loc>
+    <xhtml:link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/ueber-mich.html"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/about.html"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/chi-sono.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/about.html"/>
+  </url>
+  <url>
+    <loc>https://deine-domain.tld/de/leistungen.html</loc>
+    <xhtml:link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/leistungen.html"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/services.html"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/servizi.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/services.html"/>
+  </url>
+  <url>
+    <loc>https://deine-domain.tld/en/services.html</loc>
+    <xhtml:link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/leistungen.html"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/services.html"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/servizi.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/services.html"/>
+  </url>
+  <url>
+    <loc>https://deine-domain.tld/it/servizi.html</loc>
+    <xhtml:link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/leistungen.html"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/services.html"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/servizi.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/services.html"/>
+  </url>
+  <url>
+    <loc>https://deine-domain.tld/de/portfolio.html</loc>
+    <xhtml:link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio.html"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio.html"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/portfolio.html"/>
+  </url>
+  <url>
+    <loc>https://deine-domain.tld/en/portfolio.html</loc>
+    <xhtml:link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio.html"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio.html"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/portfolio.html"/>
+  </url>
+  <url>
+    <loc>https://deine-domain.tld/it/portfolio.html</loc>
+    <xhtml:link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio.html"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio.html"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/portfolio.html"/>
+  </url>
+  <url>
+    <loc>https://deine-domain.tld/de/kontakt.html</loc>
+    <xhtml:link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/kontakt.html"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/contact.html"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/contatti.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/contact.html"/>
+  </url>
+  <url>
+    <loc>https://deine-domain.tld/en/contact.html</loc>
+    <xhtml:link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/kontakt.html"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/contact.html"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/contatti.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/contact.html"/>
+  </url>
+  <url>
+    <loc>https://deine-domain.tld/it/contatti.html</loc>
+    <xhtml:link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/kontakt.html"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/contact.html"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/contatti.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/contact.html"/>
+  </url>
+  <url>
+    <loc>https://deine-domain.tld/de/danke.html</loc>
+    <xhtml:link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/danke.html"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/thanks.html"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/grazie.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/thanks.html"/>
+  </url>
+  <url>
+    <loc>https://deine-domain.tld/en/thanks.html</loc>
+    <xhtml:link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/danke.html"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/thanks.html"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/grazie.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/thanks.html"/>
+  </url>
+  <url>
+    <loc>https://deine-domain.tld/it/grazie.html</loc>
+    <xhtml:link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/danke.html"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/thanks.html"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/grazie.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/thanks.html"/>
+  </url>
+  <url>
+    <loc>https://deine-domain.tld/de/impressum.html</loc>
+    <xhtml:link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/impressum.html"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/legal.html"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/note-legali.html"/>
+  </url>
+  <url>
+    <loc>https://deine-domain.tld/de/datenschutz.html</loc>
+    <xhtml:link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/datenschutz.html"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/legal.html"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/privacy.html"/>
+  </url>
+  <url>
+    <loc>https://deine-domain.tld/en/legal.html</loc>
+    <xhtml:link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/impressum.html"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/datenschutz.html"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/note-legali.html"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/privacy.html"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/legal.html"/>
+  </url>
+  <url>
+    <loc>https://deine-domain.tld/it/note-legali.html</loc>
+    <xhtml:link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/impressum.html"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/legal.html"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/note-legali.html"/>
+  </url>
+  <url>
+    <loc>https://deine-domain.tld/it/privacy.html</loc>
+    <xhtml:link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/datenschutz.html"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/legal.html"/>
+    <xhtml:link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/privacy.html"/>
   </url>
 </urlset>

--- a/thanks.html
+++ b/thanks.html
@@ -5,16 +5,25 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Danke / Grazie</title>
     <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
+<style>
+  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
+  .font-display{font-family:"Outfit", var(--font-sans)}
+  body{font-family:var(--font-sans)}
+</style>
+<link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
 </head>
 <body class="font-sans text-gray-800 bg-white dark:bg-[#111827] transition-colors">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
     <div class="min-h-screen flex items-center justify-center p-6">
         <div class="max-w-md text-center">
             <h1 class="text-3xl font-bold mb-4" data-lang="de">Vielen Dank!</h1>
             <h1 class="text-3xl font-bold mb-4" data-lang="it">Grazie!</h1>
             <p class="mb-4" data-lang="de">Ihre Anzahlung war erfolgreich. Wir starten sofort mit dem Design und melden uns mit den nächsten Schritten per E‑Mail.</p>
             <p class="mb-4" data-lang="it">Il tuo acconto è stato ricevuto. Iniziamo subito la progettazione e ti contatteremo via e‑mail per i prossimi passi.</p>
-            <a href="/landing/" class="mt-4 inline-block px-6 py-3 bg-orange-500 text-white font-semibold rounded hover:bg-orange-600" data-lang="de">Zurück zur Startseite</a>
-            <a href="/landing/" class="mt-4 inline-block px-6 py-3 bg-orange-500 text-white font-semibold rounded hover:bg-orange-600" data-lang="it">Torna alla home</a>
+            <a href="/TurboSito/landing/" class="mt-4 inline-block px-6 py-3 bg-orange-500 text-white font-semibold rounded hover:bg-orange-600" data-lang="de">Zurück zur Startseite</a>
+            <a href="/TurboSito/landing/" class="mt-4 inline-block px-6 py-3 bg-orange-500 text-white font-semibold rounded hover:bg-orange-600" data-lang="it">Torna alla home</a>
         </div>
     </div>
     <script>
@@ -26,5 +35,10 @@
             });
         });
     </script>
+  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
+  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
+  <script src="/TurboSito/assets/js/reveal.js" defer></script>
+  <script src="/TurboSito/assets/js/faq.js" defer></script>
+  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- collapse hero quick-start form on small screens and add a `Projekt starten` trigger
- style toggle controls and expose script to auto-open the form when anchored
- add mobile micro-start email form that expands the quick-start form

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b59f77cea08332890bfece7e83fb5d