### PR TITLE
Add SaaS landing demo case page and mockups

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -593,3 +593,31 @@ body.is-scrolled header{
 .demo-page main{scroll-margin-top:80px}
 .section .container{max-width:980px;margin:0 auto}
 .muted{color:var(--muted)}
+/* --- Case Study Styles --- */
+.cs-hero{max-width:900px;margin:0 auto 2.5rem;padding-top:1rem}
+.cs-eyebrow{font-size:.9rem;letter-spacing:.08em;text-transform:uppercase;opacity:.7}
+.cs-sub{font-size:1.2rem;opacity:.9;margin:.5rem 0}
+.cs-note{font-size:.95rem;opacity:.7}
+
+.cs-kpis{display:grid;gap:1rem;grid-template-columns:repeat(3,minmax(0,1fr));margin:2rem auto;max-width:1000px}
+.kpi{background:var(--panel);border:1px solid var(--panel-border);border-radius:14px;padding:1.1rem}
+.kpi-num{font-size:1.6rem;font-weight:800}
+.kpi-label{opacity:.8}
+
+.cs-pae{display:grid;gap:1rem;grid-template-columns:repeat(3,minmax(0,1fr));max-width:1000px;margin:2rem auto}
+.cs-pae article{background:var(--panel);border:1px solid var(--panel-border);border-radius:14px;padding:1rem 1.2rem}
+
+.cs-gallery{display:grid;gap:1rem;grid-template-columns:repeat(3,minmax(0,1fr));max-width:1100px;margin:2rem auto}
+.cs-gallery figure{background:var(--panel);border:1px solid var(--panel-border);border-radius:14px;padding:.75rem}
+.cs-gallery img{width:100%;height:auto;border-radius:10px}
+.cs-gallery figcaption{font-size:.9rem;opacity:.8;margin-top:.4rem}
+
+.cs-process,.cs-stack,.cs-cta{max-width:900px;margin:2.5rem auto}
+.cs-process ol{display:grid;gap:.6rem;padding-left:1.25rem}
+.tags{display:flex;flex-wrap:wrap;gap:.5rem;padding:0;margin:.75rem 0}
+.tags li{background:var(--chip-bg);border:1px solid var(--panel-border);border-radius:999px;padding:.35rem .7rem;font-size:.9rem}
+.cs-cta .btn-row{display:flex;gap:.75rem;flex-wrap:wrap;margin-top:.75rem}
+
+@media (max-width:980px){
+  .cs-kpis,.cs-pae,.cs-gallery{grid-template-columns:1fr}
+}

--- a/assets/demo/saas/hero-desktop.svg
+++ b/assets/demo/saas/hero-desktop.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#141824"/>
+      <stop offset="1" stop-color="#1c2232"/>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#g)"/>
+  <rect x="120" y="120" rx="16" ry="16" width="1360" height="660" fill="#0f1320" stroke="#28324a" stroke-width="2"/>
+  <rect x="200" y="220" rx="10" ry="10" width="560" height="36" fill="#1f2840"/>
+  <rect x="200" y="268" rx="10" ry="10" width="720" height="22" fill="#1a2236" opacity=".8"/>
+  <rect x="200" y="320" rx="12" ry="12" width="220" height="52" fill="#2563eb"/>
+  <rect x="430" y="320" rx="12" ry="12" width="220" height="52" fill="none" stroke="#3b82f6"/>
+  <rect x="1040" y="260" rx="12" ry="12" width="380" height="24" fill="#0f1320" stroke="#28324a"/>
+  <text x="140" y="820" font-family="Inter, system-ui, Segoe UI, Roboto, Helvetica Neue, Arial" font-size="28" fill="#9fb0d8">
+    Mockup – Hero & Above-the-fold (Demo)
+  </text>
+</svg>

--- a/assets/demo/saas/mobile.svg
+++ b/assets/demo/saas/mobile.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="900" viewBox="0 0 900 900">
+  <rect width="900" height="900" fill="#0f1320"/>
+  <rect x="250" y="120" rx="28" ry="28" width="400" height="660" fill="#10182b" stroke="#27314a" stroke-width="2"/>
+  <rect x="280" y="170" rx="8" ry="8" width="340" height="24" fill="#1f2840"/>
+  <rect x="280" y="210" rx="8" ry="8" width="300" height="16" fill="#1a2236" opacity=".8"/>
+  <rect x="280" y="250" rx="12" ry="12" width="220" height="40" fill="#2563eb"/>
+  <rect x="280" y="310" rx="10" ry="10" width="320" height="220" fill="#0f1320" stroke="#27314a"/>
+  <rect x="280" y="540" rx="10" ry="10" width="320" height="160" fill="#0f1320" stroke="#27314a"/>
+  <text x="180" y="820" font-family="Inter, system-ui" font-size="26" fill="#9fb0d8">Mockup – Mobile-Ansicht (Demo)</text>
+</svg>

--- a/assets/demo/saas/sections.svg
+++ b/assets/demo/saas/sections.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900">
+  <rect width="1600" height="900" fill="#101523"/>
+  <rect x="120" y="120" rx="16" ry="16" width="1360" height="220" fill="#0f1320" stroke="#27314a"/>
+  <rect x="160" y="160" rx="10" ry="10" width="280" height="36" fill="#1f2840"/>
+  <rect x="160" y="210" rx="10" ry="10" width="1000" height="18" fill="#1a2236" opacity=".8"/>
+  <rect x="120" y="370" rx="16" ry="16" width="420" height="360" fill="#0f1320" stroke="#27314a"/>
+  <rect x="590" y="370" rx="16" ry="16" width="420" height="360" fill="#0f1320" stroke="#27314a"/>
+  <rect x="1060" y="370" rx="16" ry="16" width="420" height="360" fill="#0f1320" stroke="#27314a"/>
+  <text x="140" y="820" font-family="Inter, system-ui" font-size="28" fill="#9fb0d8">Mockup – Nutzen, Social-Proof, Ablauf (Demo)</text>
+</svg>

--- a/de/cases/saas-landing-demo.html
+++ b/de/cases/saas-landing-demo.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <title>Landingpage für Tech-Startup (Demo) – TurboSito</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="Demo-Case: schlanke Struktur, schnelle Performance, klare CTAs. Vorschau auf Stil & Vorgehen.">
+  <meta property="og:title" content="Landingpage für Tech-Startup (Demo)">
+  <meta property="og:description" content="Demo-Case – kein Kundenprojekt. Zeigt Struktur, Performance & Prozess.">
+  <link rel="canonical" href="/TurboSito/de/cases/saas-landing-demo.html">
+  <link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
+</head>
+<body class="cs">
+  <header class="site-header">
+    <nav class="container">
+      <a href="/TurboSito/de/portfolio.html" class="back-link">← Portfolio</a>
+    </nav>
+  </header>
+
+  <main class="container">
+    <section class="cs-hero">
+      <p class="cs-eyebrow">Case Study · Demo</p>
+      <h1>Landingpage für Tech-Startup</h1>
+      <p class="cs-sub">Von 0 auf Launch in 48h – klare Struktur, schnelle Performance, messbare Conversion-Signale.</p>
+      <p class="cs-note">Hinweis: Demo-Case für Stil & Vorgehen – kein Kundenprojekt.</p>
+    </section>
+
+    <section class="cs-kpis">
+      <article class="kpi"><div class="kpi-num">48h</div><div class="kpi-label">Time-to-Launch</div></article>
+      <article class="kpi"><div class="kpi-num">≤ 1.1s</div><div class="kpi-label">LCP (mobil, Demo-Messung)</div></article>
+      <article class="kpi"><div class="kpi-num">+ klare CTAs</div><div class="kpi-label">Struktur & Conversion-Signale</div></article>
+    </section>
+
+    <section class="cs-gallery">
+      <figure>
+        <img src="/TurboSito/assets/demo/saas/hero-desktop.svg" alt="Hero und Above-the-fold (Mockup)">
+        <figcaption>Above-the-fold: klare Botschaft + primärer CTA</figcaption>
+      </figure>
+      <figure>
+        <img src="/TurboSito/assets/demo/saas/sections.svg" alt="Nutzen & Social-Proof (Mockup)">
+        <figcaption>Nutzenblöcke, Social-Proof, kurzer Ablauf</figcaption>
+      </figure>
+      <figure>
+        <img src="/TurboSito/assets/demo/saas/mobile.svg" alt="Mobile (Mockup)">
+        <figcaption>Mobile-First: schnelles Rendering & klare Buttons</figcaption>
+      </figure>
+    </section>
+
+    <section class="cs-pae">
+      <article>
+        <h3>Ausgangslage</h3>
+        <p>Unklare Botschaft, wenig Vertrauenselemente, langsame Startseite.</p>
+      </article>
+      <article>
+        <h3>Ansatz</h3>
+        <ul>
+          <li>Hero fokussiert: Value Proposition + 1 Primär-CTA</li>
+          <li>Social-Proof & Nutzenblöcke</li>
+          <li>Statischer Export, Bild-Optimierung, lazy Assets</li>
+        </ul>
+      </article>
+      <article>
+        <h3>Ergebnis (Demo)</h3>
+        <ul>
+          <li>Schnelle Ladezeit (≤ 1.1s LCP mobil)</li>
+          <li>Scanbare Struktur, klare CTAs</li>
+          <li>Saubere Basis für A/B-Tests</li>
+        </ul>
+      </article>
+    </section>
+
+    <section class="cs-process">
+      <h2>Vorgehen in 48h</h2>
+      <ol>
+        <li><strong>Kickoff (0–1h):</strong> Ziele, Referenzen, Tonalität.</li>
+        <li><strong>Wireframe & Copy (3–6h):</strong> Hero, Nutzen, Proof, CTA.</li>
+        <li><strong>Build (8–24h):</strong> Static Export, Styles, Optimierung.</li>
+        <li><strong>Review (24–36h):</strong> Feinschliff mit Feedback.</li>
+        <li><strong>Go-Live (36–48h):</strong> Domain, Tracking, Handover.</li>
+      </ol>
+    </section>
+
+    <section class="cs-stack">
+      <h2>Stack</h2>
+      <ul class="tags">
+        <li>Static Export</li><li>Tailwind</li><li>Image-Optimierung</li><li>Lazy Assets</li>
+      </ul>
+    </section>
+
+    <section class="cs-cta">
+      <h2>Bereit, loszulegen?</h2>
+      <p>Schick mir kurz Ziel & Beispiel – ich melde mich heute.</p>
+      <div class="btn-row">
+        <a class="btn btn-primary" href="/TurboSito/de/kontakt.html">Projekt starten</a>
+        <a class="btn btn-ghost" href="/TurboSito/de/portfolio.html">Weitere Beispiele</a>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/de/portfolio.html
+++ b/de/portfolio.html
@@ -37,23 +37,23 @@
   </section>
   <section class="section grid gap-6 md:grid-cols-2 lg:grid-cols-3">
     <article class="card group hover-lift">
-      <a href="/TurboSito/de/demos/saas-landing.html">
+      <a href="/TurboSito/de/cases/saas-landing-demo.html">
         <picture>
           <source srcset="/assets/portfolio/p1.webp" type="image/webp">
           <img src="/TurboSito/assets/portfolio/p1.jpg" alt="SaaS-Landing Demo" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
         </picture>
       </a>
-      <h3 class="font-semibold text-lg"><a href="/TurboSito/de/demos/saas-landing.html"><span class="badge badge-demo">Demo</span> SaaS-Landing (Demo)</a></h3>
+      <h3 class="font-semibold text-lg"><a href="/TurboSito/de/cases/saas-landing-demo.html"><span class="badge badge-demo">Demo</span> SaaS-Landing (Demo)</a></h3>
       <ul class="mt-2 flex flex-wrap gap-2">
         <li><span class="badge"><!-- [[TAG1_DE]] --><span data-key="TAG1_DE" class="ph"></span></span></li>
         <li><span class="badge"><!-- [[TAG2_DE]] --><span data-key="TAG2_DE" class="ph"></span></span></li>
         <li><span class="badge"><!-- [[TAG3_DE]] --><span data-key="TAG3_DE" class="ph"></span></span></li>
       </ul>
-      <p class="text-[var(--muted)] text-sm mb-3">Demo – Vorschau auf Stil, Struktur und Geschwindigkeit.</p>
+      <p class="text-[var(--muted)] text-sm mb-3">Demo-Case – zeigt Stil, Struktur und Geschwindigkeit.</p>
       <div class="mt-3 flex gap-3">
-        <a class="btn" href="/TurboSito/de/demos/saas-landing.html">Demo ansehen</a>
+        <a class="btn" href="/TurboSito/de/cases/saas-landing-demo.html">Case Study ansehen</a>
       </div>
-      <a class="stretched-link" href="/TurboSito/de/demos/saas-landing.html" aria-label="Zur Demo: SaaS-Landing (Demo)"></a>
+      <a class="stretched-link" href="/TurboSito/de/cases/saas-landing-demo.html" aria-label="Zur Case Study: SaaS-Landing (Demo)"></a>
     </article>
     <article class="card group hover-lift">
       <a href="/TurboSito/de/demos/corporate-site.html">


### PR DESCRIPTION
## Summary
- add hero-desktop, sections and mobile mockup SVGs for SaaS demo
- introduce SaaS landing demo case page referencing mockups and process
- link SaaS landing portfolio card to case study with neutral subtitle and CTA
- append case study layout styles to central theme CSS

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b99035dbf08332a049ed6cee5a67c9