### PR TITLE
feat: add theme switch and refine portfolio UX

### DIFF
--- a/assets/css/portfolio.css
+++ b/assets/css/portfolio.css
@@ -1,6 +1,18 @@
 .ph-media{width:100%;aspect-ratio:16/9;background:linear-gradient(135deg,#e5e7eb,#d1d5db);}
+html[data-theme="dark"] .ph-media{background:linear-gradient(135deg,#374151,#1f2937);}
 .badge{display:inline-block;background:#e5e7eb;color:#374151;font-size:.75rem;padding:0.125rem 0.5rem;border-radius:0.25rem;}
-.tag{display:inline-block;background:#f3f4f6;color:#374151;font-size:.75rem;padding:0.125rem 0.5rem;border-radius:9999px;}
+html[data-theme="dark"] .badge{background:#374151;color:#f3f4f6;}
+.tag-pill{display:inline-block;font-size:.75rem;padding:0.125rem 0.5rem;border-radius:9999px;line-height:1.25rem;background:#f3f4f6;color:#374151;}
+html[data-theme="dark"] .tag-pill{background:#374151;color:#f3f4f6;}
+.highlight-box{background:#f3f4f6;color:#374151;border-radius:0.75rem;padding:1rem;display:flex;align-items:center;gap:0.5rem;}
+html[data-theme="dark"] .highlight-box{background:#1f2937;color:#f3f4f6;}
+.hover-lift{transition:transform .2s ease,box-shadow .2s ease}
+.hover-lift:hover{transform:translateY(-2px);box-shadow:0 4px 12px rgba(0,0,0,.15)}
+.kpi-row{color:#374151}
+html[data-theme="dark"] .kpi-row{color:#f3f4f6}
+[role="tab"]{border-color:#d1d5db}
+html[data-theme="dark"] [role="tab"]{border-color:#374151}
+[role="tab"][aria-selected="true"]{background:#F97316;color:#fff}
 .case-card{content-visibility:auto;contain-intrinsic-size:200px;}
 .case-card:focus-within{outline:2px solid #000;outline-offset:2px;}
 .skeleton{background:linear-gradient(90deg,#e5e7eb,#f3f4f6,#e5e7eb);background-size:200% 100%;animation:sk 1.2s infinite linear;}
@@ -8,4 +20,5 @@
 :focus-visible{outline:2px solid #000;outline-offset:2px}
 @media (prefers-reduced-motion: reduce){
   *{transition:none!important;animation:none!important}
+  .hover-lift:hover{transform:none;box-shadow:none}
 }

--- a/assets/js/portfolio.js
+++ b/assets/js/portfolio.js
@@ -79,6 +79,10 @@
     if(btn){
       const current=document.querySelector(`#sort-menu [data-sort="${state.sort}"]`);
       if(current) btn.textContent=current.textContent;
+      document.querySelectorAll('#sort-menu [data-sort]').forEach(opt=>{
+        const sel=opt.getAttribute('data-sort')===state.sort;
+        opt.setAttribute('aria-selected', sel);
+      });
     }
   }
 
@@ -107,7 +111,7 @@
     container.innerHTML='';
     for(let i=0;i<n;i++){
       const article=document.createElement('article');
-      article.className='case-card border p-4 rounded skeleton';
+      article.className='case-card border p-4 rounded skeleton dark:border-gray-700';
       container.appendChild(article);
     }
   }
@@ -126,15 +130,19 @@
     empty.hidden=true;
     visibleItems.forEach(item=>{
       const article=document.createElement('article');
-      article.className='case-card border p-4 rounded focus-within:ring outline-none';
+      article.className='case-card border p-4 rounded focus-within:ring outline-none hover-lift bg-white dark:bg-gray-800 dark:border-gray-700';
       article.setAttribute('role','listitem');
       article.setAttribute('aria-label',item.title);
       article.innerHTML=`
-        <div class="ph-media mb-3" role="img" aria-label="Placeholder"></div>
+        <div class="ph-media mb-3 rounded" role="img" aria-label="Placeholder"></div>
         <span class="badge mb-2">Demo</span>
         <h3 class="font-semibold mb-1">${item.title}</h3>
-        <ul class="flex flex-wrap gap-1 text-sm mb-2">${item.tags.slice(0,3).map(t=>`<li class="tag">${t}</li>`).join('')}</ul>
-        <p class="text-sm mb-3">⏱ ${item.kpis[0]} • ⚡ ${item.kpis[1]} • ✅ ${item.kpis[2]}</p>
+        <ul class="flex flex-wrap gap-1 text-sm mb-2">${item.tags.slice(0,3).map(t=>`<li class="tag-pill">${t}</li>`).join('')}</ul>
+        <p class="kpi-row text-sm mb-3 flex flex-wrap gap-3">
+          <span class="flex items-center gap-1"><span aria-hidden="true">⏱</span>${item.kpis[0]}</span>
+          <span class="flex items-center gap-1"><span aria-hidden="true">⚡</span>${item.kpis[1]}</span>
+          <span class="flex items-center gap-1"><span aria-hidden="true">✅</span>${item.kpis[2]}</span>
+        </p>
         <div class="flex flex-wrap gap-3">
           <a class="btn btn-primary" aria-label="${t.view}: ${item.title}" href="${item.caseUrl}">${t.view}</a>
           <a class="link" aria-label="${t.demo}: ${item.title}" href="${item.demoUrl}" target="_blank" rel="noopener">${t.demo}</a>

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1,0 +1,20 @@
+(() => {
+  const KEY='site-theme';
+  const root=document.documentElement;
+  const prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const saved=localStorage.getItem(KEY);
+  const initial = saved || (prefersDark ? 'dark' : 'light');
+  const apply = (mode) => {
+    root.setAttribute('data-theme', mode);
+    localStorage.setItem(KEY, mode);
+    const btn=document.querySelector('[data-theme-toggle]');
+    if (btn) btn.setAttribute('aria-pressed', mode==='dark' ? 'true' : 'false');
+  };
+  apply(initial);
+  document.addEventListener('click', (e) => {
+    const btn = e.target.closest('[data-theme-toggle]');
+    if (!btn) return;
+    const next = (root.getAttribute('data-theme')==='dark') ? 'light' : 'dark';
+    apply(next);
+  });
+})();

--- a/de/portfolio.html
+++ b/de/portfolio.html
@@ -18,6 +18,7 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+  <script src="/TurboSito/assets/js/theme.js" defer></script>
   <script defer src="/TurboSito/assets/js/portfolio.js"></script>
 </head>
 <body class="font-sans text-gray-900">
@@ -38,6 +39,11 @@
           <a href="/TurboSito/it/portfolio.html" data-lang="it" hreflang="it">IT</a>
         </nav>
         <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button>
+        <button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false">
+          <span class="icon sun" aria-hidden="true">☀️</span>
+          <span class="icon moon" aria-hidden="true">🌙</span>
+          <span>Theme</span>
+        </button>
       </div>
     </div>
   </header>
@@ -49,24 +55,24 @@
     <div aria-live="polite" class="sr-only" id="live-status"></div>
     <section>
       <nav class="flex flex-wrap gap-2 justify-center mb-4" role="tablist">
-        <button data-type="all" role="tab" aria-controls="portfolio-grid" aria-selected="true" tabindex="0" class="px-3 py-1 border rounded">Alle</button>
-        <button data-type="landing" role="tab" aria-controls="portfolio-grid" aria-selected="false" tabindex="-1" class="px-3 py-1 border rounded">Landingpages</button>
-        <button data-type="corporate" role="tab" aria-controls="portfolio-grid" aria-selected="false" tabindex="-1" class="px-3 py-1 border rounded">Corporate</button>
-        <button data-type="shop" role="tab" aria-controls="portfolio-grid" aria-selected="false" tabindex="-1" class="px-3 py-1 border rounded">Shop</button>
-        <button data-type="app" role="tab" aria-controls="portfolio-grid" aria-selected="false" tabindex="-1" class="px-3 py-1 border rounded">App/Tool</button>
+        <button data-type="all" role="tab" aria-controls="portfolio-grid" aria-selected="true" tabindex="0" class="px-3 py-1 border rounded dark:border-gray-700">Alle</button>
+        <button data-type="landing" role="tab" aria-controls="portfolio-grid" aria-selected="false" tabindex="-1" class="px-3 py-1 border rounded dark:border-gray-700">Landingpages</button>
+        <button data-type="corporate" role="tab" aria-controls="portfolio-grid" aria-selected="false" tabindex="-1" class="px-3 py-1 border rounded dark:border-gray-700">Corporate</button>
+        <button data-type="shop" role="tab" aria-controls="portfolio-grid" aria-selected="false" tabindex="-1" class="px-3 py-1 border rounded dark:border-gray-700">Shop</button>
+        <button data-type="app" role="tab" aria-controls="portfolio-grid" aria-selected="false" tabindex="-1" class="px-3 py-1 border rounded dark:border-gray-700">App/Tool</button>
       </nav>
-      <div class="flex justify-end mb-4">
-        <div class="relative">
-          <button id="sort-button" class="px-2 py-1 border rounded" aria-haspopup="listbox" aria-expanded="false">Neu → Alt</button>
-          <ul id="sort-menu" class="absolute right-0 mt-1 border bg-white rounded shadow-md hidden" role="listbox" tabindex="-1">
-            <li data-sort="new" role="option" tabindex="-1" class="px-3 py-1 cursor-pointer">Neu → Alt</li>
-            <li data-sort="impact" role="option" tabindex="-1" class="px-3 py-1 cursor-pointer">Höchste Wirkung</li>
-            <li data-sort="speed" role="option" tabindex="-1" class="px-3 py-1 cursor-pointer">Schnellste Umsetzung</li>
+      <div class="mb-4">
+        <div class="relative inline-block">
+          <button id="sort-button" class="px-2 py-1 border rounded dark:border-gray-700" aria-haspopup="listbox" aria-expanded="false">Neu → Alt</button>
+          <ul id="sort-menu" class="absolute left-0 mt-1 border bg-white dark:bg-gray-800 rounded shadow-md hidden" role="listbox" tabindex="-1">
+            <li data-sort="new" role="option" tabindex="-1" class="px-3 py-1 cursor-pointer" aria-selected="false">Neu → Alt</li>
+            <li data-sort="impact" role="option" tabindex="-1" class="px-3 py-1 cursor-pointer" aria-selected="false">Höchste Wirkung</li>
+            <li data-sort="speed" role="option" tabindex="-1" class="px-3 py-1 cursor-pointer" aria-selected="false">Schnellste Umsetzung</li>
           </ul>
         </div>
       </div>
       <div id="portfolio-grid" class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3" role="list"></div>
-      <div id="empty-state" class="hidden text-center p-4 border rounded">
+      <div id="empty-state" class="text-center p-4 border rounded" hidden>
         <p>Keine Projekte gefunden.</p>
         <button id="reset-filters" class="btn btn-primary mt-2">Filter zurücksetzen</button>
       </div>

--- a/de/portfolio/corporate-site.html
+++ b/de/portfolio/corporate-site.html
@@ -18,6 +18,7 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+  <script src="/TurboSito/assets/js/theme.js" defer></script>
 </head>
 <body class="font-sans text-gray-900">
   <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Zum Inhalt springen</a>
@@ -37,36 +38,41 @@
           <a href="/TurboSito/it/portfolio/corporate-site.html" data-lang="it" hreflang="it">IT</a>
         </nav>
         <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button>
+        <button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false">
+          <span class="icon sun" aria-hidden="true">☀️</span>
+          <span class="icon moon" aria-hidden="true">🌙</span>
+          <span>Theme</span>
+        </button>
       </div>
     </div>
   </header>
   <main id="content" class="max-w-3xl mx-auto px-4 py-12">
-    <nav aria-label="Brotkrumen" class="mb-4"><a href="../portfolio.html" class="text-sm">← Portfolio</a></nav>
+    <nav aria-label="Brotkrumen" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
       <h1 id="case-title" class="text-3xl font-bold mb-2">Corporate-Site (Demo)</h1>
       <p id="case-summary" class="text-lg mb-1">Demo-Case – Vertrauen und Struktur.</p>
       <p class="text-sm text-gray-600">Demo-Case</p>
     </header>
     <section class="grid gap-4 md:grid-cols-3 mb-8">
-      <div class="p-4 border rounded text-center"><strong id="kpi-1">48h</strong><br><span class="text-sm">Umsetzungszeit</span></div>
-      <div class="p-4 border rounded text-center"><strong id="kpi-2">≤1.1s LCP</strong><br><span class="text-sm">mobil, Demo</span></div>
-      <div class="p-4 border rounded text-center"><strong id="kpi-3">Seriöse Wirkung</strong><br><span class="text-sm">Glaubwürdigkeit</span></div>
+      <div class="highlight-box"><strong id="kpi-1">48h</strong><span class="text-sm">Umsetzungszeit</span></div>
+      <div class="highlight-box"><strong id="kpi-2">≤1.1s LCP</strong><span class="text-sm">mobil, Demo</span></div>
+      <div class="highlight-box"><strong id="kpi-3">Seriöse Wirkung</strong><span class="text-sm">Glaubwürdigkeit</span></div>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Ausgangslage</h2>
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Ausgangslage</h2>
       <p>Beratungsfirma wollte eine schlanke Seite, die Vertrauen schafft.</p>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Ansatz</h2>
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Ansatz</h2>
       <p>Klare Leistungen, einfache Navigation und statischer Export.</p>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Ergebnis</h2>
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Ergebnis</h2>
       <p>Besucher finden Infos schnell und nehmen Kontakt auf.</p>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Vorgehen in 48h</h2>
-      <ol class="list-decimal pl-5 space-y-1">
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Vorgehen in 48h</h2>
+      <ol class="list-decimal pl-6 space-y-1">
         <li>Briefing & Ziele</li>
         <li>Wireframe</li>
         <li>Copy-Entwurf</li>
@@ -75,7 +81,7 @@
       </ol>
       <div id="stack-tags" class="mt-4 flex flex-wrap gap-2"></div>
     </section>
-    <section class="mt-8 flex flex-wrap gap-4">
+    <section class="flex justify-center gap-4 mt-8">
       <a class="btn btn-primary" href="/TurboSito/de/kontakt.html">Projekt starten</a>
       <a class="btn btn-outline" href="../portfolio.html">Weitere Beispiele</a>
     </section>
@@ -94,7 +100,7 @@
         document.getElementById('kpi-1').textContent=item.kpis[0];
         document.getElementById('kpi-2').textContent=item.kpis[1];
         document.getElementById('kpi-3').textContent=item.kpis[2];
-        document.getElementById('stack-tags').innerHTML=item.tags.map(t=>`<span class="tag">${t}</span>`).join(' ');
+        document.getElementById('stack-tags').innerHTML=item.tags.map(t=>`<span class="tag-pill">${t}</span>`).join(' ');
         const ld=[{
           "@context":"https://schema.org",
           "@type":"CreativeWork",

--- a/de/portfolio/fashion-shop.html
+++ b/de/portfolio/fashion-shop.html
@@ -18,6 +18,7 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+  <script src="/TurboSito/assets/js/theme.js" defer></script>
 </head>
 <body class="font-sans text-gray-900">
   <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Zum Inhalt springen</a>
@@ -37,36 +38,41 @@
           <a href="/TurboSito/it/portfolio/fashion-shop.html" data-lang="it" hreflang="it">IT</a>
         </nav>
         <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button>
+        <button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false">
+          <span class="icon sun" aria-hidden="true">☀️</span>
+          <span class="icon moon" aria-hidden="true">🌙</span>
+          <span>Theme</span>
+        </button>
       </div>
     </div>
   </header>
   <main id="content" class="max-w-3xl mx-auto px-4 py-12">
-    <nav aria-label="Brotkrumen" class="mb-4"><a href="../portfolio.html" class="text-sm">← Portfolio</a></nav>
+    <nav aria-label="Brotkrumen" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
       <h1 id="case-title" class="text-3xl font-bold mb-2">Fashion-Shop (Demo)</h1>
       <p id="case-summary" class="text-lg mb-1">Demo-Case – Klarer Shop-Fokus.</p>
       <p class="text-sm text-gray-600">Demo-Case</p>
     </header>
     <section class="grid gap-4 md:grid-cols-3 mb-8">
-      <div class="p-4 border rounded text-center"><strong id="kpi-1">48h</strong><br><span class="text-sm">Umsetzungszeit</span></div>
-      <div class="p-4 border rounded text-center"><strong id="kpi-2">≤1.1s LCP</strong><br><span class="text-sm">mobil, Demo</span></div>
-      <div class="p-4 border rounded text-center"><strong id="kpi-3">Fokussierter Checkout</strong><br><span class="text-sm">klarer Pfad</span></div>
+      <div class="highlight-box"><strong id="kpi-1">48h</strong><span class="text-sm">Umsetzungszeit</span></div>
+      <div class="highlight-box"><strong id="kpi-2">≤1.1s LCP</strong><span class="text-sm">mobil, Demo</span></div>
+      <div class="highlight-box"><strong id="kpi-3">Fokussierter Checkout</strong><span class="text-sm">klarer Pfad</span></div>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Ausgangslage</h2>
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Ausgangslage</h2>
       <p>Mode-Startup wollte einen einfachen Shop, der verkauft.</p>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Ansatz</h2>
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Ansatz</h2>
       <p>Minimaler Katalog, klare Produktkarten und schnelle Ladezeiten.</p>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Ergebnis</h2>
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Ergebnis</h2>
       <p>Kunden finden Produkte schnell und schließen den Kauf ab.</p>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Vorgehen in 48h</h2>
-      <ol class="list-decimal pl-5 space-y-1">
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Vorgehen in 48h</h2>
+      <ol class="list-decimal pl-6 space-y-1">
         <li>Briefing & Ziele</li>
         <li>Wireframe</li>
         <li>Copy-Entwurf</li>
@@ -75,7 +81,7 @@
       </ol>
       <div id="stack-tags" class="mt-4 flex flex-wrap gap-2"></div>
     </section>
-    <section class="mt-8 flex flex-wrap gap-4">
+    <section class="flex justify-center gap-4 mt-8">
       <a class="btn btn-primary" href="/TurboSito/de/kontakt.html">Projekt starten</a>
       <a class="btn btn-outline" href="../portfolio.html">Weitere Beispiele</a>
     </section>
@@ -94,7 +100,7 @@
         document.getElementById('kpi-1').textContent=item.kpis[0];
         document.getElementById('kpi-2').textContent=item.kpis[1];
         document.getElementById('kpi-3').textContent=item.kpis[2];
-        document.getElementById('stack-tags').innerHTML=item.tags.map(t=>`<span class="tag">${t}</span>`).join(' ');
+        document.getElementById('stack-tags').innerHTML=item.tags.map(t=>`<span class="tag-pill">${t}</span>`).join(' ');
         const ld=[{
           "@context":"https://schema.org",
           "@type":"CreativeWork",

--- a/de/portfolio/saas-landing.html
+++ b/de/portfolio/saas-landing.html
@@ -18,6 +18,7 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+  <script src="/TurboSito/assets/js/theme.js" defer></script>
 </head>
 <body class="font-sans text-gray-900">
   <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Zum Inhalt springen</a>
@@ -37,36 +38,41 @@
           <a href="/TurboSito/it/portfolio/saas-landing.html" data-lang="it" hreflang="it">IT</a>
         </nav>
         <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button>
+        <button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false">
+          <span class="icon sun" aria-hidden="true">☀️</span>
+          <span class="icon moon" aria-hidden="true">🌙</span>
+          <span>Theme</span>
+        </button>
       </div>
     </div>
   </header>
   <main id="content" class="max-w-3xl mx-auto px-4 py-12">
-    <nav aria-label="Brotkrumen" class="mb-4"><a href="../portfolio.html" class="text-sm">← Portfolio</a></nav>
+    <nav aria-label="Brotkrumen" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
       <h1 id="case-title" class="text-3xl font-bold mb-2">SaaS-Landing (Demo)</h1>
       <p id="case-summary" class="text-lg mb-1">Demo-Case – Stil, Struktur, Speed.</p>
       <p class="text-sm text-gray-600">Demo-Case</p>
     </header>
     <section class="grid gap-4 md:grid-cols-3 mb-8">
-      <div class="p-4 border rounded text-center"><strong id="kpi-1">48h</strong><br><span class="text-sm">Umsetzungszeit</span></div>
-      <div class="p-4 border rounded text-center"><strong id="kpi-2">≤1.1s LCP</strong><br><span class="text-sm">mobil, Demo</span></div>
-      <div class="p-4 border rounded text-center"><strong id="kpi-3">Klare CTAs</strong><br><span class="text-sm">fokussiert</span></div>
+      <div class="highlight-box"><strong id="kpi-1">48h</strong><span class="text-sm">Umsetzungszeit</span></div>
+      <div class="highlight-box"><strong id="kpi-2">≤1.1s LCP</strong><span class="text-sm">mobil, Demo</span></div>
+      <div class="highlight-box"><strong id="kpi-3">Klare CTAs</strong><span class="text-sm">fokussiert</span></div>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Ausgangslage</h2>
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Ausgangslage</h2>
       <p>Kleines SaaS brauchte eine klare Botschaft für erste Signups.</p>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Ansatz</h2>
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Ansatz</h2>
       <p>Schlanke Struktur, Tailwind-Styling und Mobile-First-Blöcke.</p>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Ergebnis</h2>
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Ergebnis</h2>
       <p>Demo lädt schnell, betont den Wert und führt zur CTA.</p>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Vorgehen in 48h</h2>
-      <ol class="list-decimal pl-5 space-y-1">
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Vorgehen in 48h</h2>
+      <ol class="list-decimal pl-6 space-y-1">
         <li>Briefing & Ziele</li>
         <li>Wireframe</li>
         <li>Copy-Entwurf</li>
@@ -75,7 +81,7 @@
       </ol>
       <div id="stack-tags" class="mt-4 flex flex-wrap gap-2"></div>
     </section>
-    <section class="mt-8 flex flex-wrap gap-4">
+    <section class="flex justify-center gap-4 mt-8">
       <a class="btn btn-primary" href="/TurboSito/de/kontakt.html">Projekt starten</a>
       <a class="btn btn-outline" href="../portfolio.html">Weitere Beispiele</a>
     </section>
@@ -94,7 +100,7 @@
         document.getElementById('kpi-1').textContent=item.kpis[0];
         document.getElementById('kpi-2').textContent=item.kpis[1];
         document.getElementById('kpi-3').textContent=item.kpis[2];
-        document.getElementById('stack-tags').innerHTML=item.tags.map(t=>`<span class="tag">${t}</span>`).join(' ');
+        document.getElementById('stack-tags').innerHTML=item.tags.map(t=>`<span class="tag-pill">${t}</span>`).join(' ');
         const ld=[{
           "@context":"https://schema.org",
           "@type":"CreativeWork",

--- a/en/_partials/header.html
+++ b/en/_partials/header.html
@@ -16,7 +16,7 @@
     <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü">
       <span aria-hidden="true"></span>
     </button>
-    <button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false">
+    <button class="theme-toggle" data-theme-toggle aria-label="Toggle theme" aria-pressed="false">
       <span class="icon sun" aria-hidden="true">☀️</span>
       <span class="icon moon" aria-hidden="true">🌙</span>
       <span>Theme</span>

--- a/en/portfolio.html
+++ b/en/portfolio.html
@@ -18,6 +18,7 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+  <script src="/TurboSito/assets/js/theme.js" defer></script>
   <script defer src="/TurboSito/assets/js/portfolio.js"></script>
 </head>
 <body class="font-sans text-gray-900">
@@ -38,6 +39,11 @@
           <a href="/TurboSito/it/portfolio.html" data-lang="it" hreflang="it">IT</a>
         </nav>
         <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button>
+        <button class="theme-toggle" data-theme-toggle aria-label="Toggle theme" aria-pressed="false">
+          <span class="icon sun" aria-hidden="true">☀️</span>
+          <span class="icon moon" aria-hidden="true">🌙</span>
+          <span>Theme</span>
+        </button>
       </div>
     </div>
   </header>
@@ -49,24 +55,24 @@
     <div aria-live="polite" class="sr-only" id="live-status"></div>
     <section>
       <nav class="flex flex-wrap gap-2 justify-center mb-4" role="tablist">
-        <button data-type="all" role="tab" aria-controls="portfolio-grid" aria-selected="true" tabindex="0" class="px-3 py-1 border rounded">All</button>
-        <button data-type="landing" role="tab" aria-controls="portfolio-grid" aria-selected="false" tabindex="-1" class="px-3 py-1 border rounded">Landing pages</button>
-        <button data-type="corporate" role="tab" aria-controls="portfolio-grid" aria-selected="false" tabindex="-1" class="px-3 py-1 border rounded">Corporate</button>
-        <button data-type="shop" role="tab" aria-controls="portfolio-grid" aria-selected="false" tabindex="-1" class="px-3 py-1 border rounded">Shop</button>
-        <button data-type="app" role="tab" aria-controls="portfolio-grid" aria-selected="false" tabindex="-1" class="px-3 py-1 border rounded">App/Tool</button>
+        <button data-type="all" role="tab" aria-controls="portfolio-grid" aria-selected="true" tabindex="0" class="px-3 py-1 border rounded dark:border-gray-700">All</button>
+        <button data-type="landing" role="tab" aria-controls="portfolio-grid" aria-selected="false" tabindex="-1" class="px-3 py-1 border rounded dark:border-gray-700">Landing pages</button>
+        <button data-type="corporate" role="tab" aria-controls="portfolio-grid" aria-selected="false" tabindex="-1" class="px-3 py-1 border rounded dark:border-gray-700">Corporate</button>
+        <button data-type="shop" role="tab" aria-controls="portfolio-grid" aria-selected="false" tabindex="-1" class="px-3 py-1 border rounded dark:border-gray-700">Shop</button>
+        <button data-type="app" role="tab" aria-controls="portfolio-grid" aria-selected="false" tabindex="-1" class="px-3 py-1 border rounded dark:border-gray-700">App/Tool</button>
       </nav>
-      <div class="flex justify-end mb-4">
-        <div class="relative">
-          <button id="sort-button" class="px-2 py-1 border rounded" aria-haspopup="listbox" aria-expanded="false">New → Old</button>
-          <ul id="sort-menu" class="absolute right-0 mt-1 border bg-white rounded shadow-md hidden" role="listbox" tabindex="-1">
-            <li data-sort="new" role="option" tabindex="-1" class="px-3 py-1 cursor-pointer">New → Old</li>
-            <li data-sort="impact" role="option" tabindex="-1" class="px-3 py-1 cursor-pointer">Highest impact</li>
-            <li data-sort="speed" role="option" tabindex="-1" class="px-3 py-1 cursor-pointer">Fastest build</li>
+      <div class="mb-4">
+        <div class="relative inline-block">
+          <button id="sort-button" class="px-2 py-1 border rounded dark:border-gray-700" aria-haspopup="listbox" aria-expanded="false">New → Old</button>
+          <ul id="sort-menu" class="absolute left-0 mt-1 border bg-white dark:bg-gray-800 rounded shadow-md hidden" role="listbox" tabindex="-1">
+            <li data-sort="new" role="option" tabindex="-1" class="px-3 py-1 cursor-pointer" aria-selected="false">New → Old</li>
+            <li data-sort="impact" role="option" tabindex="-1" class="px-3 py-1 cursor-pointer" aria-selected="false">Highest impact</li>
+            <li data-sort="speed" role="option" tabindex="-1" class="px-3 py-1 cursor-pointer" aria-selected="false">Fastest build</li>
           </ul>
         </div>
       </div>
       <div id="portfolio-grid" class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3" role="list"></div>
-      <div id="empty-state" class="hidden text-center p-4 border rounded">
+      <div id="empty-state" class="text-center p-4 border rounded" hidden>
         <p>No projects found.</p>
         <button id="reset-filters" class="btn btn-primary mt-2">Reset filters</button>
       </div>

--- a/en/portfolio/corporate-site.html
+++ b/en/portfolio/corporate-site.html
@@ -18,6 +18,7 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+  <script src="/TurboSito/assets/js/theme.js" defer></script>
 </head>
 <body class="font-sans text-gray-900">
   <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
@@ -37,36 +38,41 @@
           <a href="/TurboSito/it/portfolio/corporate-site.html" data-lang="it" hreflang="it">IT</a>
         </nav>
         <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button>
+        <button class="theme-toggle" data-theme-toggle aria-label="Toggle theme" aria-pressed="false">
+          <span class="icon sun" aria-hidden="true">☀️</span>
+          <span class="icon moon" aria-hidden="true">🌙</span>
+          <span>Theme</span>
+        </button>
       </div>
     </div>
   </header>
   <main id="content" class="max-w-3xl mx-auto px-4 py-12">
-    <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm">← Portfolio</a></nav>
+    <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
       <h1 id="case-title" class="text-3xl font-bold mb-2">Corporate Site (Demo)</h1>
       <p id="case-summary" class="text-lg mb-1">Demo case – trust and structure.</p>
       <p class="text-sm text-gray-600">Demo case</p>
     </header>
     <section class="grid gap-4 md:grid-cols-3 mb-8">
-      <div class="p-4 border rounded text-center"><strong id="kpi-1">48h</strong><br><span class="text-sm">launch time</span></div>
-      <div class="p-4 border rounded text-center"><strong id="kpi-2">≤1.1s LCP</strong><br><span class="text-sm">mobile demo</span></div>
-      <div class="p-4 border rounded text-center"><strong id="kpi-3">Serious impact</strong><br><span class="text-sm">credibility</span></div>
+      <div class="highlight-box"><strong id="kpi-1">48h</strong><span class="text-sm">launch time</span></div>
+      <div class="highlight-box"><strong id="kpi-2">≤1.1s LCP</strong><span class="text-sm">mobile demo</span></div>
+      <div class="highlight-box"><strong id="kpi-3">Serious impact</strong><span class="text-sm">credibility</span></div>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Challenge</h2>
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Challenge</h2>
       <p>Consulting firm needed a lean site to build trust.</p>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Approach</h2>
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Approach</h2>
       <p>Clear services, simple navigation and static export.</p>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Result</h2>
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Result</h2>
       <p>Visitors find info quickly and get in touch.</p>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">48h process</h2>
-      <ol class="list-decimal pl-5 space-y-1">
+      <h2 class="mt-6 mb-2 text-lg font-semibold">48h process</h2>
+      <ol class="list-decimal pl-6 space-y-1">
         <li>Brief & goals</li>
         <li>Wireframe</li>
         <li>Copy draft</li>
@@ -75,7 +81,7 @@
       </ol>
       <div id="stack-tags" class="mt-4 flex flex-wrap gap-2"></div>
     </section>
-    <section class="mt-8 flex flex-wrap gap-4">
+    <section class="flex justify-center gap-4 mt-8">
       <a class="btn btn-primary" href="/TurboSito/en/contact.html">Start project</a>
       <a class="btn btn-outline" href="../portfolio.html">More examples</a>
     </section>
@@ -94,7 +100,7 @@
         document.getElementById('kpi-1').textContent=item.kpis[0];
         document.getElementById('kpi-2').textContent=item.kpis[1];
         document.getElementById('kpi-3').textContent=item.kpis[2];
-        document.getElementById('stack-tags').innerHTML=item.tags.map(t=>`<span class="tag">${t}</span>`).join(' ');
+        document.getElementById('stack-tags').innerHTML=item.tags.map(t=>`<span class="tag-pill">${t}</span>`).join(' ');
         const ld=[{
           "@context":"https://schema.org",
           "@type":"CreativeWork",

--- a/en/portfolio/fashion-shop.html
+++ b/en/portfolio/fashion-shop.html
@@ -18,6 +18,7 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+  <script src="/TurboSito/assets/js/theme.js" defer></script>
 </head>
 <body class="font-sans text-gray-900">
   <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
@@ -37,36 +38,41 @@
           <a href="/TurboSito/it/portfolio/fashion-shop.html" data-lang="it" hreflang="it">IT</a>
         </nav>
         <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button>
+        <button class="theme-toggle" data-theme-toggle aria-label="Toggle theme" aria-pressed="false">
+          <span class="icon sun" aria-hidden="true">☀️</span>
+          <span class="icon moon" aria-hidden="true">🌙</span>
+          <span>Theme</span>
+        </button>
       </div>
     </div>
   </header>
   <main id="content" class="max-w-3xl mx-auto px-4 py-12">
-    <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm">← Portfolio</a></nav>
+    <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
       <h1 id="case-title" class="text-3xl font-bold mb-2">Fashion Shop (Demo)</h1>
       <p id="case-summary" class="text-lg mb-1">Demo case – clear shop focus.</p>
       <p class="text-sm text-gray-600">Demo case</p>
     </header>
     <section class="grid gap-4 md:grid-cols-3 mb-8">
-      <div class="p-4 border rounded text-center"><strong id="kpi-1">48h</strong><br><span class="text-sm">launch time</span></div>
-      <div class="p-4 border rounded text-center"><strong id="kpi-2">≤1.1s LCP</strong><br><span class="text-sm">mobile demo</span></div>
-      <div class="p-4 border rounded text-center"><strong id="kpi-3">Focused checkout</strong><br><span class="text-sm">clear path</span></div>
+      <div class="highlight-box"><strong id="kpi-1">48h</strong><span class="text-sm">launch time</span></div>
+      <div class="highlight-box"><strong id="kpi-2">≤1.1s LCP</strong><span class="text-sm">mobile demo</span></div>
+      <div class="highlight-box"><strong id="kpi-3">Focused checkout</strong><span class="text-sm">clear path</span></div>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Challenge</h2>
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Challenge</h2>
       <p>Fashion start-up needed a simple shop that sells.</p>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Approach</h2>
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Approach</h2>
       <p>Minimal catalog, clear product cards and fast loading.</p>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Result</h2>
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Result</h2>
       <p>Customers find products quickly and complete checkout.</p>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">48h process</h2>
-      <ol class="list-decimal pl-5 space-y-1">
+      <h2 class="mt-6 mb-2 text-lg font-semibold">48h process</h2>
+      <ol class="list-decimal pl-6 space-y-1">
         <li>Brief & goals</li>
         <li>Wireframe</li>
         <li>Copy draft</li>
@@ -75,7 +81,7 @@
       </ol>
       <div id="stack-tags" class="mt-4 flex flex-wrap gap-2"></div>
     </section>
-    <section class="mt-8 flex flex-wrap gap-4">
+    <section class="flex justify-center gap-4 mt-8">
       <a class="btn btn-primary" href="/TurboSito/en/contact.html">Start project</a>
       <a class="btn btn-outline" href="../portfolio.html">More examples</a>
     </section>
@@ -94,7 +100,7 @@
         document.getElementById('kpi-1').textContent=item.kpis[0];
         document.getElementById('kpi-2').textContent=item.kpis[1];
         document.getElementById('kpi-3').textContent=item.kpis[2];
-        document.getElementById('stack-tags').innerHTML=item.tags.map(t=>`<span class="tag">${t}</span>`).join(' ');
+        document.getElementById('stack-tags').innerHTML=item.tags.map(t=>`<span class="tag-pill">${t}</span>`).join(' ');
         const ld=[{
           "@context":"https://schema.org",
           "@type":"CreativeWork",

--- a/en/portfolio/saas-landing.html
+++ b/en/portfolio/saas-landing.html
@@ -18,6 +18,7 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+  <script src="/TurboSito/assets/js/theme.js" defer></script>
 </head>
 <body class="font-sans text-gray-900">
   <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
@@ -37,36 +38,41 @@
           <a href="/TurboSito/it/portfolio/saas-landing.html" data-lang="it" hreflang="it">IT</a>
         </nav>
         <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button>
+        <button class="theme-toggle" data-theme-toggle aria-label="Toggle theme" aria-pressed="false">
+          <span class="icon sun" aria-hidden="true">☀️</span>
+          <span class="icon moon" aria-hidden="true">🌙</span>
+          <span>Theme</span>
+        </button>
       </div>
     </div>
   </header>
   <main id="content" class="max-w-3xl mx-auto px-4 py-12">
-    <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm">← Portfolio</a></nav>
+    <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
       <h1 id="case-title" class="text-3xl font-bold mb-2">SaaS Landing (Demo)</h1>
       <p id="case-summary" class="text-lg mb-1">Demo case – style, structure, speed.</p>
       <p class="text-sm text-gray-600">Demo case</p>
     </header>
     <section class="grid gap-4 md:grid-cols-3 mb-8">
-      <div class="p-4 border rounded text-center"><strong id="kpi-1">48h</strong><br><span class="text-sm">launch time</span></div>
-      <div class="p-4 border rounded text-center"><strong id="kpi-2">≤1.1s LCP</strong><br><span class="text-sm">mobile demo</span></div>
-      <div class="p-4 border rounded text-center"><strong id="kpi-3">Clear CTAs</strong><br><span class="text-sm">focused</span></div>
+      <div class="highlight-box"><strong id="kpi-1">48h</strong><span class="text-sm">launch time</span></div>
+      <div class="highlight-box"><strong id="kpi-2">≤1.1s LCP</strong><span class="text-sm">mobile demo</span></div>
+      <div class="highlight-box"><strong id="kpi-3">Clear CTAs</strong><span class="text-sm">focused</span></div>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Challenge</h2>
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Challenge</h2>
       <p>Small SaaS needed a clear above-the-fold message for early signups.</p>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Approach</h2>
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Approach</h2>
       <p>Lean structure, Tailwind styling and mobile-first blocks.</p>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Result</h2>
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Result</h2>
       <p>Demo loads fast, highlights value and guides to CTA.</p>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">48h process</h2>
-      <ol class="list-decimal pl-5 space-y-1">
+      <h2 class="mt-6 mb-2 text-lg font-semibold">48h process</h2>
+      <ol class="list-decimal pl-6 space-y-1">
         <li>Brief & goals</li>
         <li>Wireframe</li>
         <li>Copy draft</li>
@@ -75,7 +81,7 @@
       </ol>
       <div id="stack-tags" class="mt-4 flex flex-wrap gap-2"></div>
     </section>
-    <section class="mt-8 flex flex-wrap gap-4">
+    <section class="flex justify-center gap-4 mt-8">
       <a class="btn btn-primary" href="/TurboSito/en/contact.html">Start project</a>
       <a class="btn btn-outline" href="../portfolio.html">More examples</a>
     </section>
@@ -94,7 +100,7 @@
         document.getElementById('kpi-1').textContent=item.kpis[0];
         document.getElementById('kpi-2').textContent=item.kpis[1];
         document.getElementById('kpi-3').textContent=item.kpis[2];
-        document.getElementById('stack-tags').innerHTML=item.tags.map(t=>`<span class="tag">${t}</span>`).join(' ');
+        document.getElementById('stack-tags').innerHTML=item.tags.map(t=>`<span class="tag-pill">${t}</span>`).join(' ');
         const ld=[{
           "@context":"https://schema.org",
           "@type":"CreativeWork",

--- a/it/_partials/header.html
+++ b/it/_partials/header.html
@@ -16,7 +16,7 @@
     <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü">
       <span aria-hidden="true"></span>
     </button>
-    <button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false">
+    <button class="theme-toggle" data-theme-toggle aria-label="Cambia tema" aria-pressed="false">
       <span class="icon sun" aria-hidden="true">☀️</span>
       <span class="icon moon" aria-hidden="true">🌙</span>
       <span>Theme</span>

--- a/it/portfolio.html
+++ b/it/portfolio.html
@@ -18,6 +18,7 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+  <script src="/TurboSito/assets/js/theme.js" defer></script>
   <script defer src="/TurboSito/assets/js/portfolio.js"></script>
 </head>
 <body class="font-sans text-gray-900">
@@ -38,6 +39,11 @@
           <a href="/TurboSito/it/portfolio.html" data-lang="it" hreflang="it">IT</a>
         </nav>
         <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menù"><span aria-hidden="true"></span></button>
+        <button class="theme-toggle" data-theme-toggle aria-label="Cambia tema" aria-pressed="false">
+          <span class="icon sun" aria-hidden="true">☀️</span>
+          <span class="icon moon" aria-hidden="true">🌙</span>
+          <span>Theme</span>
+        </button>
       </div>
     </div>
   </header>
@@ -49,24 +55,24 @@
     <div aria-live="polite" class="sr-only" id="live-status"></div>
     <section>
       <nav class="flex flex-wrap gap-2 justify-center mb-4" role="tablist">
-        <button data-type="all" role="tab" aria-controls="portfolio-grid" aria-selected="true" tabindex="0" class="px-3 py-1 border rounded">Tutte</button>
-        <button data-type="landing" role="tab" aria-controls="portfolio-grid" aria-selected="false" tabindex="-1" class="px-3 py-1 border rounded">Landing page</button>
-        <button data-type="corporate" role="tab" aria-controls="portfolio-grid" aria-selected="false" tabindex="-1" class="px-3 py-1 border rounded">Corporate</button>
-        <button data-type="shop" role="tab" aria-controls="portfolio-grid" aria-selected="false" tabindex="-1" class="px-3 py-1 border rounded">Shop</button>
-        <button data-type="app" role="tab" aria-controls="portfolio-grid" aria-selected="false" tabindex="-1" class="px-3 py-1 border rounded">App/Tool</button>
+        <button data-type="all" role="tab" aria-controls="portfolio-grid" aria-selected="true" tabindex="0" class="px-3 py-1 border rounded dark:border-gray-700">Tutte</button>
+        <button data-type="landing" role="tab" aria-controls="portfolio-grid" aria-selected="false" tabindex="-1" class="px-3 py-1 border rounded dark:border-gray-700">Landing page</button>
+        <button data-type="corporate" role="tab" aria-controls="portfolio-grid" aria-selected="false" tabindex="-1" class="px-3 py-1 border rounded dark:border-gray-700">Corporate</button>
+        <button data-type="shop" role="tab" aria-controls="portfolio-grid" aria-selected="false" tabindex="-1" class="px-3 py-1 border rounded dark:border-gray-700">Shop</button>
+        <button data-type="app" role="tab" aria-controls="portfolio-grid" aria-selected="false" tabindex="-1" class="px-3 py-1 border rounded dark:border-gray-700">App/Tool</button>
       </nav>
-      <div class="flex justify-end mb-4">
-        <div class="relative">
-          <button id="sort-button" class="px-2 py-1 border rounded" aria-haspopup="listbox" aria-expanded="false">Nuovo → Vecchio</button>
-          <ul id="sort-menu" class="absolute right-0 mt-1 border bg-white rounded shadow-md hidden" role="listbox" tabindex="-1">
-            <li data-sort="new" role="option" tabindex="-1" class="px-3 py-1 cursor-pointer">Nuovo → Vecchio</li>
-            <li data-sort="impact" role="option" tabindex="-1" class="px-3 py-1 cursor-pointer">Impatto maggiore</li>
-            <li data-sort="speed" role="option" tabindex="-1" class="px-3 py-1 cursor-pointer">Più veloce</li>
+      <div class="mb-4">
+        <div class="relative inline-block">
+          <button id="sort-button" class="px-2 py-1 border rounded dark:border-gray-700" aria-haspopup="listbox" aria-expanded="false">Nuovo → Vecchio</button>
+          <ul id="sort-menu" class="absolute left-0 mt-1 border bg-white dark:bg-gray-800 rounded shadow-md hidden" role="listbox" tabindex="-1">
+            <li data-sort="new" role="option" tabindex="-1" class="px-3 py-1 cursor-pointer" aria-selected="false">Nuovo → Vecchio</li>
+            <li data-sort="impact" role="option" tabindex="-1" class="px-3 py-1 cursor-pointer" aria-selected="false">Impatto maggiore</li>
+            <li data-sort="speed" role="option" tabindex="-1" class="px-3 py-1 cursor-pointer" aria-selected="false">Più veloce</li>
           </ul>
         </div>
       </div>
       <div id="portfolio-grid" class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3" role="list"></div>
-      <div id="empty-state" class="hidden text-center p-4 border rounded">
+      <div id="empty-state" class="text-center p-4 border rounded" hidden>
         <p>Nessun progetto trovato.</p>
         <button id="reset-filters" class="btn btn-primary mt-2">Reimposta filtri</button>
       </div>

--- a/it/portfolio/corporate-site.html
+++ b/it/portfolio/corporate-site.html
@@ -18,6 +18,7 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+  <script src="/TurboSito/assets/js/theme.js" defer></script>
 </head>
 <body class="font-sans text-gray-900">
   <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Vai al contenuto</a>
@@ -37,36 +38,41 @@
           <a href="/TurboSito/it/portfolio/corporate-site.html" data-lang="it" hreflang="it">IT</a>
         </nav>
         <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menù"><span aria-hidden="true"></span></button>
+        <button class="theme-toggle" data-theme-toggle aria-label="Cambia tema" aria-pressed="false">
+          <span class="icon sun" aria-hidden="true">☀️</span>
+          <span class="icon moon" aria-hidden="true">🌙</span>
+          <span>Theme</span>
+        </button>
       </div>
     </div>
   </header>
   <main id="content" class="max-w-3xl mx-auto px-4 py-12">
-    <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm">← Portfolio</a></nav>
+    <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
       <h1 id="case-title" class="text-3xl font-bold mb-2">Corporate Site (Demo)</h1>
       <p id="case-summary" class="text-lg mb-1">Caso demo – fiducia e struttura.</p>
       <p class="text-sm text-gray-600">Caso demo</p>
     </header>
     <section class="grid gap-4 md:grid-cols-3 mb-8">
-      <div class="p-4 border rounded text-center"><strong id="kpi-1">48h</strong><br><span class="text-sm">tempo di lancio</span></div>
-      <div class="p-4 border rounded text-center"><strong id="kpi-2">≤1.1s LCP</strong><br><span class="text-sm">mobile demo</span></div>
-      <div class="p-4 border rounded text-center"><strong id="kpi-3">Impatto serio</strong><br><span class="text-sm">credibilità</span></div>
+      <div class="highlight-box"><strong id="kpi-1">48h</strong><span class="text-sm">tempo di lancio</span></div>
+      <div class="highlight-box"><strong id="kpi-2">≤1.1s LCP</strong><span class="text-sm">mobile demo</span></div>
+      <div class="highlight-box"><strong id="kpi-3">Impatto serio</strong><span class="text-sm">credibilità</span></div>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Sfida</h2>
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Sfida</h2>
       <p>Società di consulenza voleva un sito snello che generi fiducia.</p>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Approccio</h2>
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Approccio</h2>
       <p>Servizi chiari, navigazione semplice ed export statico.</p>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Risultato</h2>
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Risultato</h2>
       <p>I visitatori trovano rapidamente le informazioni e contattano l'azienda.</p>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Processo in 48h</h2>
-      <ol class="list-decimal pl-5 space-y-1">
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Processo in 48h</h2>
+      <ol class="list-decimal pl-6 space-y-1">
         <li>Briefing e obiettivi</li>
         <li>Wireframe</li>
         <li>Bozza copy</li>
@@ -75,7 +81,7 @@
       </ol>
       <div id="stack-tags" class="mt-4 flex flex-wrap gap-2"></div>
     </section>
-    <section class="mt-8 flex flex-wrap gap-4">
+    <section class="flex justify-center gap-4 mt-8">
       <a class="btn btn-primary" href="/TurboSito/it/contatto.html">Avvia progetto</a>
       <a class="btn btn-outline" href="../portfolio.html">Altri esempi</a>
     </section>
@@ -94,7 +100,7 @@
         document.getElementById('kpi-1').textContent=item.kpis[0];
         document.getElementById('kpi-2').textContent=item.kpis[1];
         document.getElementById('kpi-3').textContent=item.kpis[2];
-        document.getElementById('stack-tags').innerHTML=item.tags.map(t=>`<span class="tag">${t}</span>`).join(' ');
+        document.getElementById('stack-tags').innerHTML=item.tags.map(t=>`<span class="tag-pill">${t}</span>`).join(' ');
         const ld=[{
           "@context":"https://schema.org",
           "@type":"CreativeWork",

--- a/it/portfolio/fashion-shop.html
+++ b/it/portfolio/fashion-shop.html
@@ -18,6 +18,7 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+  <script src="/TurboSito/assets/js/theme.js" defer></script>
 </head>
 <body class="font-sans text-gray-900">
   <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Vai al contenuto</a>
@@ -37,36 +38,41 @@
           <a href="/TurboSito/it/portfolio/fashion-shop.html" data-lang="it" hreflang="it">IT</a>
         </nav>
         <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menù"><span aria-hidden="true"></span></button>
+        <button class="theme-toggle" data-theme-toggle aria-label="Cambia tema" aria-pressed="false">
+          <span class="icon sun" aria-hidden="true">☀️</span>
+          <span class="icon moon" aria-hidden="true">🌙</span>
+          <span>Theme</span>
+        </button>
       </div>
     </div>
   </header>
   <main id="content" class="max-w-3xl mx-auto px-4 py-12">
-    <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm">← Portfolio</a></nav>
+    <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
       <h1 id="case-title" class="text-3xl font-bold mb-2">Fashion Shop (Demo)</h1>
       <p id="case-summary" class="text-lg mb-1">Caso demo – focus chiaro sullo shop.</p>
       <p class="text-sm text-gray-600">Caso demo</p>
     </header>
     <section class="grid gap-4 md:grid-cols-3 mb-8">
-      <div class="p-4 border rounded text-center"><strong id="kpi-1">48h</strong><br><span class="text-sm">tempo di lancio</span></div>
-      <div class="p-4 border rounded text-center"><strong id="kpi-2">≤1.1s LCP</strong><br><span class="text-sm">mobile demo</span></div>
-      <div class="p-4 border rounded text-center"><strong id="kpi-3">Checkout mirato</strong><br><span class="text-sm">percorso chiaro</span></div>
+      <div class="highlight-box"><strong id="kpi-1">48h</strong><span class="text-sm">tempo di lancio</span></div>
+      <div class="highlight-box"><strong id="kpi-2">≤1.1s LCP</strong><span class="text-sm">mobile demo</span></div>
+      <div class="highlight-box"><strong id="kpi-3">Checkout mirato</strong><span class="text-sm">percorso chiaro</span></div>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Sfida</h2>
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Sfida</h2>
       <p>Startup moda voleva uno shop semplice che vendesse.</p>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Approccio</h2>
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Approccio</h2>
       <p>Catalogo minimale, schede prodotto chiare e caricamento veloce.</p>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Risultato</h2>
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Risultato</h2>
       <p>I clienti trovano rapidamente i prodotti e completano l'acquisto.</p>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Processo in 48h</h2>
-      <ol class="list-decimal pl-5 space-y-1">
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Processo in 48h</h2>
+      <ol class="list-decimal pl-6 space-y-1">
         <li>Briefing e obiettivi</li>
         <li>Wireframe</li>
         <li>Bozza copy</li>
@@ -75,7 +81,7 @@
       </ol>
       <div id="stack-tags" class="mt-4 flex flex-wrap gap-2"></div>
     </section>
-    <section class="mt-8 flex flex-wrap gap-4">
+    <section class="flex justify-center gap-4 mt-8">
       <a class="btn btn-primary" href="/TurboSito/it/contatto.html">Avvia progetto</a>
       <a class="btn btn-outline" href="../portfolio.html">Altri esempi</a>
     </section>
@@ -94,7 +100,7 @@
         document.getElementById('kpi-1').textContent=item.kpis[0];
         document.getElementById('kpi-2').textContent=item.kpis[1];
         document.getElementById('kpi-3').textContent=item.kpis[2];
-        document.getElementById('stack-tags').innerHTML=item.tags.map(t=>`<span class="tag">${t}</span>`).join(' ');
+        document.getElementById('stack-tags').innerHTML=item.tags.map(t=>`<span class="tag-pill">${t}</span>`).join(' ');
         const ld=[{
           "@context":"https://schema.org",
           "@type":"CreativeWork",

--- a/it/portfolio/saas-landing.html
+++ b/it/portfolio/saas-landing.html
@@ -18,6 +18,7 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
+  <script src="/TurboSito/assets/js/theme.js" defer></script>
 </head>
 <body class="font-sans text-gray-900">
   <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Vai al contenuto</a>
@@ -37,36 +38,41 @@
           <a href="/TurboSito/it/portfolio/saas-landing.html" data-lang="it" hreflang="it">IT</a>
         </nav>
         <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menù"><span aria-hidden="true"></span></button>
+        <button class="theme-toggle" data-theme-toggle aria-label="Cambia tema" aria-pressed="false">
+          <span class="icon sun" aria-hidden="true">☀️</span>
+          <span class="icon moon" aria-hidden="true">🌙</span>
+          <span>Theme</span>
+        </button>
       </div>
     </div>
   </header>
   <main id="content" class="max-w-3xl mx-auto px-4 py-12">
-    <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm">← Portfolio</a></nav>
+    <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
       <h1 id="case-title" class="text-3xl font-bold mb-2">Landing SaaS (Demo)</h1>
       <p id="case-summary" class="text-lg mb-1">Caso demo – stile, struttura, velocità.</p>
       <p class="text-sm text-gray-600">Caso demo</p>
     </header>
     <section class="grid gap-4 md:grid-cols-3 mb-8">
-      <div class="p-4 border rounded text-center"><strong id="kpi-1">48h</strong><br><span class="text-sm">tempo di lancio</span></div>
-      <div class="p-4 border rounded text-center"><strong id="kpi-2">≤1.1s LCP</strong><br><span class="text-sm">mobile demo</span></div>
-      <div class="p-4 border rounded text-center"><strong id="kpi-3">CTA chiare</strong><br><span class="text-sm">focalizzate</span></div>
+      <div class="highlight-box"><strong id="kpi-1">48h</strong><span class="text-sm">tempo di lancio</span></div>
+      <div class="highlight-box"><strong id="kpi-2">≤1.1s LCP</strong><span class="text-sm">mobile demo</span></div>
+      <div class="highlight-box"><strong id="kpi-3">CTA chiare</strong><span class="text-sm">focalizzate</span></div>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Sfida</h2>
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Sfida</h2>
       <p>Piccola SaaS aveva bisogno di un messaggio chiaro per i primi iscritti.</p>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Approccio</h2>
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Approccio</h2>
       <p>Struttura snella, stile Tailwind e blocchi mobile-first.</p>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Risultato</h2>
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Risultato</h2>
       <p>La demo è veloce, evidenzia il valore e guida alla CTA.</p>
     </section>
     <section class="mb-6">
-      <h2 class="text-2xl font-semibold mb-2">Processo in 48h</h2>
-      <ol class="list-decimal pl-5 space-y-1">
+      <h2 class="mt-6 mb-2 text-lg font-semibold">Processo in 48h</h2>
+      <ol class="list-decimal pl-6 space-y-1">
         <li>Briefing e obiettivi</li>
         <li>Wireframe</li>
         <li>Bozza copy</li>
@@ -75,7 +81,7 @@
       </ol>
       <div id="stack-tags" class="mt-4 flex flex-wrap gap-2"></div>
     </section>
-    <section class="mt-8 flex flex-wrap gap-4">
+    <section class="flex justify-center gap-4 mt-8">
       <a class="btn btn-primary" href="/TurboSito/it/contatto.html">Avvia progetto</a>
       <a class="btn btn-outline" href="../portfolio.html">Altri esempi</a>
     </section>
@@ -94,7 +100,7 @@
         document.getElementById('kpi-1').textContent=item.kpis[0];
         document.getElementById('kpi-2').textContent=item.kpis[1];
         document.getElementById('kpi-3').textContent=item.kpis[2];
-        document.getElementById('stack-tags').innerHTML=item.tags.map(t=>`<span class="tag">${t}</span>`).join(' ');
+        document.getElementById('stack-tags').innerHTML=item.tags.map(t=>`<span class="tag-pill">${t}</span>`).join(' ');
         const ld=[{
           "@context":"https://schema.org",
           "@type":"CreativeWork",


### PR DESCRIPTION
## Summary
- bring back persistent theme toggle across headers
- enhance portfolio cards, filters and empty state
- restyle case study pages with highlight boxes and accessible sections

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bee116c00c8332bffa5872adf8cbc2