### PR TITLE
feat: add dynamic portfolio and case studies

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,3 +183,23 @@ Die Seiten sind bewusst schlank aufgebaut.  Um die Core Web Vitals einzuhalten
 ## Build
 - Entwicklung: `npm i` → `npm run build` → Ausgabe in /dist
 - Pages Source: GitHub Actions (Settings → Pages → Source: GitHub Actions)
+
+## Portfolio & Case Studies
+
+Die Übersichtsseite lädt ihre Karten aus sprachspezifischen JSON-Dateien unter `assets/data/portfolio.{lang}.json`.  Um einen neuen Case anzulegen:
+
+1. Datensatz in allen drei JSONs ergänzen (`slug`, `title`, `type`, `kpis`, `impactScore`, `timeToLaunchHours`, `summary`, `demoUrl`, `caseUrl`, `highlights`, `tags`).
+2. Detailseite unter `/{lang}/portfolio/{slug}.html` anlegen und `slug` im Inline-Script setzen.
+3. In den HTML-`<head>`-Bereich die passenden `link rel="alternate"`-Tags für alle Sprachversionen aufnehmen.
+4. `demoUrl` zeigt auf eine eigenständige Demo, `caseUrl` auf die jeweilige Detailseite.
+
+Die Portfolio-Seite unterstützt Filter (Type) und Sortierung über URL-Parameter (`?type=landing&sort=impact`).  Weitere Cases werden per „Mehr laden“-Button progressiv eingeblendet.
+
+### Test-Checkliste
+
+- Tabs und Sortierung per Tastatur bedienbar
+- `aria-label` je Karte/CTA vorhanden
+- Farben haben ausreichenden Kontrast
+- JSON-LD validiert (`<script type="application/ld+json">` in jeder Case-Detailseite)
+- `npm run build` läuft ohne Fehler
+

--- a/assets/css/portfolio.css
+++ b/assets/css/portfolio.css
@@ -1,0 +1,4 @@
+.ph-media{width:100%;aspect-ratio:16/9;background:linear-gradient(135deg,#e5e7eb,#d1d5db);}
+.badge{display:inline-block;background:#e5e7eb;color:#374151;font-size:.75rem;padding:0.125rem 0.5rem;border-radius:0.25rem;}
+.tag{display:inline-block;background:#f3f4f6;color:#374151;font-size:.75rem;padding:0.125rem 0.5rem;border-radius:9999px;}
+.case-card:focus-within{outline:2px solid #000;outline-offset:2px;}

--- a/assets/data/portfolio.de.json
+++ b/assets/data/portfolio.de.json
@@ -1,0 +1,43 @@
+{
+  "items": [
+    {
+      "slug": "saas-landing",
+      "title": "SaaS-Landing (Demo)",
+      "type": "landing",
+      "kpis": ["48h", "≤1.1s LCP", "Klare CTAs"],
+      "impactScore": 9,
+      "timeToLaunchHours": 48,
+      "summary": "Demo-Case – Stil, Struktur, Speed.",
+      "demoUrl": "/TurboSito/de/demos/saas-landing.html",
+      "caseUrl": "/TurboSito/de/portfolio/saas-landing.html",
+      "highlights": ["Value Proposition klar", "CTA direkt sichtbar", "Mobile-First"],
+      "tags": ["Tailwind", "Static Export", "A11y-Ready"]
+    },
+    {
+      "slug": "corporate-site",
+      "title": "Corporate-Site (Demo)",
+      "type": "corporate",
+      "kpis": ["48h", "≤1.1s LCP", "Seriöse Wirkung"],
+      "impactScore": 8,
+      "timeToLaunchHours": 48,
+      "summary": "Demo-Case – Vertrauen und Struktur.",
+      "demoUrl": "/TurboSito/de/demos/corporate-site.html",
+      "caseUrl": "/TurboSito/de/portfolio/corporate-site.html",
+      "highlights": ["Fokus auf Leistungen", "Schlanke Navigation", "Responsiv"],
+      "tags": ["Tailwind", "Static Export", "SEO-Ready"]
+    },
+    {
+      "slug": "fashion-shop",
+      "title": "Fashion-Shop (Demo)",
+      "type": "shop",
+      "kpis": ["48h", "≤1.1s LCP", "Schneller Checkout"],
+      "impactScore": 7,
+      "timeToLaunchHours": 48,
+      "summary": "Demo-Shop – klar und schnell.",
+      "demoUrl": "/TurboSito/de/demos/fashion-shop.html",
+      "caseUrl": "/TurboSito/de/portfolio/fashion-shop.html",
+      "highlights": ["Einfaches Grid", "Schneller Warenkorb", "Mobile-First"],
+      "tags": ["Tailwind", "Static Export", "Snipcart"]
+    }
+  ]
+}

--- a/assets/data/portfolio.en.json
+++ b/assets/data/portfolio.en.json
@@ -1,0 +1,43 @@
+{
+  "items": [
+    {
+      "slug": "saas-landing",
+      "title": "SaaS Landing (Demo)",
+      "type": "landing",
+      "kpis": ["48h", "≤1.1s LCP", "Clear CTAs"],
+      "impactScore": 9,
+      "timeToLaunchHours": 48,
+      "summary": "Demo case – style, structure, speed.",
+      "demoUrl": "/TurboSito/de/demos/saas-landing.html",
+      "caseUrl": "/TurboSito/en/portfolio/saas-landing.html",
+      "highlights": ["Value proposition clear", "Above-the-fold CTA", "Mobile-first"],
+      "tags": ["Tailwind", "Static Export", "A11y-Ready"]
+    },
+    {
+      "slug": "corporate-site",
+      "title": "Corporate Site (Demo)",
+      "type": "corporate",
+      "kpis": ["48h", "≤1.1s LCP", "Trusted feel"],
+      "impactScore": 8,
+      "timeToLaunchHours": 48,
+      "summary": "Demo case – trust and structure.",
+      "demoUrl": "/TurboSito/de/demos/corporate-site.html",
+      "caseUrl": "/TurboSito/en/portfolio/corporate-site.html",
+      "highlights": ["Focused services", "Lean navigation", "Responsive"],
+      "tags": ["Tailwind", "Static Export", "SEO-Ready"]
+    },
+    {
+      "slug": "fashion-shop",
+      "title": "Fashion Shop (Demo)",
+      "type": "shop",
+      "kpis": ["48h", "≤1.1s LCP", "Fast checkout"],
+      "impactScore": 7,
+      "timeToLaunchHours": 48,
+      "summary": "Demo store – clean and quick.",
+      "demoUrl": "/TurboSito/de/demos/fashion-shop.html",
+      "caseUrl": "/TurboSito/en/portfolio/fashion-shop.html",
+      "highlights": ["Simple grid", "Quick cart", "Mobile-first"],
+      "tags": ["Tailwind", "Static Export", "Snipcart"]
+    }
+  ]
+}

--- a/assets/data/portfolio.it.json
+++ b/assets/data/portfolio.it.json
@@ -1,0 +1,43 @@
+{
+  "items": [
+    {
+      "slug": "saas-landing",
+      "title": "Landing SaaS (Demo)",
+      "type": "landing",
+      "kpis": ["48h", "≤1.1s LCP", "CTA chiare"],
+      "impactScore": 9,
+      "timeToLaunchHours": 48,
+      "summary": "Caso demo – stile, struttura, velocità.",
+      "demoUrl": "/TurboSito/de/demos/saas-landing.html",
+      "caseUrl": "/TurboSito/it/portfolio/saas-landing.html",
+      "highlights": ["Value proposition chiara", "CTA above-the-fold", "Mobile-first"],
+      "tags": ["Tailwind", "Static Export", "A11y-Ready"]
+    },
+    {
+      "slug": "corporate-site",
+      "title": "Sito Corporate (Demo)",
+      "type": "corporate",
+      "kpis": ["48h", "≤1.1s LCP", "Fiducia"],
+      "impactScore": 8,
+      "timeToLaunchHours": 48,
+      "summary": "Caso demo – fiducia e struttura.",
+      "demoUrl": "/TurboSito/de/demos/corporate-site.html",
+      "caseUrl": "/TurboSito/it/portfolio/corporate-site.html",
+      "highlights": ["Servizi focalizzati", "Navigazione snella", "Responsive"],
+      "tags": ["Tailwind", "Static Export", "SEO-Ready"]
+    },
+    {
+      "slug": "fashion-shop",
+      "title": "Shop Moda (Demo)",
+      "type": "shop",
+      "kpis": ["48h", "≤1.1s LCP", "Checkout veloce"],
+      "impactScore": 7,
+      "timeToLaunchHours": 48,
+      "summary": "Negozio demo – pulito e rapido.",
+      "demoUrl": "/TurboSito/de/demos/fashion-shop.html",
+      "caseUrl": "/TurboSito/it/portfolio/fashion-shop.html",
+      "highlights": ["Grid semplice", "Carrello rapido", "Mobile-first"],
+      "tags": ["Tailwind", "Static Export", "Snipcart"]
+    }
+  ]
+}

--- a/assets/js/portfolio.js
+++ b/assets/js/portfolio.js
@@ -1,0 +1,102 @@
+(function(){
+  const lang = document.documentElement.lang || 'en';
+  const labels = {
+    en: {view:'View case study', demo:'Open demo', load:'Load more'},
+    de: {view:'Case Study ansehen', demo:'Demo öffnen', load:'Mehr laden'},
+    it: {view:'Vedi case study', demo:'Apri demo', load:'Carica altro'}
+  };
+  const t = labels[lang] || labels.en;
+  const state = {type:'all', sort:'new', visible:2, items:[]};
+
+  async function loadData(language){
+    const res = await fetch(`/TurboSito/assets/data/portfolio.${language}.json`);
+    const json = await res.json();
+    return json.items;
+  }
+
+  function applyFilters(items){
+    let filtered = state.type && state.type !== 'all' ? items.filter(i=>i.type===state.type) : items;
+    return applySort(filtered);
+  }
+
+  function applySort(items){
+    const arr = [...items];
+    if(state.sort==='impact') arr.sort((a,b)=>b.impactScore - a.impactScore);
+    else if(state.sort==='speed') arr.sort((a,b)=>a.timeToLaunchHours - b.timeToLaunchHours);
+    return arr; // 'new' keeps original order
+  }
+
+  function render(){
+    const container = document.getElementById('portfolio-grid');
+    container.innerHTML='';
+    const items = applyFilters(state.items).slice(0,state.visible);
+    items.forEach(item=>{
+      const article = document.createElement('article');
+      article.className = 'case-card border p-4 rounded focus-within:ring outline-none';
+      article.setAttribute('role','listitem');
+      article.setAttribute('aria-label', item.title);
+      article.innerHTML = `
+        <div class="ph-media mb-3" role="img" aria-label="Placeholder"></div>
+        <span class="badge mb-2">Demo</span>
+        <h3 class="font-semibold mb-1">${item.title}</h3>
+        <ul class="flex flex-wrap gap-1 text-sm mb-2">
+          ${item.tags.slice(0,3).map(t=>`<li class="tag">${t}</li>`).join('')}
+        </ul>
+        <p class="text-sm mb-3">⏱ ${item.kpis[0]} • ⚡ ${item.kpis[1]} • ✅ ${item.kpis[2]}</p>
+        <div class="flex flex-wrap gap-3">
+          <a class="btn btn-primary" aria-label="${t.view}: ${item.title}" href="${item.caseUrl}">${t.view}</a>
+          <a class="link" aria-label="${t.demo}: ${item.title}" href="${item.demoUrl}" target="_blank" rel="noopener">${t.demo}</a>
+        </div>`;
+      container.appendChild(article);
+    });
+    const more = document.getElementById('load-more');
+    more.hidden = applyFilters(state.items).length <= state.visible;
+    more.textContent = t.load;
+  }
+
+  function hydrateFromURL(){
+    const params = new URLSearchParams(location.search);
+    if(params.get('type')) state.type = params.get('type');
+    if(params.get('sort')) state.sort = params.get('sort');
+    document.querySelectorAll('[data-type]').forEach(btn=>{
+      const active = btn.getAttribute('data-type') === state.type;
+      btn.setAttribute('aria-pressed', active);
+    });
+    const sortSel = document.getElementById('sort');
+    if(sortSel) sortSel.value = state.sort;
+  }
+
+  function updateURL(){
+    const url = new URL(location);
+    if(state.type && state.type !== 'all') url.searchParams.set('type', state.type); else url.searchParams.delete('type');
+    if(state.sort && state.sort !== 'new') url.searchParams.set('sort', state.sort); else url.searchParams.delete('sort');
+    history.replaceState(null,'',url);
+  }
+
+  function initA11yTabs(){
+    document.querySelectorAll('[data-type]').forEach(btn=>{
+      btn.addEventListener('click',()=>{
+        state.type = btn.getAttribute('data-type');
+        document.querySelectorAll('[data-type]').forEach(b=>b.setAttribute('aria-pressed', b===btn));
+        updateURL();
+        state.visible = 2;
+        render();
+      });
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', async()=>{
+    state.items = await loadData(lang);
+    hydrateFromURL();
+    initA11yTabs();
+    const sortSel = document.getElementById('sort');
+    if(sortSel) sortSel.addEventListener('change', e=>{
+      state.sort = e.target.value;
+      updateURL();
+      render();
+    });
+    const more = document.getElementById('load-more');
+    if(more) more.addEventListener('click', ()=>{state.visible+=2; render();});
+    render();
+  });
+})();

--- a/de/portfolio.html
+++ b/de/portfolio.html
@@ -4,164 +4,74 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Portfolio – TurboSito</title>
-  <meta name="description" content="Auswahl aktueller Arbeiten und Projekte.">
-  <link rel="canonical" href="https://deine-domain.tld/de/portfolio.html">
-  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio.html">
-  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio.html">
-  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio.html">
-  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
-  <meta property="og:title" content="Portfolio – TurboSito">
-  <meta property="og:description" content="Auswahl aktueller Arbeiten und Projekte.">
-  <meta property="og:url" content="https://deine-domain.tld/de/portfolio.html">
-  <meta property="og:locale" content="de_DE">
-  <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
-  <meta name="twitter:card" content="summary_large_image">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
-<style>
-  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
-  .font-display{font-family:"Outfit", var(--font-sans)}
-  body{font-family:var(--font-sans)}
-</style>
-<link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
-<script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+  <meta name="description" content="Demo-Cases – schnell und klar."/>
+  <link rel="canonical" href="https://deine-domain.tld/de/portfolio.html"/>
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio.html"/>
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio.html"/>
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio.html"/>
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/portfolio.html"/>
+  <meta property="og:title" content="Portfolio – TurboSito"/>
+  <meta property="og:description" content="Demo-Cases – schnell und klar."/>
+  <meta property="og:url" content="https://deine-domain.tld/de/portfolio.html"/>
+  <meta property="og:locale" content="de_DE"/>
+  <meta name="twitter:card" content="summary"/>
+  <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
+  <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
+  <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+  <script defer src="/TurboSito/assets/js/portfolio.js"></script>
 </head>
 <body class="font-sans text-gray-900">
-  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
-<header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/de/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/de/">Start</a><a href="/TurboSito/de/ueber-mich.html">Über mich</a><a href="/TurboSito/de/leistungen.html">Leistungen</a><a href="/TurboSito/de/portfolio.html">Portfolio</a><a href="/TurboSito/de/kontakt.html">Kontakt</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Sprache"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button></div></div></header>
-
-<main id="content" class="max-w-6xl mx-auto px-4 py-20">
-  <section class="section-lg mb-12 text-center">
-    <h1 class="font-display text-3xl md:text-4xl font-bold mb-6">Demo-Projekte</h1>
-    <p>Ehrliche Vorschau auf Stil und Prozess. Echte Case Studies folgen.</p>
-  </section>
-  <section class="section grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-    <article class="card group hover-lift">
-      <a href="/TurboSito/de/cases/saas-landing-demo.html">
-        <picture>
-          <source srcset="/assets/portfolio/p1.webp" type="image/webp">
-          <img src="/TurboSito/assets/portfolio/p1.jpg" alt="SaaS-Landing Demo" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
-        </picture>
-      </a>
-      <h3 class="font-semibold text-lg"><a href="/TurboSito/de/cases/saas-landing-demo.html"><span class="badge badge-demo">Demo</span> SaaS-Landing (Demo)</a></h3>
-      <ul class="mt-2 flex flex-wrap gap-2">
-        <li><span class="badge"><!-- [[TAG1_DE]] --><span data-key="TAG1_DE" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG2_DE]] --><span data-key="TAG2_DE" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG3_DE]] --><span data-key="TAG3_DE" class="ph"></span></span></li>
-      </ul>
-      <p class="text-[var(--muted)] text-sm mb-3">Demo-Case – zeigt Stil, Struktur und Geschwindigkeit.</p>
-      <div class="mt-3 flex gap-3">
-        <a class="btn" href="/TurboSito/de/cases/saas-landing-demo.html">Case Study ansehen</a>
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Zum Inhalt springen</a>
+  <header id="site-header">
+    <div class="container flex items-center justify-between gap-4">
+      <nav class="site-nav">
+        <a class="brand" href="/TurboSito/de/">TurboSito</a>
+        <a href="/TurboSito/de/ueber-mich.html">Über mich</a>
+        <a href="/TurboSito/de/leistungen.html">Leistungen</a>
+        <a href="/TurboSito/de/portfolio.html">Portfolio</a>
+        <a href="/TurboSito/de/kontakt.html">Kontakt</a>
+      </nav>
+      <div class="header-right flex items-center gap-2">
+        <nav class="lang-switch" aria-label="Sprachen">
+          <a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a>
+          <a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a>
+          <a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a>
+        </nav>
+        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button>
       </div>
-      <a class="stretched-link" href="/TurboSito/de/cases/saas-landing-demo.html" aria-label="Zur Case Study: SaaS-Landing (Demo)"></a>
-    </article>
-    <article class="card group hover-lift">
-      <a href="/TurboSito/de/demos/corporate-site.html">
-        <picture>
-          <source srcset="/assets/portfolio/p2.webp" type="image/webp">
-          <img src="/TurboSito/assets/portfolio/p2.jpg" alt="Corporate Website für Beratungsfirma" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
-        </picture>
-      </a>
-      <h3 class="font-semibold text-lg"><a href="/TurboSito/de/demos/corporate-site.html"><span class="badge badge-demo">Demo</span> Corporate Website für Beratungsfirma</a></h3>
-      <ul class="mt-2 flex flex-wrap gap-2">
-        <li><span class="badge"><!-- [[TAG1_DE]] --><span data-key="TAG1_DE" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG2_DE]] --><span data-key="TAG2_DE" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG3_DE]] --><span data-key="TAG3_DE" class="ph"></span></span></li>
-      </ul>
-      <p class="text-[var(--muted)] text-sm mb-3">Demo – modulare Corporate-Seite.</p>
-      <div class="mt-3 flex gap-3">
-        <a class="btn" href="/TurboSito/de/demos/corporate-site.html">Demo ansehen</a>
+    </div>
+  </header>
+  <main id="content" class="max-w-6xl mx-auto px-4 py-12">
+    <section class="text-center mb-10">
+      <h1 class="text-3xl font-bold mb-2">Portfolio</h1>
+      <p>Ehrliche Vorschau auf unseren Prozess.</p>
+    </section>
+    <section>
+      <nav class="flex flex-wrap gap-2 justify-center mb-4" role="tablist">
+        <button data-type="all" aria-pressed="true" class="px-3 py-1 border rounded">Alle</button>
+        <button data-type="landing" aria-pressed="false" class="px-3 py-1 border rounded">Landingpages</button>
+        <button data-type="corporate" aria-pressed="false" class="px-3 py-1 border rounded">Corporate</button>
+        <button data-type="shop" aria-pressed="false" class="px-3 py-1 border rounded">Shop</button>
+        <button data-type="app" aria-pressed="false" class="px-3 py-1 border rounded">App/Tool</button>
+      </nav>
+      <div class="flex justify-end mb-4">
+        <label class="flex items-center gap-2">
+          <span class="sr-only">Sortierung</span>
+          <select id="sort" class="border rounded px-2 py-1">
+            <option value="new">Neu → Alt</option>
+            <option value="impact">Höchste Wirkung</option>
+            <option value="speed">Schnellste Umsetzung</option>
+          </select>
+        </label>
       </div>
-      <a class="stretched-link" href="/TurboSito/de/demos/corporate-site.html" aria-label="Zur Demo: Corporate Website für Beratungsfirma"></a>
-    </article>
-    <article class="card group hover-lift">
-      <a href="/TurboSito/de/demos/fashion-shop.html">
-        <picture>
-          <source srcset="/assets/portfolio/p3.webp" type="image/webp">
-          <img src="/TurboSito/assets/portfolio/p3.jpg" alt="Online-Shop für Modebrand" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
-        </picture>
-      </a>
-      <h3 class="font-semibold text-lg"><a href="/TurboSito/de/demos/fashion-shop.html"><span class="badge badge-demo">Demo</span> Online-Shop für Modebrand</a></h3>
-      <ul class="mt-2 flex flex-wrap gap-2">
-        <li><span class="badge"><!-- [[TAG1_DE]] --><span data-key="TAG1_DE" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG2_DE]] --><span data-key="TAG2_DE" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG3_DE]] --><span data-key="TAG3_DE" class="ph"></span></span></li>
-      </ul>
-      <p class="text-[var(--muted)] text-sm mb-3">Demo – Shop-Startseite.</p>
-      <div class="mt-3 flex gap-3">
-        <a class="btn" href="/TurboSito/de/demos/fashion-shop.html">Demo ansehen</a>
+      <div id="portfolio-grid" class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3" role="list"></div>
+      <div class="text-center mt-6">
+        <button id="load-more" class="px-4 py-2 border rounded"></button>
       </div>
-      <a class="stretched-link" href="/TurboSito/de/demos/fashion-shop.html" aria-label="Zur Demo: Online-Shop für Modebrand"></a>
-    </article>
-    <article class="card group hover-lift">
-      <picture>
-        <source srcset="/assets/portfolio/p4.webp" type="image/webp">
-        <img src="/TurboSito/assets/portfolio/p4.jpg" alt="Portfolio-Site für Fotografin" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
-      </picture>
-      <h3 class="font-semibold text-lg">Portfolio-Site für Fotografin</h3>
-      <ul class="mt-2 flex flex-wrap gap-2">
-        <li><span class="badge"><!-- [[TAG1_DE]] --><span data-key="TAG1_DE" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG2_DE]] --><span data-key="TAG2_DE" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG3_DE]] --><span data-key="TAG3_DE" class="ph"></span></span></li>
-      </ul>
-      <p class="text-[var(--muted)] text-sm mb-3">Mehr Buchungen dank Online-Präsenz.</p>
-      <div class="mt-3 flex gap-3">
-        <a class="btn btn-outline" href="[[LIVE_URL_DE]]">Live</a>
-        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_DE]]">Code</a>
-      </div>
-    </article>
-    <article class="card group hover-lift">
-      <picture>
-        <source srcset="/assets/portfolio/p5.webp" type="image/webp">
-        <img src="/TurboSito/assets/portfolio/p5.jpg" alt="Event-Microsite" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
-      </picture>
-      <h3 class="font-semibold text-lg">Event-Microsite</h3>
-      <ul class="mt-2 flex flex-wrap gap-2">
-        <li><span class="badge"><!-- [[TAG1_DE]] --><span data-key="TAG1_DE" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG2_DE]] --><span data-key="TAG2_DE" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG3_DE]] --><span data-key="TAG3_DE" class="ph"></span></span></li>
-      </ul>
-      <p class="text-[var(--muted)] text-sm mb-3">2.000 Registrierungen in einer Woche.</p>
-      <div class="mt-3 flex gap-3">
-        <a class="btn btn-outline" href="[[LIVE_URL_DE]]">Live</a>
-        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_DE]]">Code</a>
-      </div>
-    </article>
-    <article class="card group hover-lift">
-      <picture>
-        <source srcset="/assets/portfolio/p6.webp" type="image/webp">
-        <img src="/TurboSito/assets/portfolio/p6.jpg" alt="Mehrsprachige Hotelseite" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
-      </picture>
-      <h3 class="font-semibold text-lg">Mehrsprachige Hotelseite</h3>
-      <ul class="mt-2 flex flex-wrap gap-2">
-        <li><span class="badge"><!-- [[TAG1_DE]] --><span data-key="TAG1_DE" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG2_DE]] --><span data-key="TAG2_DE" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG3_DE]] --><span data-key="TAG3_DE" class="ph"></span></span></li>
-      </ul>
-      <p class="text-[var(--muted)] text-sm mb-3">Internationale Buchungen um 25% erhöht.</p>
-      <div class="mt-3 flex gap-3">
-        <a class="btn btn-outline" href="[[LIVE_URL_DE]]">Live</a>
-        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_DE]]">Code</a>
-      </div>
-    </article>
-  </section>
-</main>
-<footer class="border-t border-white/10">
-  <div class="container section text-center text-sm">
-    <p>Kontakt: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
-    <p class="mt-2">
-      <a href="/TurboSito/de/impressum.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Impressum</a>
-      <span class="mx-2">·</span>
-      <a href="/TurboSito/de/datenschutz.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Datenschutz</a>
-    </p>
-  </div>
-</footer>
-  <script src="/TurboSito/assets/js/reveal.js" defer></script>
-  <script src="/TurboSito/assets/js/faq.js" defer></script>
-  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
-  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
-  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
-  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
-  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+    </section>
+  </main>
+  <footer class="text-center py-10 text-sm">
+    <p>&copy; TurboSito</p>
+  </footer>
 </body>
 </html>

--- a/de/portfolio/corporate-site.html
+++ b/de/portfolio/corporate-site.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="de" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Corporate-Site – TurboSito</title>
+  <meta name="description" content="Demo-Case: Corporate-Website."/>
+  <link rel="canonical" href="https://deine-domain.tld/de/portfolio/corporate-site.html"/>
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio/corporate-site.html"/>
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio/corporate-site.html"/>
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio/corporate-site.html"/>
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/portfolio/corporate-site.html"/>
+  <meta property="og:title" content="Corporate-Site – TurboSito"/>
+  <meta property="og:description" content="Demo-Case: Vertrauen und Struktur."/>
+  <meta property="og:url" content="https://deine-domain.tld/de/portfolio/corporate-site.html"/>
+  <meta property="og:locale" content="de_DE"/>
+  <meta name="twitter:card" content="summary"/>
+  <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
+  <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
+  <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Zum Inhalt springen</a>
+  <header id="site-header">
+    <div class="container flex items-center justify-between gap-4">
+      <nav class="site-nav">
+        <a class="brand" href="/TurboSito/de/">TurboSito</a>
+        <a href="/TurboSito/de/ueber-mich.html">Über mich</a>
+        <a href="/TurboSito/de/leistungen.html">Leistungen</a>
+        <a href="/TurboSito/de/portfolio.html">Portfolio</a>
+        <a href="/TurboSito/de/kontakt.html">Kontakt</a>
+      </nav>
+      <div class="header-right flex items-center gap-2">
+        <nav class="lang-switch" aria-label="Sprachen">
+          <a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a>
+          <a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a>
+          <a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a>
+        </nav>
+        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button>
+      </div>
+    </div>
+  </header>
+  <main id="content" class="max-w-3xl mx-auto px-4 py-12">
+    <nav aria-label="Brotkrumen" class="mb-4"><a href="../portfolio.html" class="text-sm">← Portfolio</a></nav>
+    <header class="mb-8">
+      <h1 id="case-title" class="text-3xl font-bold mb-2">Corporate-Site (Demo)</h1>
+      <p id="case-summary" class="text-lg mb-1">Demo-Case – Vertrauen und Struktur.</p>
+      <p class="text-sm text-gray-600">Demo-Case</p>
+    </header>
+    <section class="grid gap-4 md:grid-cols-3 mb-8">
+      <div class="p-4 border rounded text-center"><strong id="kpi-1">48h</strong><br><span class="text-sm">Umsetzungszeit</span></div>
+      <div class="p-4 border rounded text-center"><strong id="kpi-2">≤1.1s LCP</strong><br><span class="text-sm">mobil, Demo</span></div>
+      <div class="p-4 border rounded text-center"><strong id="kpi-3">Seriöse Wirkung</strong><br><span class="text-sm">Glaubwürdigkeit</span></div>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Ausgangslage</h2>
+      <p>Beratungsfirma wollte eine schlanke Seite, die Vertrauen schafft.</p>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Ansatz</h2>
+      <p>Klare Leistungen, einfache Navigation und statischer Export.</p>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Ergebnis</h2>
+      <p>Besucher finden Infos schnell und nehmen Kontakt auf.</p>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Vorgehen in 48h</h2>
+      <ol class="list-decimal pl-5 space-y-1">
+        <li>Briefing & Ziele</li>
+        <li>Wireframe</li>
+        <li>Copy-Entwurf</li>
+        <li>Build & QA</li>
+        <li>Launch</li>
+      </ol>
+      <div id="stack-tags" class="mt-4 flex flex-wrap gap-2"></div>
+    </section>
+    <section class="mt-8 flex flex-wrap gap-4">
+      <a class="btn btn-primary" href="/TurboSito/de/kontakt.html">Projekt starten</a>
+      <a class="btn btn-outline" href="../portfolio.html">Weitere Beispiele</a>
+    </section>
+    <script id="ld-json" type="application/ld+json"></script>
+    <script>
+    (async()=>{
+      const slug='corporate-site';
+      const lang=document.documentElement.lang;
+      const res=await fetch(`/TurboSito/assets/data/portfolio.${lang}.json`);
+      const data=await res.json();
+      const item=data.items.find(i=>i.slug===slug);
+      if(!item) return;
+      document.getElementById('case-title').textContent=item.title;
+      document.getElementById('case-summary').textContent=item.summary;
+      document.getElementById('kpi-1').textContent=item.kpis[0];
+      document.getElementById('kpi-2').textContent=item.kpis[1];
+      document.getElementById('kpi-3').textContent=item.kpis[2];
+      document.getElementById('stack-tags').innerHTML=item.tags.map(t=>`<span class="tag">${t}</span>`).join(' ');
+      const ld={"@context":"https://schema.org","@type":"CreativeWork","name":item.title,"about":item.summary,"inLanguage":lang,"timeRequired":"PT"+item.timeToLaunchHours+"H","author":{"@type":"Person","name":"TurboSito"},"offers":{"@type":"Offer","priceCurrency":"EUR","price":"0"},"keywords":item.tags.join(',')};
+      document.getElementById('ld-json').textContent=JSON.stringify(ld);
+    })();
+    </script>
+  </main>
+  <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+</body>
+</html>

--- a/de/portfolio/fashion-shop.html
+++ b/de/portfolio/fashion-shop.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="de" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Fashion-Shop – TurboSito</title>
+  <meta name="description" content="Demo-Case: Fashion-Shop."/>
+  <link rel="canonical" href="https://deine-domain.tld/de/portfolio/fashion-shop.html"/>
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio/fashion-shop.html"/>
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio/fashion-shop.html"/>
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio/fashion-shop.html"/>
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/portfolio/fashion-shop.html"/>
+  <meta property="og:title" content="Fashion-Shop – TurboSito"/>
+  <meta property="og:description" content="Demo-Case: klarer Shop mit schnellem Checkout."/>
+  <meta property="og:url" content="https://deine-domain.tld/de/portfolio/fashion-shop.html"/>
+  <meta property="og:locale" content="de_DE"/>
+  <meta name="twitter:card" content="summary"/>
+  <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
+  <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
+  <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Zum Inhalt springen</a>
+  <header id="site-header">
+    <div class="container flex items-center justify-between gap-4">
+      <nav class="site-nav">
+        <a class="brand" href="/TurboSito/de/">TurboSito</a>
+        <a href="/TurboSito/de/ueber-mich.html">Über mich</a>
+        <a href="/TurboSito/de/leistungen.html">Leistungen</a>
+        <a href="/TurboSito/de/portfolio.html">Portfolio</a>
+        <a href="/TurboSito/de/kontakt.html">Kontakt</a>
+      </nav>
+      <div class="header-right flex items-center gap-2">
+        <nav class="lang-switch" aria-label="Sprachen">
+          <a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a>
+          <a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a>
+          <a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a>
+        </nav>
+        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button>
+      </div>
+    </div>
+  </header>
+  <main id="content" class="max-w-3xl mx-auto px-4 py-12">
+    <nav aria-label="Brotkrumen" class="mb-4"><a href="../portfolio.html" class="text-sm">← Portfolio</a></nav>
+    <header class="mb-8">
+      <h1 id="case-title" class="text-3xl font-bold mb-2">Fashion-Shop (Demo)</h1>
+      <p id="case-summary" class="text-lg mb-1">Demo-Shop – klar und schnell.</p>
+      <p class="text-sm text-gray-600">Demo-Case</p>
+    </header>
+    <section class="grid gap-4 md:grid-cols-3 mb-8">
+      <div class="p-4 border rounded text-center"><strong id="kpi-1">48h</strong><br><span class="text-sm">Umsetzungszeit</span></div>
+      <div class="p-4 border rounded text-center"><strong id="kpi-2">≤1.1s LCP</strong><br><span class="text-sm">mobil, Demo</span></div>
+      <div class="p-4 border rounded text-center"><strong id="kpi-3">Schneller Checkout</strong><br><span class="text-sm">Conversion</span></div>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Ausgangslage</h2>
+      <p>Produkte schnell und ohne Ballast zeigen.</p>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Ansatz</h2>
+      <p>Einfaches Grid, Snipcart-Integration und Mobile-First.</p>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Ergebnis</h2>
+      <p>Klarer Aufbau und schneller Checkout steigern Verkäufe.</p>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Vorgehen in 48h</h2>
+      <ol class="list-decimal pl-5 space-y-1">
+        <li>Briefing & Ziele</li>
+        <li>Wireframe</li>
+        <li>Copy-Entwurf</li>
+        <li>Build & QA</li>
+        <li>Launch</li>
+      </ol>
+      <div id="stack-tags" class="mt-4 flex flex-wrap gap-2"></div>
+    </section>
+    <section class="mt-8 flex flex-wrap gap-4">
+      <a class="btn btn-primary" href="/TurboSito/de/kontakt.html">Projekt starten</a>
+      <a class="btn btn-outline" href="../portfolio.html">Weitere Beispiele</a>
+    </section>
+    <script id="ld-json" type="application/ld+json"></script>
+    <script>
+    (async()=>{
+      const slug='fashion-shop';
+      const lang=document.documentElement.lang;
+      const res=await fetch(`/TurboSito/assets/data/portfolio.${lang}.json`);
+      const data=await res.json();
+      const item=data.items.find(i=>i.slug===slug);
+      if(!item) return;
+      document.getElementById('case-title').textContent=item.title;
+      document.getElementById('case-summary').textContent=item.summary;
+      document.getElementById('kpi-1').textContent=item.kpis[0];
+      document.getElementById('kpi-2').textContent=item.kpis[1];
+      document.getElementById('kpi-3').textContent=item.kpis[2];
+      document.getElementById('stack-tags').innerHTML=item.tags.map(t=>`<span class="tag">${t}</span>`).join(' ');
+      const ld={"@context":"https://schema.org","@type":"CreativeWork","name":item.title,"about":item.summary,"inLanguage":lang,"timeRequired":"PT"+item.timeToLaunchHours+"H","author":{"@type":"Person","name":"TurboSito"},"offers":{"@type":"Offer","priceCurrency":"EUR","price":"0"},"keywords":item.tags.join(',')};
+      document.getElementById('ld-json').textContent=JSON.stringify(ld);
+    })();
+    </script>
+  </main>
+  <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+</body>
+</html>

--- a/de/portfolio/saas-landing.html
+++ b/de/portfolio/saas-landing.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="de" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>SaaS-Landing – TurboSito</title>
+  <meta name="description" content="Demo-Case: SaaS-Landingpage."/>
+  <link rel="canonical" href="https://deine-domain.tld/de/portfolio/saas-landing.html"/>
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio/saas-landing.html"/>
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio/saas-landing.html"/>
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio/saas-landing.html"/>
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/portfolio/saas-landing.html"/>
+  <meta property="og:title" content="SaaS-Landing – TurboSito"/>
+  <meta property="og:description" content="Demo-Case: Stil, Struktur, Speed."/>
+  <meta property="og:url" content="https://deine-domain.tld/de/portfolio/saas-landing.html"/>
+  <meta property="og:locale" content="de_DE"/>
+  <meta name="twitter:card" content="summary"/>
+  <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
+  <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
+  <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Zum Inhalt springen</a>
+  <header id="site-header">
+    <div class="container flex items-center justify-between gap-4">
+      <nav class="site-nav">
+        <a class="brand" href="/TurboSito/de/">TurboSito</a>
+        <a href="/TurboSito/de/ueber-mich.html">Über mich</a>
+        <a href="/TurboSito/de/leistungen.html">Leistungen</a>
+        <a href="/TurboSito/de/portfolio.html">Portfolio</a>
+        <a href="/TurboSito/de/kontakt.html">Kontakt</a>
+      </nav>
+      <div class="header-right flex items-center gap-2">
+        <nav class="lang-switch" aria-label="Sprachen">
+          <a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a>
+          <a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a>
+          <a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a>
+        </nav>
+        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button>
+      </div>
+    </div>
+  </header>
+  <main id="content" class="max-w-3xl mx-auto px-4 py-12">
+    <nav aria-label="Brotkrumen" class="mb-4"><a href="../portfolio.html" class="text-sm">← Portfolio</a></nav>
+    <header class="mb-8">
+      <h1 id="case-title" class="text-3xl font-bold mb-2">SaaS-Landing (Demo)</h1>
+      <p id="case-summary" class="text-lg mb-1">Demo-Case – Stil, Struktur, Speed.</p>
+      <p class="text-sm text-gray-600">Demo-Case</p>
+    </header>
+    <section class="grid gap-4 md:grid-cols-3 mb-8">
+      <div class="p-4 border rounded text-center"><strong id="kpi-1">48h</strong><br><span class="text-sm">Umsetzungszeit</span></div>
+      <div class="p-4 border rounded text-center"><strong id="kpi-2">≤1.1s LCP</strong><br><span class="text-sm">mobil, Demo</span></div>
+      <div class="p-4 border rounded text-center"><strong id="kpi-3">Klare CTAs</strong><br><span class="text-sm">fokussiert</span></div>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Ausgangslage</h2>
+      <p>Kleines SaaS brauchte eine klare Botschaft für erste Signups.</p>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Ansatz</h2>
+      <p>Schlanke Struktur, Tailwind-Styling und Mobile-First-Blöcke.</p>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Ergebnis</h2>
+      <p>Demo lädt schnell, betont den Wert und führt zur CTA.</p>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Vorgehen in 48h</h2>
+      <ol class="list-decimal pl-5 space-y-1">
+        <li>Briefing & Ziele</li>
+        <li>Wireframe</li>
+        <li>Copy-Entwurf</li>
+        <li>Build & QA</li>
+        <li>Launch</li>
+      </ol>
+      <div id="stack-tags" class="mt-4 flex flex-wrap gap-2"></div>
+    </section>
+    <section class="mt-8 flex flex-wrap gap-4">
+      <a class="btn btn-primary" href="/TurboSito/de/kontakt.html">Projekt starten</a>
+      <a class="btn btn-outline" href="../portfolio.html">Weitere Beispiele</a>
+    </section>
+    <script id="ld-json" type="application/ld+json"></script>
+    <script>
+    (async()=>{
+      const slug='saas-landing';
+      const lang=document.documentElement.lang;
+      const res=await fetch(`/TurboSito/assets/data/portfolio.${lang}.json`);
+      const data=await res.json();
+      const item=data.items.find(i=>i.slug===slug);
+      if(!item) return;
+      document.getElementById('case-title').textContent=item.title;
+      document.getElementById('case-summary').textContent=item.summary;
+      document.getElementById('kpi-1').textContent=item.kpis[0];
+      document.getElementById('kpi-2').textContent=item.kpis[1];
+      document.getElementById('kpi-3').textContent=item.kpis[2];
+      document.getElementById('stack-tags').innerHTML=item.tags.map(t=>`<span class="tag">${t}</span>`).join(' ');
+      const ld={"@context":"https://schema.org","@type":"CreativeWork","name":item.title,"about":item.summary,"inLanguage":lang,"timeRequired":"PT"+item.timeToLaunchHours+"H","author":{"@type":"Person","name":"TurboSito"},"offers":{"@type":"Offer","priceCurrency":"EUR","price":"0"},"keywords":item.tags.join(',')};
+      document.getElementById('ld-json').textContent=JSON.stringify(ld);
+    })();
+    </script>
+  </main>
+  <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+</body>
+</html>

--- a/en/portfolio.html
+++ b/en/portfolio.html
@@ -4,175 +4,74 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Portfolio – TurboSito</title>
-  <meta name="description" content="Selection of recent work and projects.">
-  <link rel="canonical" href="https://deine-domain.tld/en/portfolio.html">
-  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio.html">
-  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio.html">
-  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio.html">
-  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
-  <meta property="og:title" content="Portfolio – TurboSito">
-  <meta property="og:description" content="Selection of recent work and projects.">
-  <meta property="og:url" content="https://deine-domain.tld/en/portfolio.html">
-  <meta property="og:locale" content="en_US">
-  <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
-  <meta name="twitter:card" content="summary_large_image">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
-<style>
-  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
-  .font-display{font-family:"Outfit", var(--font-sans)}
-  body{font-family:var(--font-sans)}
-</style>
-<link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
-<script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+  <meta name="description" content="Demo case studies – fast and clear."/>
+  <link rel="canonical" href="https://deine-domain.tld/en/portfolio.html"/>
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio.html"/>
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio.html"/>
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio.html"/>
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/portfolio.html"/>
+  <meta property="og:title" content="Portfolio – TurboSito"/>
+  <meta property="og:description" content="Demo case studies – fast and clear."/>
+  <meta property="og:url" content="https://deine-domain.tld/en/portfolio.html"/>
+  <meta property="og:locale" content="en_US"/>
+  <meta name="twitter:card" content="summary"/>
+  <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
+  <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
+  <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+  <script defer src="/TurboSito/assets/js/portfolio.js"></script>
 </head>
 <body class="font-sans text-gray-900">
   <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
-<header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/en/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/en/">Home</a><a href="/TurboSito/en/about.html">About</a><a href="/TurboSito/en/services.html">Services</a><a href="/TurboSito/en/portfolio.html">Portfolio</a><a href="/TurboSito/en/contact.html">Contact</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Language"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Toggle theme" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button></div></div></header>
-
-<main id="content" class="max-w-6xl mx-auto px-4 py-20">
-  <section class="section-lg mb-12 text-center">
-    <h1 class="font-display text-3xl md:text-4xl font-bold mb-6">Portfolio</h1>
-    <p>A selection of recent work and projects.</p>
-  </section>
-  <section class="section grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-    <article class="card group hover-lift case-card" data-slug="landingpage-tech-startup">
-      <a href="/TurboSito/en/cases/landingpage-tech-startup.html">
-        <picture>
-          <source srcset="/assets/portfolio/p1.webp" type="image/webp">
-          <img src="/TurboSito/assets/portfolio/p1.jpg" alt="Landing page for tech startup" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
-        </picture>
-      </a>
-      <h3 class="font-semibold text-lg"><a href="/TurboSito/en/cases/landingpage-tech-startup.html">Landing page for tech startup</a></h3>
-      <ul class="mt-2 flex flex-wrap gap-2">
-        <li><span class="badge"><!-- [[TAG1_EN]] --><span data-key="TAG1_EN" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG2_EN]] --><span data-key="TAG2_EN" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG3_EN]] --><span data-key="TAG3_EN" class="ph"></span></span></li>
-      </ul>
-      <p class="text-[var(--muted)] text-sm mb-3">Boosted signups by 40%.</p>
-      <div class="mt-3 flex gap-3 relative z-10">
-        <a class="btn btn-outline" href="[[LIVE_URL_EN]]">Live</a>
-        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_EN]]">Code</a>
+  <header id="site-header">
+    <div class="container flex items-center justify-between gap-4">
+      <nav class="site-nav">
+        <a class="brand" href="/TurboSito/en/">TurboSito</a>
+        <a href="/TurboSito/en/about.html">About</a>
+        <a href="/TurboSito/en/services.html">Services</a>
+        <a href="/TurboSito/en/portfolio.html">Portfolio</a>
+        <a href="/TurboSito/en/contact.html">Contact</a>
+      </nav>
+      <div class="header-right flex items-center gap-2">
+        <nav class="lang-switch" aria-label="Language switch">
+          <a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a>
+          <a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a>
+          <a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a>
+        </nav>
+        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button>
       </div>
-      <a class="btn btn-outline case-cta" href="/TurboSito/en/cases/landingpage-tech-startup.html">Read case</a>
-      <a class="stretched-link" href="/TurboSito/en/cases/landingpage-tech-startup.html" aria-label="Read case: Landing page for tech startup"></a>
-    </article>
-    <article class="card group hover-lift">
-      <picture>
-        <source srcset="/assets/portfolio/p2.webp" type="image/webp">
-        <img src="/TurboSito/assets/portfolio/p2.jpg" alt="Corporate site for consulting firm" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
-      </picture>
-      <h3 class="font-semibold text-lg">Corporate site for consulting firm</h3>
-      <ul class="mt-2 flex flex-wrap gap-2">
-        <li><span class="badge"><!-- [[TAG1_EN]] --><span data-key="TAG1_EN" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG2_EN]] --><span data-key="TAG2_EN" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG3_EN]] --><span data-key="TAG3_EN" class="ph"></span></span></li>
-      </ul>
-      <p class="text-[var(--muted)] text-sm mb-3">Leads increased by 30%.</p>
-      <div class="mt-3 flex gap-3">
-        <a class="btn btn-outline" href="[[LIVE_URL_EN]]">Live</a>
-        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_EN]]">Code</a>
+    </div>
+  </header>
+  <main id="content" class="max-w-6xl mx-auto px-4 py-12">
+    <section class="text-center mb-10">
+      <h1 class="text-3xl font-bold mb-2">Portfolio</h1>
+      <p>Honest previews of our process.</p>
+    </section>
+    <section>
+      <nav class="flex flex-wrap gap-2 justify-center mb-4" role="tablist">
+        <button data-type="all" aria-pressed="true" class="px-3 py-1 border rounded">All</button>
+        <button data-type="landing" aria-pressed="false" class="px-3 py-1 border rounded">Landingpages</button>
+        <button data-type="corporate" aria-pressed="false" class="px-3 py-1 border rounded">Corporate</button>
+        <button data-type="shop" aria-pressed="false" class="px-3 py-1 border rounded">Shop</button>
+        <button data-type="app" aria-pressed="false" class="px-3 py-1 border rounded">App/Tool</button>
+      </nav>
+      <div class="flex justify-end mb-4">
+        <label class="flex items-center gap-2">
+          <span class="sr-only">Sort by</span>
+          <select id="sort" class="border rounded px-2 py-1">
+            <option value="new">Newest</option>
+            <option value="impact">Highest impact</option>
+            <option value="speed">Fastest launch</option>
+          </select>
+        </label>
       </div>
-      <a class="link inline-flex items-center gap-1" href="/TurboSito/en/cases/consulting-corp-site.html">View details
-        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M13 5l7 7-7 7v-4H4v-6h9V5z"/></svg>
-      </a>
-    </article>
-    <article class="card group hover-lift">
-      <picture>
-        <source srcset="/assets/portfolio/p3.webp" type="image/webp">
-        <img src="/TurboSito/assets/portfolio/p3.jpg" alt="Online store for fashion brand" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
-      </picture>
-      <h3 class="font-semibold text-lg">Online store for fashion brand</h3>
-      <ul class="mt-2 flex flex-wrap gap-2">
-        <li><span class="badge"><!-- [[TAG1_EN]] --><span data-key="TAG1_EN" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG2_EN]] --><span data-key="TAG2_EN" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG3_EN]] --><span data-key="TAG3_EN" class="ph"></span></span></li>
-      </ul>
-      <p class="text-[var(--muted)] text-sm mb-3">Revenue doubled in three months.</p>
-      <div class="mt-3 flex gap-3">
-        <a class="btn btn-outline" href="[[LIVE_URL_EN]]">Live</a>
-        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_EN]]">Code</a>
+      <div id="portfolio-grid" class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3" role="list"></div>
+      <div class="text-center mt-6">
+        <button id="load-more" class="px-4 py-2 border rounded"></button>
       </div>
-      <a class="link inline-flex items-center gap-1" href="/TurboSito/en/cases/fashion-shop.html">View details
-        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M13 5l7 7-7 7v-4H4v-6h9V5z"/></svg>
-      </a>
-    </article>
-    <article class="card group hover-lift">
-      <picture>
-        <source srcset="/assets/portfolio/p4.webp" type="image/webp">
-        <img src="/TurboSito/assets/portfolio/p4.jpg" alt="Portfolio site for photographer" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
-      </picture>
-      <h3 class="font-semibold text-lg">Portfolio site for photographer</h3>
-      <ul class="mt-2 flex flex-wrap gap-2">
-        <li><span class="badge"><!-- [[TAG1_EN]] --><span data-key="TAG1_EN" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG2_EN]] --><span data-key="TAG2_EN" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG3_EN]] --><span data-key="TAG3_EN" class="ph"></span></span></li>
-      </ul>
-      <p class="text-[var(--muted)] text-sm mb-3">More bookings through strong online presence.</p>
-      <div class="mt-3 flex gap-3">
-        <a class="btn btn-outline" href="[[LIVE_URL_EN]]">Live</a>
-        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_EN]]">Code</a>
-      </div>
-      <a class="link inline-flex items-center gap-1" href="/TurboSito/en/cases/photographer-portfolio.html">View details
-        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M13 5l7 7-7 7v-4H4v-6h9V5z"/></svg>
-      </a>
-    </article>
-    <article class="card group hover-lift">
-      <picture>
-        <source srcset="/assets/portfolio/p5.webp" type="image/webp">
-        <img src="/TurboSito/assets/portfolio/p5.jpg" alt="Event microsite" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
-      </picture>
-      <h3 class="font-semibold text-lg">Event microsite</h3>
-      <ul class="mt-2 flex flex-wrap gap-2">
-        <li><span class="badge"><!-- [[TAG1_EN]] --><span data-key="TAG1_EN" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG2_EN]] --><span data-key="TAG2_EN" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG3_EN]] --><span data-key="TAG3_EN" class="ph"></span></span></li>
-      </ul>
-      <p class="text-[var(--muted)] text-sm mb-3">2k registrations in one week.</p>
-      <div class="mt-3 flex gap-3">
-        <a class="btn btn-outline" href="[[LIVE_URL_EN]]">Live</a>
-        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_EN]]">Code</a>
-      </div>
-      <a class="link inline-flex items-center gap-1" href="/TurboSito/en/cases/event-microsite.html">View details
-        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M13 5l7 7-7 7v-4H4v-6h9V5z"/></svg>
-      </a>
-    </article>
-    <article class="card group hover-lift">
-      <picture>
-        <source srcset="/assets/portfolio/p6.webp" type="image/webp">
-        <img src="/TurboSito/assets/portfolio/p6.jpg" alt="Multilingual hotel site" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
-      </picture>
-      <h3 class="font-semibold text-lg">Multilingual hotel site</h3>
-      <ul class="mt-2 flex flex-wrap gap-2">
-        <li><span class="badge"><!-- [[TAG1_EN]] --><span data-key="TAG1_EN" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG2_EN]] --><span data-key="TAG2_EN" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG3_EN]] --><span data-key="TAG3_EN" class="ph"></span></span></li>
-      </ul>
-      <p class="text-[var(--muted)] text-sm mb-3">International bookings up 25%.</p>
-      <div class="mt-3 flex gap-3">
-        <a class="btn btn-outline" href="[[LIVE_URL_EN]]">Live</a>
-        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_EN]]">Code</a>
-      </div>
-      <a class="link inline-flex items-center gap-1" href="/TurboSito/en/cases/hotel-multilingual.html">View details
-        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M13 5l7 7-7 7v-4H4v-6h9V5z"/></svg>
-      </a>
-    </article>
-  </section>
-</main>
-<footer class="border-t border-white/10">
-  <div class="container section text-center text-sm">
-    <p>Contact: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
-    <p class="mt-2">
-      <a href="/TurboSito/en/legal.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Legal</a>
-    </p>
-  </div>
-</footer>
-  <script src="/TurboSito/assets/js/reveal.js" defer></script>
-  <script src="/TurboSito/assets/js/faq.js" defer></script>
-  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
-  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
-  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
-  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
-  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+    </section>
+  </main>
+  <footer class="text-center py-10 text-sm">
+    <p>&copy; TurboSito</p>
+  </footer>
 </body>
 </html>

--- a/en/portfolio/corporate-site.html
+++ b/en/portfolio/corporate-site.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Corporate Site – TurboSito</title>
+  <meta name="description" content="Demo case: corporate website."/>
+  <link rel="canonical" href="https://deine-domain.tld/en/portfolio/corporate-site.html"/>
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio/corporate-site.html"/>
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio/corporate-site.html"/>
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio/corporate-site.html"/>
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/portfolio/corporate-site.html"/>
+  <meta property="og:title" content="Corporate Site – TurboSito"/>
+  <meta property="og:description" content="Demo case: trust and structure."/>
+  <meta property="og:url" content="https://deine-domain.tld/en/portfolio/corporate-site.html"/>
+  <meta property="og:locale" content="en_US"/>
+  <meta name="twitter:card" content="summary"/>
+  <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
+  <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
+  <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
+  <header id="site-header">
+    <div class="container flex items-center justify-between gap-4">
+      <nav class="site-nav">
+        <a class="brand" href="/TurboSito/en/">TurboSito</a>
+        <a href="/TurboSito/en/about.html">About</a>
+        <a href="/TurboSito/en/services.html">Services</a>
+        <a href="/TurboSito/en/portfolio.html">Portfolio</a>
+        <a href="/TurboSito/en/contact.html">Contact</a>
+      </nav>
+      <div class="header-right flex items-center gap-2">
+        <nav class="lang-switch" aria-label="Language switch">
+          <a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a>
+          <a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a>
+          <a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a>
+        </nav>
+        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button>
+      </div>
+    </div>
+  </header>
+  <main id="content" class="max-w-3xl mx-auto px-4 py-12">
+    <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm">← Portfolio</a></nav>
+    <header class="mb-8">
+      <h1 id="case-title" class="text-3xl font-bold mb-2">Corporate Site (Demo)</h1>
+      <p id="case-summary" class="text-lg mb-1">Demo case – trust and structure.</p>
+      <p class="text-sm text-gray-600">Demo case</p>
+    </header>
+    <section class="grid gap-4 md:grid-cols-3 mb-8">
+      <div class="p-4 border rounded text-center"><strong id="kpi-1">48h</strong><br><span class="text-sm">launch time</span></div>
+      <div class="p-4 border rounded text-center"><strong id="kpi-2">≤1.1s LCP</strong><br><span class="text-sm">mobile demo</span></div>
+      <div class="p-4 border rounded text-center"><strong id="kpi-3">Trusted feel</strong><br><span class="text-sm">credibility</span></div>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Challenge</h2>
+      <p>Consulting firm wanted a lean site to build trust.</p>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Approach</h2>
+      <p>Clear services, simple navigation and static export.</p>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Result</h2>
+      <p>Visitors find info fast and get in touch easily.</p>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">48h process</h2>
+      <ol class="list-decimal pl-5 space-y-1">
+        <li>Brief & goals</li>
+        <li>Wireframe</li>
+        <li>Copy draft</li>
+        <li>Build & QA</li>
+        <li>Launch</li>
+      </ol>
+      <div id="stack-tags" class="mt-4 flex flex-wrap gap-2"></div>
+    </section>
+    <section class="mt-8 flex flex-wrap gap-4">
+      <a class="btn btn-primary" href="/TurboSito/en/contact.html">Start project</a>
+      <a class="btn btn-outline" href="../portfolio.html">More examples</a>
+    </section>
+    <script id="ld-json" type="application/ld+json"></script>
+    <script>
+    (async()=>{
+      const slug='corporate-site';
+      const lang=document.documentElement.lang;
+      const res=await fetch(`/TurboSito/assets/data/portfolio.${lang}.json`);
+      const data=await res.json();
+      const item=data.items.find(i=>i.slug===slug);
+      if(!item) return;
+      document.getElementById('case-title').textContent=item.title;
+      document.getElementById('case-summary').textContent=item.summary;
+      document.getElementById('kpi-1').textContent=item.kpis[0];
+      document.getElementById('kpi-2').textContent=item.kpis[1];
+      document.getElementById('kpi-3').textContent=item.kpis[2];
+      document.getElementById('stack-tags').innerHTML=item.tags.map(t=>`<span class="tag">${t}</span>`).join(' ');
+      const ld={"@context":"https://schema.org","@type":"CreativeWork","name":item.title,"about":item.summary,"inLanguage":lang,"timeRequired":"PT"+item.timeToLaunchHours+"H","author":{"@type":"Person","name":"TurboSito"},"offers":{"@type":"Offer","priceCurrency":"EUR","price":"0"},"keywords":item.tags.join(',')};
+      document.getElementById('ld-json').textContent=JSON.stringify(ld);
+    })();
+    </script>
+  </main>
+  <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+</body>
+</html>

--- a/en/portfolio/fashion-shop.html
+++ b/en/portfolio/fashion-shop.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Fashion Shop – TurboSito</title>
+  <meta name="description" content="Demo case: fashion shop."/>
+  <link rel="canonical" href="https://deine-domain.tld/en/portfolio/fashion-shop.html"/>
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio/fashion-shop.html"/>
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio/fashion-shop.html"/>
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio/fashion-shop.html"/>
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/portfolio/fashion-shop.html"/>
+  <meta property="og:title" content="Fashion Shop – TurboSito"/>
+  <meta property="og:description" content="Demo case: clean store with quick checkout."/>
+  <meta property="og:url" content="https://deine-domain.tld/en/portfolio/fashion-shop.html"/>
+  <meta property="og:locale" content="en_US"/>
+  <meta name="twitter:card" content="summary"/>
+  <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
+  <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
+  <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
+  <header id="site-header">
+    <div class="container flex items-center justify-between gap-4">
+      <nav class="site-nav">
+        <a class="brand" href="/TurboSito/en/">TurboSito</a>
+        <a href="/TurboSito/en/about.html">About</a>
+        <a href="/TurboSito/en/services.html">Services</a>
+        <a href="/TurboSito/en/portfolio.html">Portfolio</a>
+        <a href="/TurboSito/en/contact.html">Contact</a>
+      </nav>
+      <div class="header-right flex items-center gap-2">
+        <nav class="lang-switch" aria-label="Language switch">
+          <a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a>
+          <a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a>
+          <a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a>
+        </nav>
+        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button>
+      </div>
+    </div>
+  </header>
+  <main id="content" class="max-w-3xl mx-auto px-4 py-12">
+    <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm">← Portfolio</a></nav>
+    <header class="mb-8">
+      <h1 id="case-title" class="text-3xl font-bold mb-2">Fashion Shop (Demo)</h1>
+      <p id="case-summary" class="text-lg mb-1">Demo store – clean and quick.</p>
+      <p class="text-sm text-gray-600">Demo case</p>
+    </header>
+    <section class="grid gap-4 md:grid-cols-3 mb-8">
+      <div class="p-4 border rounded text-center"><strong id="kpi-1">48h</strong><br><span class="text-sm">launch time</span></div>
+      <div class="p-4 border rounded text-center"><strong id="kpi-2">≤1.1s LCP</strong><br><span class="text-sm">mobile demo</span></div>
+      <div class="p-4 border rounded text-center"><strong id="kpi-3">Fast checkout</strong><br><span class="text-sm">conversion</span></div>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Challenge</h2>
+      <p>Show products quickly with a lightweight stack.</p>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Approach</h2>
+      <p>Simple grid, Snipcart integration and mobile-first design.</p>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Result</h2>
+      <p>Clear structure and fast checkout increase conversions.</p>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">48h process</h2>
+      <ol class="list-decimal pl-5 space-y-1">
+        <li>Brief & goals</li>
+        <li>Wireframe</li>
+        <li>Copy draft</li>
+        <li>Build & QA</li>
+        <li>Launch</li>
+      </ol>
+      <div id="stack-tags" class="mt-4 flex flex-wrap gap-2"></div>
+    </section>
+    <section class="mt-8 flex flex-wrap gap-4">
+      <a class="btn btn-primary" href="/TurboSito/en/contact.html">Start project</a>
+      <a class="btn btn-outline" href="../portfolio.html">More examples</a>
+    </section>
+    <script id="ld-json" type="application/ld+json"></script>
+    <script>
+    (async()=>{
+      const slug='fashion-shop';
+      const lang=document.documentElement.lang;
+      const res=await fetch(`/TurboSito/assets/data/portfolio.${lang}.json`);
+      const data=await res.json();
+      const item=data.items.find(i=>i.slug===slug);
+      if(!item) return;
+      document.getElementById('case-title').textContent=item.title;
+      document.getElementById('case-summary').textContent=item.summary;
+      document.getElementById('kpi-1').textContent=item.kpis[0];
+      document.getElementById('kpi-2').textContent=item.kpis[1];
+      document.getElementById('kpi-3').textContent=item.kpis[2];
+      document.getElementById('stack-tags').innerHTML=item.tags.map(t=>`<span class="tag">${t}</span>`).join(' ');
+      const ld={"@context":"https://schema.org","@type":"CreativeWork","name":item.title,"about":item.summary,"inLanguage":lang,"timeRequired":"PT"+item.timeToLaunchHours+"H","author":{"@type":"Person","name":"TurboSito"},"offers":{"@type":"Offer","priceCurrency":"EUR","price":"0"},"keywords":item.tags.join(',')};
+      document.getElementById('ld-json').textContent=JSON.stringify(ld);
+    })();
+    </script>
+  </main>
+  <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+</body>
+</html>

--- a/en/portfolio/saas-landing.html
+++ b/en/portfolio/saas-landing.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>SaaS Landing – TurboSito</title>
+  <meta name="description" content="Demo case: SaaS landing page."/>
+  <link rel="canonical" href="https://deine-domain.tld/en/portfolio/saas-landing.html"/>
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio/saas-landing.html"/>
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio/saas-landing.html"/>
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio/saas-landing.html"/>
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/portfolio/saas-landing.html"/>
+  <meta property="og:title" content="SaaS Landing – TurboSito"/>
+  <meta property="og:description" content="Demo case: style, structure, speed."/>
+  <meta property="og:url" content="https://deine-domain.tld/en/portfolio/saas-landing.html"/>
+  <meta property="og:locale" content="en_US"/>
+  <meta name="twitter:card" content="summary"/>
+  <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
+  <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
+  <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
+  <header id="site-header">
+    <div class="container flex items-center justify-between gap-4">
+      <nav class="site-nav">
+        <a class="brand" href="/TurboSito/en/">TurboSito</a>
+        <a href="/TurboSito/en/about.html">About</a>
+        <a href="/TurboSito/en/services.html">Services</a>
+        <a href="/TurboSito/en/portfolio.html">Portfolio</a>
+        <a href="/TurboSito/en/contact.html">Contact</a>
+      </nav>
+      <div class="header-right flex items-center gap-2">
+        <nav class="lang-switch" aria-label="Language switch">
+          <a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a>
+          <a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a>
+          <a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a>
+        </nav>
+        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button>
+      </div>
+    </div>
+  </header>
+  <main id="content" class="max-w-3xl mx-auto px-4 py-12">
+    <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm">← Portfolio</a></nav>
+    <header class="mb-8">
+      <h1 id="case-title" class="text-3xl font-bold mb-2">SaaS Landing (Demo)</h1>
+      <p id="case-summary" class="text-lg mb-1">Demo case – style, structure, speed.</p>
+      <p class="text-sm text-gray-600">Demo case</p>
+    </header>
+    <section class="grid gap-4 md:grid-cols-3 mb-8">
+      <div class="p-4 border rounded text-center"><strong id="kpi-1">48h</strong><br><span class="text-sm">launch time</span></div>
+      <div class="p-4 border rounded text-center"><strong id="kpi-2">≤1.1s LCP</strong><br><span class="text-sm">mobile demo</span></div>
+      <div class="p-4 border rounded text-center"><strong id="kpi-3">Clear CTAs</strong><br><span class="text-sm">focused</span></div>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Challenge</h2>
+      <p>Small SaaS needed a clear above-the-fold message for early signups.</p>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Approach</h2>
+      <p>Lean structure, Tailwind styling and mobile-first blocks.</p>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Result</h2>
+      <p>Demo loads fast, highlights value and guides to CTA.</p>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">48h process</h2>
+      <ol class="list-decimal pl-5 space-y-1">
+        <li>Brief & goals</li>
+        <li>Wireframe</li>
+        <li>Copy draft</li>
+        <li>Build & QA</li>
+        <li>Launch</li>
+      </ol>
+      <div id="stack-tags" class="mt-4 flex flex-wrap gap-2"></div>
+    </section>
+    <section class="mt-8 flex flex-wrap gap-4">
+      <a class="btn btn-primary" href="/TurboSito/en/contact.html">Start project</a>
+      <a class="btn btn-outline" href="../portfolio.html">More examples</a>
+    </section>
+    <script id="ld-json" type="application/ld+json"></script>
+    <script>
+    (async()=>{
+      const slug='saas-landing';
+      const lang=document.documentElement.lang;
+      const res=await fetch(`/TurboSito/assets/data/portfolio.${lang}.json`);
+      const data=await res.json();
+      const item=data.items.find(i=>i.slug===slug);
+      if(!item) return;
+      document.getElementById('case-title').textContent=item.title;
+      document.getElementById('case-summary').textContent=item.summary;
+      document.getElementById('kpi-1').textContent=item.kpis[0];
+      document.getElementById('kpi-2').textContent=item.kpis[1];
+      document.getElementById('kpi-3').textContent=item.kpis[2];
+      document.getElementById('stack-tags').innerHTML=item.tags.map(t=>`<span class="tag">${t}</span>`).join(' ');
+      const ld={"@context":"https://schema.org","@type":"CreativeWork","name":item.title,"about":item.summary,"inLanguage":lang,"timeRequired":"PT"+item.timeToLaunchHours+"H","author":{"@type":"Person","name":"TurboSito"},"offers":{"@type":"Offer","priceCurrency":"EUR","price":"0"},"keywords":item.tags.join(',')};
+      document.getElementById('ld-json').textContent=JSON.stringify(ld);
+    })();
+    </script>
+  </main>
+  <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+</body>
+</html>

--- a/it/portfolio.html
+++ b/it/portfolio.html
@@ -4,177 +4,74 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Portfolio – TurboSito</title>
-  <meta name="description" content="Selezione di lavori e progetti recenti.">
-  <link rel="canonical" href="https://deine-domain.tld/it/portfolio.html">
-  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio.html">
-  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio.html">
-  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio.html">
-  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/">
-  <meta property="og:title" content="Portfolio – TurboSito">
-  <meta property="og:description" content="Selezione di lavori e progetti recenti.">
-  <meta property="og:url" content="https://deine-domain.tld/it/portfolio.html">
-  <meta property="og:locale" content="it_IT">
-  <meta property="og:image" content="https://deine-domain.tld/assets/img/og-default.jpg">
-  <meta name="twitter:card" content="summary_large_image">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Outfit:wght@600;800&display=swap" rel="stylesheet">
-<style>
-  :root{--font-sans:"Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Liberation Sans", "Helvetica Neue", sans-serif}
-  .font-display{font-family:"Outfit", var(--font-sans)}
-  body{font-family:var(--font-sans)}
-</style>
-<link rel="stylesheet" href="/TurboSito/assets/css/theme.css">
-<script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+  <meta name="description" content="Case demo – rapidi e chiari."/>
+  <link rel="canonical" href="https://deine-domain.tld/it/portfolio.html"/>
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio.html"/>
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio.html"/>
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio.html"/>
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/portfolio.html"/>
+  <meta property="og:title" content="Portfolio – TurboSito"/>
+  <meta property="og:description" content="Case demo – rapidi e chiari."/>
+  <meta property="og:url" content="https://deine-domain.tld/it/portfolio.html"/>
+  <meta property="og:locale" content="it_IT"/>
+  <meta name="twitter:card" content="summary"/>
+  <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
+  <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
+  <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+  <script defer src="/TurboSito/assets/js/portfolio.js"></script>
 </head>
 <body class="font-sans text-gray-900">
-  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
-<header id="site-header"><div class="container"><div class="header-left"><a class="brand" href="/TurboSito/it/">TurboSito</a><nav class="site-nav"><a href="/TurboSito/it/">Home</a><a href="/TurboSito/it/chi-sono.html">Chi sono</a><a href="/TurboSito/it/servizi.html">Servizi</a><a href="/TurboSito/it/portfolio.html">Portfolio</a><a href="/TurboSito/it/contatti.html">Contatti</a></nav></div><div class="header-right"><nav class="lang-switch" aria-label="Lingue"><a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a><a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a><a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a></nav><button class="theme-toggle" data-theme-toggle aria-label="Cambia tema" aria-pressed="false"><span class="icon sun" aria-hidden="true">☀️</span><span class="icon moon" aria-hidden="true">🌙</span><span>Theme</span></button><button class="hamburger" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button></div></div></header>
-
-<main id="content" class="max-w-6xl mx-auto px-4 py-20">
-  <section class="section-lg mb-12 text-center">
-    <h1 class="font-display text-3xl md:text-4xl font-bold mb-6">Portfolio</h1>
-    <p>Selezione di lavori e progetti recenti.</p>
-  </section>
-  <section class="section grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-    <article class="card group hover-lift case-card" data-slug="landingpage-tech-startup">
-      <a href="/TurboSito/it/cases/landingpage-tech-startup.html">
-        <picture>
-          <source srcset="/assets/portfolio/p1.webp" type="image/webp">
-          <img src="/TurboSito/assets/portfolio/p1.jpg" alt="Landing page per startup tecnologica" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
-        </picture>
-      </a>
-      <h3 class="font-semibold text-lg"><a href="/TurboSito/it/cases/landingpage-tech-startup.html">Landing page per startup tecnologica</a></h3>
-      <ul class="mt-2 flex flex-wrap gap-2">
-        <li><span class="badge"><!-- [[TAG1_IT]] --><span data-key="TAG1_IT" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG2_IT]] --><span data-key="TAG2_IT" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG3_IT]] --><span data-key="TAG3_IT" class="ph"></span></span></li>
-      </ul>
-      <p class="text-[var(--muted)] text-sm mb-3">Iscrizioni aumentate del 40%.</p>
-      <div class="mt-3 flex gap-3 relative z-10">
-        <a class="btn btn-outline" href="[[LIVE_URL_IT]]">Live</a>
-        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_IT]]">Code</a>
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Vai al contenuto</a>
+  <header id="site-header">
+    <div class="container flex items-center justify-between gap-4">
+      <nav class="site-nav">
+        <a class="brand" href="/TurboSito/it/">TurboSito</a>
+        <a href="/TurboSito/it/chi-sono.html">Chi sono</a>
+        <a href="/TurboSito/it/servizi.html">Servizi</a>
+        <a href="/TurboSito/it/portfolio.html">Portfolio</a>
+        <a href="/TurboSito/it/contatti.html">Contatti</a>
+      </nav>
+      <div class="header-right flex items-center gap-2">
+        <nav class="lang-switch" aria-label="Lingue">
+          <a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a>
+          <a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a>
+          <a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a>
+        </nav>
+        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button>
       </div>
-      <a class="btn btn-outline case-cta" href="/TurboSito/it/cases/landingpage-tech-startup.html">Caso studio</a>
-      <a class="stretched-link" href="/TurboSito/it/cases/landingpage-tech-startup.html" aria-label="Caso studio: Landing page per startup tecnologica"></a>
-    </article>
-    <article class="card group hover-lift">
-      <picture>
-        <source srcset="/assets/portfolio/p2.webp" type="image/webp">
-        <img src="/TurboSito/assets/portfolio/p2.jpg" alt="Sito corporate per società di consulenza" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
-      </picture>
-      <h3 class="font-semibold text-lg">Sito corporate per società di consulenza</h3>
-      <ul class="mt-2 flex flex-wrap gap-2">
-        <li><span class="badge"><!-- [[TAG1_IT]] --><span data-key="TAG1_IT" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG2_IT]] --><span data-key="TAG2_IT" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG3_IT]] --><span data-key="TAG3_IT" class="ph"></span></span></li>
-      </ul>
-      <p class="text-[var(--muted)] text-sm mb-3">Lead aumentati del 30%.</p>
-      <div class="mt-3 flex gap-3">
-        <a class="btn btn-outline" href="[[LIVE_URL_IT]]">Live</a>
-        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_IT]]">Code</a>
+    </div>
+  </header>
+  <main id="content" class="max-w-6xl mx-auto px-4 py-12">
+    <section class="text-center mb-10">
+      <h1 class="text-3xl font-bold mb-2">Portfolio</h1>
+      <p>Anteprima onesta del nostro processo.</p>
+    </section>
+    <section>
+      <nav class="flex flex-wrap gap-2 justify-center mb-4" role="tablist">
+        <button data-type="all" aria-pressed="true" class="px-3 py-1 border rounded">Tutti</button>
+        <button data-type="landing" aria-pressed="false" class="px-3 py-1 border rounded">Landingpages</button>
+        <button data-type="corporate" aria-pressed="false" class="px-3 py-1 border rounded">Corporate</button>
+        <button data-type="shop" aria-pressed="false" class="px-3 py-1 border rounded">Shop</button>
+        <button data-type="app" aria-pressed="false" class="px-3 py-1 border rounded">App/Tool</button>
+      </nav>
+      <div class="flex justify-end mb-4">
+        <label class="flex items-center gap-2">
+          <span class="sr-only">Ordina</span>
+          <select id="sort" class="border rounded px-2 py-1">
+            <option value="new">Nuovo → Vecchio</option>
+            <option value="impact">Impatto maggiore</option>
+            <option value="speed">Implementazione più rapida</option>
+          </select>
+        </label>
       </div>
-      <a class="link inline-flex items-center gap-1" href="/TurboSito/it/casi/consulting-corp-site.html">Vedi dettagli
-        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M13 5l7 7-7 7v-4H4v-6h9V5z"/></svg>
-      </a>
-    </article>
-    <article class="card group hover-lift">
-      <picture>
-        <source srcset="/assets/portfolio/p3.webp" type="image/webp">
-        <img src="/TurboSito/assets/portfolio/p3.jpg" alt="E-commerce per brand di moda" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
-      </picture>
-      <h3 class="font-semibold text-lg">E-commerce per brand di moda</h3>
-      <ul class="mt-2 flex flex-wrap gap-2">
-        <li><span class="badge"><!-- [[TAG1_IT]] --><span data-key="TAG1_IT" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG2_IT]] --><span data-key="TAG2_IT" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG3_IT]] --><span data-key="TAG3_IT" class="ph"></span></span></li>
-      </ul>
-      <p class="text-[var(--muted)] text-sm mb-3">Fatturato raddoppiato in tre mesi.</p>
-      <div class="mt-3 flex gap-3">
-        <a class="btn btn-outline" href="[[LIVE_URL_IT]]">Live</a>
-        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_IT]]">Code</a>
+      <div id="portfolio-grid" class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3" role="list"></div>
+      <div class="text-center mt-6">
+        <button id="load-more" class="px-4 py-2 border rounded"></button>
       </div>
-      <a class="link inline-flex items-center gap-1" href="/TurboSito/it/casi/fashion-shop.html">Vedi dettagli
-        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M13 5l7 7-7 7v-4H4v-6h9V5z"/></svg>
-      </a>
-    </article>
-    <article class="card group hover-lift">
-      <picture>
-        <source srcset="/assets/portfolio/p4.webp" type="image/webp">
-        <img src="/TurboSito/assets/portfolio/p4.jpg" alt="Sito portfolio per fotografa" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
-      </picture>
-      <h3 class="font-semibold text-lg">Sito portfolio per fotografa</h3>
-      <ul class="mt-2 flex flex-wrap gap-2">
-        <li><span class="badge"><!-- [[TAG1_IT]] --><span data-key="TAG1_IT" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG2_IT]] --><span data-key="TAG2_IT" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG3_IT]] --><span data-key="TAG3_IT" class="ph"></span></span></li>
-      </ul>
-      <p class="text-[var(--muted)] text-sm mb-3">Più prenotazioni grazie alla presenza online.</p>
-      <div class="mt-3 flex gap-3">
-        <a class="btn btn-outline" href="[[LIVE_URL_IT]]">Live</a>
-        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_IT]]">Code</a>
-      </div>
-      <a class="link inline-flex items-center gap-1" href="/TurboSito/it/casi/photographer-portfolio.html">Vedi dettagli
-        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M13 5l7 7-7 7v-4H4v-6h9V5z"/></svg>
-      </a>
-    </article>
-    <article class="card group hover-lift">
-      <picture>
-        <source srcset="/assets/portfolio/p5.webp" type="image/webp">
-        <img src="/TurboSito/assets/portfolio/p5.jpg" alt="Microsito per evento" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
-      </picture>
-      <h3 class="font-semibold text-lg">Microsito per evento</h3>
-      <ul class="mt-2 flex flex-wrap gap-2">
-        <li><span class="badge"><!-- [[TAG1_IT]] --><span data-key="TAG1_IT" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG2_IT]] --><span data-key="TAG2_IT" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG3_IT]] --><span data-key="TAG3_IT" class="ph"></span></span></li>
-      </ul>
-      <p class="text-[var(--muted)] text-sm mb-3">2.000 registrazioni in una settimana.</p>
-      <div class="mt-3 flex gap-3">
-        <a class="btn btn-outline" href="[[LIVE_URL_IT]]">Live</a>
-        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_IT]]">Code</a>
-      </div>
-      <a class="link inline-flex items-center gap-1" href="/TurboSito/it/casi/event-microsite.html">Vedi dettagli
-        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M13 5l7 7-7 7v-4H4v-6h9V5z"/></svg>
-      </a>
-    </article>
-    <article class="card group hover-lift">
-      <picture>
-        <source srcset="/assets/portfolio/p6.webp" type="image/webp">
-        <img src="/TurboSito/assets/portfolio/p6.jpg" alt="Sito multilingue per hotel" width="600" height="400" loading="lazy" decoding="async" class="w-full h-48 object-cover mb-3 transition-transform duration-200 group-hover:scale-[1.02]">
-      </picture>
-      <h3 class="font-semibold text-lg">Sito multilingue per hotel</h3>
-      <ul class="mt-2 flex flex-wrap gap-2">
-        <li><span class="badge"><!-- [[TAG1_IT]] --><span data-key="TAG1_IT" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG2_IT]] --><span data-key="TAG2_IT" class="ph"></span></span></li>
-        <li><span class="badge"><!-- [[TAG3_IT]] --><span data-key="TAG3_IT" class="ph"></span></span></li>
-      </ul>
-      <p class="text-[var(--muted)] text-sm mb-3">Prenotazioni internazionali +25%.</p>
-      <div class="mt-3 flex gap-3">
-        <a class="btn btn-outline" href="[[LIVE_URL_IT]]">Live</a>
-        <a class="link inline-flex items-center gap-1" href="[[CODE_URL_IT]]">Code</a>
-      </div>
-      <a class="link inline-flex items-center gap-1" href="/TurboSito/it/casi/hotel-multilingual.html">Vedi dettagli
-        <svg aria-hidden="true" width="16" height="16" viewBox="0 0 24 24"><path fill="currentColor" d="M13 5l7 7-7 7v-4H4v-6h9V5z"/></svg>
-      </a>
-    </article>
-  </section>
-</main>
-<footer class="border-t border-white/10">
-  <div class="container section text-center text-sm">
-    <p>Contatto: <a href="mailto:info@deine-domain.tld" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">info@deine-domain.tld</a></p>
-    <p class="mt-2">
-      <a href="/TurboSito/it/note-legali.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Note legali</a>
-      <span class="mx-2">·</span>
-      <a href="/TurboSito/it/privacy.html" class="underline focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 rounded">Privacy</a>
-    </p>
-  </div>
-</footer>
-  <script src="/TurboSito/assets/js/reveal.js" defer></script>
-  <script src="/TurboSito/assets/js/faq.js" defer></script>
-  <script src="/TurboSito/assets/js/nav-active.js" defer></script>
-  <script src="/TurboSito/assets/js/lang-switch.js" defer></script>
-  <script src="/TurboSito/assets/js/scroll-header.js" defer></script>
-  <script src="/TurboSito/assets/js/theme-toggle.js" defer></script>
-  <script src="/TurboSito/assets/js/mobile-nav.js" defer></script>
+    </section>
+  </main>
+  <footer class="text-center py-10 text-sm">
+    <p>&copy; TurboSito</p>
+  </footer>
 </body>
 </html>

--- a/it/portfolio/corporate-site.html
+++ b/it/portfolio/corporate-site.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="it" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Sito Corporate – TurboSito</title>
+  <meta name="description" content="Caso demo: sito corporate."/>
+  <link rel="canonical" href="https://deine-domain.tld/it/portfolio/corporate-site.html"/>
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio/corporate-site.html"/>
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio/corporate-site.html"/>
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio/corporate-site.html"/>
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/portfolio/corporate-site.html"/>
+  <meta property="og:title" content="Sito Corporate – TurboSito"/>
+  <meta property="og:description" content="Caso demo: fiducia e struttura."/>
+  <meta property="og:url" content="https://deine-domain.tld/it/portfolio/corporate-site.html"/>
+  <meta property="og:locale" content="it_IT"/>
+  <meta name="twitter:card" content="summary"/>
+  <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
+  <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
+  <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Vai al contenuto</a>
+  <header id="site-header">
+    <div class="container flex items-center justify-between gap-4">
+      <nav class="site-nav">
+        <a class="brand" href="/TurboSito/it/">TurboSito</a>
+        <a href="/TurboSito/it/chi-sono.html">Chi sono</a>
+        <a href="/TurboSito/it/servizi.html">Servizi</a>
+        <a href="/TurboSito/it/portfolio.html">Portfolio</a>
+        <a href="/TurboSito/it/contatti.html">Contatti</a>
+      </nav>
+      <div class="header-right flex items-center gap-2">
+        <nav class="lang-switch" aria-label="Lingue">
+          <a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a>
+          <a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a>
+          <a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a>
+        </nav>
+        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button>
+      </div>
+    </div>
+  </header>
+  <main id="content" class="max-w-3xl mx-auto px-4 py-12">
+    <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm">← Portfolio</a></nav>
+    <header class="mb-8">
+      <h1 id="case-title" class="text-3xl font-bold mb-2">Sito Corporate (Demo)</h1>
+      <p id="case-summary" class="text-lg mb-1">Caso demo – fiducia e struttura.</p>
+      <p class="text-sm text-gray-600">Caso demo</p>
+    </header>
+    <section class="grid gap-4 md:grid-cols-3 mb-8">
+      <div class="p-4 border rounded text-center"><strong id="kpi-1">48h</strong><br><span class="text-sm">tempo di lancio</span></div>
+      <div class="p-4 border rounded text-center"><strong id="kpi-2">≤1.1s LCP</strong><br><span class="text-sm">mobile, demo</span></div>
+      <div class="p-4 border rounded text-center"><strong id="kpi-3">Fiducia</strong><br><span class="text-sm">credibilità</span></div>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Situazione iniziale</h2>
+      <p>Studio di consulenza voleva un sito snello per costruire fiducia.</p>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Approccio</h2>
+      <p>Servizi chiari, navigazione semplice ed export statico.</p>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Risultato</h2>
+      <p>I visitatori trovano info rapidamente e contattano.</p>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Processo 48h</h2>
+      <ol class="list-decimal pl-5 space-y-1">
+        <li>Brief & obiettivi</li>
+        <li>Wireframe</li>
+        <li>Bozza copy</li>
+        <li>Build & QA</li>
+        <li>Lancio</li>
+      </ol>
+      <div id="stack-tags" class="mt-4 flex flex-wrap gap-2"></div>
+    </section>
+    <section class="mt-8 flex flex-wrap gap-4">
+      <a class="btn btn-primary" href="/TurboSito/it/contatti.html">Avvia progetto</a>
+      <a class="btn btn-outline" href="../portfolio.html">Altri esempi</a>
+    </section>
+    <script id="ld-json" type="application/ld+json"></script>
+    <script>
+    (async()=>{
+      const slug='corporate-site';
+      const lang=document.documentElement.lang;
+      const res=await fetch(`/TurboSito/assets/data/portfolio.${lang}.json`);
+      const data=await res.json();
+      const item=data.items.find(i=>i.slug===slug);
+      if(!item) return;
+      document.getElementById('case-title').textContent=item.title;
+      document.getElementById('case-summary').textContent=item.summary;
+      document.getElementById('kpi-1').textContent=item.kpis[0];
+      document.getElementById('kpi-2').textContent=item.kpis[1];
+      document.getElementById('kpi-3').textContent=item.kpis[2];
+      document.getElementById('stack-tags').innerHTML=item.tags.map(t=>`<span class="tag">${t}</span>`).join(' ');
+      const ld={"@context":"https://schema.org","@type":"CreativeWork","name":item.title,"about":item.summary,"inLanguage":lang,"timeRequired":"PT"+item.timeToLaunchHours+"H","author":{"@type":"Person","name":"TurboSito"},"offers":{"@type":"Offer","priceCurrency":"EUR","price":"0"},"keywords":item.tags.join(',')};
+      document.getElementById('ld-json').textContent=JSON.stringify(ld);
+    })();
+    </script>
+  </main>
+  <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+</body>
+</html>

--- a/it/portfolio/fashion-shop.html
+++ b/it/portfolio/fashion-shop.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="it" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Shop Moda – TurboSito</title>
+  <meta name="description" content="Caso demo: shop moda."/>
+  <link rel="canonical" href="https://deine-domain.tld/it/portfolio/fashion-shop.html"/>
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio/fashion-shop.html"/>
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio/fashion-shop.html"/>
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio/fashion-shop.html"/>
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/portfolio/fashion-shop.html"/>
+  <meta property="og:title" content="Shop Moda – TurboSito"/>
+  <meta property="og:description" content="Caso demo: shop pulito con checkout veloce."/>
+  <meta property="og:url" content="https://deine-domain.tld/it/portfolio/fashion-shop.html"/>
+  <meta property="og:locale" content="it_IT"/>
+  <meta name="twitter:card" content="summary"/>
+  <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
+  <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
+  <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Vai al contenuto</a>
+  <header id="site-header">
+    <div class="container flex items-center justify-between gap-4">
+      <nav class="site-nav">
+        <a class="brand" href="/TurboSito/it/">TurboSito</a>
+        <a href="/TurboSito/it/chi-sono.html">Chi sono</a>
+        <a href="/TurboSito/it/servizi.html">Servizi</a>
+        <a href="/TurboSito/it/portfolio.html">Portfolio</a>
+        <a href="/TurboSito/it/contatti.html">Contatti</a>
+      </nav>
+      <div class="header-right flex items-center gap-2">
+        <nav class="lang-switch" aria-label="Lingue">
+          <a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a>
+          <a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a>
+          <a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a>
+        </nav>
+        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button>
+      </div>
+    </div>
+  </header>
+  <main id="content" class="max-w-3xl mx-auto px-4 py-12">
+    <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm">← Portfolio</a></nav>
+    <header class="mb-8">
+      <h1 id="case-title" class="text-3xl font-bold mb-2">Shop Moda (Demo)</h1>
+      <p id="case-summary" class="text-lg mb-1">Negozio demo – pulito e rapido.</p>
+      <p class="text-sm text-gray-600">Caso demo</p>
+    </header>
+    <section class="grid gap-4 md:grid-cols-3 mb-8">
+      <div class="p-4 border rounded text-center"><strong id="kpi-1">48h</strong><br><span class="text-sm">tempo di lancio</span></div>
+      <div class="p-4 border rounded text-center"><strong id="kpi-2">≤1.1s LCP</strong><br><span class="text-sm">mobile, demo</span></div>
+      <div class="p-4 border rounded text-center"><strong id="kpi-3">Checkout veloce</strong><br><span class="text-sm">conversione</span></div>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Situazione iniziale</h2>
+      <p>Mostrare prodotti rapidamente con stack leggero.</p>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Approccio</h2>
+      <p>Grid semplice, integrazione Snipcart e design mobile-first.</p>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Risultato</h2>
+      <p>Struttura chiara e checkout rapido aumentano le conversioni.</p>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Processo 48h</h2>
+      <ol class="list-decimal pl-5 space-y-1">
+        <li>Brief & obiettivi</li>
+        <li>Wireframe</li>
+        <li>Bozza copy</li>
+        <li>Build & QA</li>
+        <li>Lancio</li>
+      </ol>
+      <div id="stack-tags" class="mt-4 flex flex-wrap gap-2"></div>
+    </section>
+    <section class="mt-8 flex flex-wrap gap-4">
+      <a class="btn btn-primary" href="/TurboSito/it/contatti.html">Avvia progetto</a>
+      <a class="btn btn-outline" href="../portfolio.html">Altri esempi</a>
+    </section>
+    <script id="ld-json" type="application/ld+json"></script>
+    <script>
+    (async()=>{
+      const slug='fashion-shop';
+      const lang=document.documentElement.lang;
+      const res=await fetch(`/TurboSito/assets/data/portfolio.${lang}.json`);
+      const data=await res.json();
+      const item=data.items.find(i=>i.slug===slug);
+      if(!item) return;
+      document.getElementById('case-title').textContent=item.title;
+      document.getElementById('case-summary').textContent=item.summary;
+      document.getElementById('kpi-1').textContent=item.kpis[0];
+      document.getElementById('kpi-2').textContent=item.kpis[1];
+      document.getElementById('kpi-3').textContent=item.kpis[2];
+      document.getElementById('stack-tags').innerHTML=item.tags.map(t=>`<span class="tag">${t}</span>`).join(' ');
+      const ld={"@context":"https://schema.org","@type":"CreativeWork","name":item.title,"about":item.summary,"inLanguage":lang,"timeRequired":"PT"+item.timeToLaunchHours+"H","author":{"@type":"Person","name":"TurboSito"},"offers":{"@type":"Offer","priceCurrency":"EUR","price":"0"},"keywords":item.tags.join(',')};
+      document.getElementById('ld-json').textContent=JSON.stringify(ld);
+    })();
+    </script>
+  </main>
+  <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+</body>
+</html>

--- a/it/portfolio/saas-landing.html
+++ b/it/portfolio/saas-landing.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="it" class="scroll-smooth">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Landing SaaS – TurboSito</title>
+  <meta name="description" content="Caso demo: landing SaaS."/>
+  <link rel="canonical" href="https://deine-domain.tld/it/portfolio/saas-landing.html"/>
+  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio/saas-landing.html"/>
+  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio/saas-landing.html"/>
+  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio/saas-landing.html"/>
+  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/portfolio/saas-landing.html"/>
+  <meta property="og:title" content="Landing SaaS – TurboSito"/>
+  <meta property="og:description" content="Caso demo: stile, struttura, velocità."/>
+  <meta property="og:url" content="https://deine-domain.tld/it/portfolio/saas-landing.html"/>
+  <meta property="og:locale" content="it_IT"/>
+  <meta name="twitter:card" content="summary"/>
+  <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
+  <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
+  <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+</head>
+<body class="font-sans text-gray-900">
+  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Vai al contenuto</a>
+  <header id="site-header">
+    <div class="container flex items-center justify-between gap-4">
+      <nav class="site-nav">
+        <a class="brand" href="/TurboSito/it/">TurboSito</a>
+        <a href="/TurboSito/it/chi-sono.html">Chi sono</a>
+        <a href="/TurboSito/it/servizi.html">Servizi</a>
+        <a href="/TurboSito/it/portfolio.html">Portfolio</a>
+        <a href="/TurboSito/it/contatti.html">Contatti</a>
+      </nav>
+      <div class="header-right flex items-center gap-2">
+        <nav class="lang-switch" aria-label="Lingue">
+          <a href="/TurboSito/de/" data-lang="de" hreflang="de">DE</a>
+          <a href="/TurboSito/en/" data-lang="en" hreflang="en">EN</a>
+          <a href="/TurboSito/it/" data-lang="it" hreflang="it">IT</a>
+        </nav>
+        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button>
+      </div>
+    </div>
+  </header>
+  <main id="content" class="max-w-3xl mx-auto px-4 py-12">
+    <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm">← Portfolio</a></nav>
+    <header class="mb-8">
+      <h1 id="case-title" class="text-3xl font-bold mb-2">Landing SaaS (Demo)</h1>
+      <p id="case-summary" class="text-lg mb-1">Caso demo – stile, struttura, velocità.</p>
+      <p class="text-sm text-gray-600">Caso demo</p>
+    </header>
+    <section class="grid gap-4 md:grid-cols-3 mb-8">
+      <div class="p-4 border rounded text-center"><strong id="kpi-1">48h</strong><br><span class="text-sm">tempo di lancio</span></div>
+      <div class="p-4 border rounded text-center"><strong id="kpi-2">≤1.1s LCP</strong><br><span class="text-sm">mobile, demo</span></div>
+      <div class="p-4 border rounded text-center"><strong id="kpi-3">CTA chiare</strong><br><span class="text-sm">foco</span></div>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Situazione iniziale</h2>
+      <p>Piccola SaaS necessitava di un messaggio chiaro per le prime iscrizioni.</p>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Approccio</h2>
+      <p>Struttura snella, styling Tailwind e blocchi mobile-first.</p>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Risultato</h2>
+      <p>La demo è veloce, mette in evidenza il valore e guida alla CTA.</p>
+    </section>
+    <section class="mb-6">
+      <h2 class="text-2xl font-semibold mb-2">Processo 48h</h2>
+      <ol class="list-decimal pl-5 space-y-1">
+        <li>Brief & obiettivi</li>
+        <li>Wireframe</li>
+        <li>Bozza copy</li>
+        <li>Build & QA</li>
+        <li>Lancio</li>
+      </ol>
+      <div id="stack-tags" class="mt-4 flex flex-wrap gap-2"></div>
+    </section>
+    <section class="mt-8 flex flex-wrap gap-4">
+      <a class="btn btn-primary" href="/TurboSito/it/contatti.html">Avvia progetto</a>
+      <a class="btn btn-outline" href="../portfolio.html">Altri esempi</a>
+    </section>
+    <script id="ld-json" type="application/ld+json"></script>
+    <script>
+    (async()=>{
+      const slug='saas-landing';
+      const lang=document.documentElement.lang;
+      const res=await fetch(`/TurboSito/assets/data/portfolio.${lang}.json`);
+      const data=await res.json();
+      const item=data.items.find(i=>i.slug===slug);
+      if(!item) return;
+      document.getElementById('case-title').textContent=item.title;
+      document.getElementById('case-summary').textContent=item.summary;
+      document.getElementById('kpi-1').textContent=item.kpis[0];
+      document.getElementById('kpi-2').textContent=item.kpis[1];
+      document.getElementById('kpi-3').textContent=item.kpis[2];
+      document.getElementById('stack-tags').innerHTML=item.tags.map(t=>`<span class="tag">${t}</span>`).join(' ');
+      const ld={"@context":"https://schema.org","@type":"CreativeWork","name":item.title,"about":item.summary,"inLanguage":lang,"timeRequired":"PT"+item.timeToLaunchHours+"H","author":{"@type":"Person","name":"TurboSito"},"offers":{"@type":"Offer","priceCurrency":"EUR","price":"0"},"keywords":item.tags.join(',')};
+      document.getElementById('ld-json').textContent=JSON.stringify(ld);
+    })();
+    </script>
+  </main>
+  <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add language-specific portfolio data and renderer
- implement filterable portfolio overview with progressive loading
- add case study detail pages with JSON-LD and navigation

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bedb57532c833296541a396c4eaccf