### PR TITLE
Enhance portfolio SEO, accessibility, and analytics

### DIFF
--- a/assets/data/site.meta.de.json
+++ b/assets/data/site.meta.de.json
@@ -1,0 +1,11 @@
+{
+  "overview": {
+    "title": "Portfolio – TurboSito Webdesign Demos",
+    "description": "Ehrliche Vorschau auf Stil, Struktur und Tempo. So könnte auch Ihr Projekt aussehen."
+  },
+  "case": {
+    "titleSuffix": "– Case Study (Demo)",
+    "description": "Kurze Case Study mit Highlights, Vorgehen in 48h und messbaren Signalen."
+  }
+}
+

--- a/assets/data/site.meta.en.json
+++ b/assets/data/site.meta.en.json
@@ -1,0 +1,11 @@
+{
+  "overview": {
+    "title": "Portfolio – TurboSito Web Design Demos",
+    "description": "Honest preview of style, structure and speed. Your project could look like this."
+  },
+  "case": {
+    "titleSuffix": "– Case Study (Demo)",
+    "description": "Short case study with highlights, 48h approach and measurable signals."
+  }
+}
+

--- a/assets/data/site.meta.it.json
+++ b/assets/data/site.meta.it.json
@@ -1,0 +1,11 @@
+{
+  "overview": {
+    "title": "Portfolio – Demo di Webdesign TurboSito",
+    "description": "Anteprima onesta di stile, struttura e velocità. Così potrebbe essere il tuo progetto."
+  },
+  "case": {
+    "titleSuffix": "– Case Study (Demo)",
+    "description": "Breve case study con punti salienti, approccio in 48h e segnali misurabili."
+  }
+}
+

--- a/assets/js/portfolio.js
+++ b/assets/js/portfolio.js
@@ -12,128 +12,169 @@
  * @property {string[]} tags
  * @property {string[]} [highlights]
  */
+
 /** @typedef {{items: PortfolioItem[]}} LocalizedDataset */
-(function(){
-  const lang = document.documentElement.lang || 'en';
-  const labels = {
-    en: {view:'View case study', demo:'Open demo', load:'Load more', none:'No projects', reset:'Reset filters'},
-    de: {view:'Case Study ansehen', demo:'Demo öffnen', load:'Mehr laden', none:'Keine Projekte', reset:'Filter zurücksetzen'},
-    it: {view:'Vedi case study', demo:'Apri demo', load:'Carica altro', none:'Nessun progetto', reset:'Reimposta filtri'}
+
+export function getCurrentLang() {
+  return document.documentElement.lang || 'en';
+}
+
+export function getBaseUrl() {
+  return window.location.origin;
+}
+
+export function getLangPathMap(path) {
+  const clean = path.replace(/^\/TurboSito/, '');
+  const rel = clean.replace(/^\/(de|en|it)/, '');
+  return {
+    de: `/de${rel}`,
+    en: `/en${rel}`,
+    it: `/it${rel}`
   };
-  const t = labels[lang] || labels.en;
-  const live = document.getElementById('live-status');
-  const state = {type:'all', sort:'new', visible:6, items:[], search:'', missing:false};
-  const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
 
-  function applyReducedMotion(){
-    if(prefersReduced) document.documentElement.classList.add('reduced-motion');
+const lang = getCurrentLang();
+
+let meta = {};
+try {
+  const res = await fetch(`/TurboSito/assets/data/site.meta.${lang}.json`, { cache: 'force-cache' });
+  meta = await res.json();
+} catch {}
+
+export function getMeta(section) {
+  return meta[section] || {};
+}
+
+const labels = {
+  en: { view: 'View case study', demo: 'Open demo', load: 'Load more', none: 'No projects', reset: 'Reset filters' },
+  de: { view: 'Case Study ansehen', demo: 'Demo öffnen', load: 'Mehr laden', none: 'Keine Projekte', reset: 'Filter zurücksetzen' },
+  it: { view: 'Vedi case study', demo: 'Apri demo', load: 'Carica altro', none: 'Nessun progetto', reset: 'Reimposta filtri' }
+};
+
+const t = labels[lang] || labels.en;
+const live = document.getElementById('live-status');
+const state = { type: 'all', sort: 'new', visible: 6, items: [], search: '', missing: false };
+const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+function applyReducedMotion() {
+  if (prefersReduced) document.documentElement.classList.add('reduced-motion');
+}
+
+export function validateItem(item) {
+  const must = ['slug', 'title', 'type', 'kpis', 'impactScore', 'tags', 'caseUrl'];
+  const ok = must.every(k => k in item);
+  if (!ok) console.warn('Invalid item', item);
+  return ok;
+}
+
+async function loadData(language) {
+  try {
+    const res = await fetch(`/TurboSito/assets/data/portfolio.${language}.json`, { cache: 'force-cache' });
+    const json = /** @type {LocalizedDataset} */ (await res.json());
+    state.items = json.items.filter(validateItem);
+    announceCount(applyFilters(state.items).length);
+    render();
+    document.dispatchEvent(new Event('portfolio:items-ready'));
+  } catch (e) {
+    showError();
   }
+}
 
-  function validateItem(item){
-    const required=['slug','title','type','kpis','impactScore','timeToLaunchHours','summary','demoUrl','caseUrl','tags'];
-    return required.every(k=>k in item);
-  }
+function showError() {
+  const container = document.getElementById('portfolio-grid');
+  container.innerHTML = `<div class="p-4 border rounded text-center">${t.none}. <button id="retry" class="btn btn-primary mt-2">Retry</button></div>`;
+  document.getElementById('retry')?.addEventListener('click', () => { renderSkeletons(state.visible); loadData(lang); });
+}
 
-  async function loadData(language){
-    try{
-      const res = await fetch(`/TurboSito/assets/data/portfolio.${language}.json`,{cache:'force-cache'});
-      const json = /** @type {LocalizedDataset} */(await res.json());
-      state.items = json.items.filter(validateItem);
-      announceCount(applyFilters(state.items).length);
-      render();
-    }catch(e){
-      showError();
-    }
-  }
+function normalizeState() {
+  const validTypes = ['all', 'landing', 'corporate', 'shop', 'app'];
+  const validSort = ['new', 'impact', 'speed'];
+  if (!validTypes.includes(state.type)) state.type = 'all';
+  if (!validSort.includes(state.sort)) state.sort = 'new';
+}
 
-  function showError(){
-    const container=document.getElementById('portfolio-grid');
-    container.innerHTML=`<div class="p-4 border rounded text-center">${t.none}. <button id="retry" class="btn btn-primary mt-2">Retry</button></div>`;
-    document.getElementById('retry').addEventListener('click',()=>{renderSkeletons(state.visible);loadData(lang);});
-  }
+function hydrateFromURL() {
+  const params = new URLSearchParams(location.search);
+  state.type = params.get('type') || 'all';
+  state.sort = params.get('sort') || 'new';
+  state.missing = params.get('missing') === '1';
+  normalizeState();
+  updateControls();
+  if (state.missing && live) live.textContent = 'Case nicht gefunden';
+}
 
-  function normalizeState(){
-    const validTypes=['all','landing','corporate','shop','app'];
-    const validSort=['new','impact','speed'];
-    if(!validTypes.includes(state.type)) state.type='all';
-    if(!validSort.includes(state.sort)) state.sort='new';
-  }
-
-  function hydrateFromURL(){
-    const params=new URLSearchParams(location.search);
-    state.type=params.get('type')||'all';
-    state.sort=params.get('sort')||'new';
-    state.missing=params.get('missing')==='1';
-    normalizeState();
-    updateControls();
-    if(state.missing && live) live.textContent='Case nicht gefunden';
-  }
-
-  function updateControls(){
-    document.querySelectorAll('[data-type]').forEach(btn=>{
-      const active=btn.getAttribute('data-type')===state.type;
-      btn.setAttribute('aria-selected', active);
-      btn.tabIndex=active?0:-1;
+function updateControls() {
+  document.querySelectorAll('[data-type]').forEach(btn => {
+    const active = btn.getAttribute('data-type') === state.type;
+    btn.setAttribute('aria-selected', active);
+    btn.tabIndex = active ? 0 : -1;
+  });
+  const btn = document.getElementById('sort-button');
+  if (btn) {
+    const current = document.querySelector(`#sort-menu [data-sort="${state.sort}"]`);
+    if (current) btn.textContent = current.textContent;
+    document.querySelectorAll('#sort-menu [data-sort]').forEach(opt => {
+      const sel = opt.getAttribute('data-sort') === state.sort;
+      opt.setAttribute('aria-selected', sel);
     });
-    const btn=document.getElementById('sort-button');
-    if(btn){
-      const current=document.querySelector(`#sort-menu [data-sort="${state.sort}"]`);
-      if(current) btn.textContent=current.textContent;
-      document.querySelectorAll('#sort-menu [data-sort]').forEach(opt=>{
-        const sel=opt.getAttribute('data-sort')===state.sort;
-        opt.setAttribute('aria-selected', sel);
-      });
-    }
   }
+}
 
-  function applyFilters(items){
-    let res = state.type!=='all'? items.filter(i=>i.type===state.type):items;
-    if(state.search){
-      const q=state.search.toLowerCase();
-      res=res.filter(i=>(i.title+i.summary+i.tags.join('')).toLowerCase().includes(q));
-    }
-    return applySort(res);
+function applyFilters(items) {
+  let res = state.type !== 'all' ? items.filter(i => i.type === state.type) : items;
+  if (state.search) {
+    const q = state.search.toLowerCase();
+    res = res.filter(i => (i.title + i.summary + i.tags.join('')).toLowerCase().includes(q));
   }
+  return applySort(res);
+}
 
-  function applySort(items){
-    const arr=[...items];
-    if(state.sort==='impact') arr.sort((a,b)=>b.impactScore-a.impactScore);
-    else if(state.sort==='speed') arr.sort((a,b)=>a.timeToLaunchHours-b.timeToLaunchHours);
-    return arr;
+function applySort(items) {
+  const arr = [...items];
+  if (state.sort === 'impact') arr.sort((a, b) => b.impactScore - a.impactScore);
+  else if (state.sort === 'speed') arr.sort((a, b) => a.timeToLaunchHours - b.timeToLaunchHours);
+  return arr;
+}
+
+function announceCount(count) {
+  if (live) live.textContent = `${count} ${count === 1 ? 'project' : 'projects'} visible`;
+}
+
+function renderSkeletons(n) {
+  const container = document.getElementById('portfolio-grid');
+  container.setAttribute('aria-busy', 'true');
+  container.innerHTML = '';
+  for (let i = 0; i < n; i++) {
+    const article = document.createElement('article');
+    article.className = 'case-card border p-4 rounded skeleton dark:border-gray-700';
+    container.appendChild(article);
   }
+}
 
-  function announceCount(count){
-    if(live) live.textContent=`${count} ${count===1?'project':'projects'} visible`;
+export function getOverviewItems() {
+  return state.items;
+}
+
+function render() {
+  const container = document.getElementById('portfolio-grid');
+  const empty = document.getElementById('empty-state');
+  const items = applyFilters(state.items);
+  const visibleItems = items.slice(0, state.visible);
+  container.setAttribute('aria-busy', 'true');
+  container.innerHTML = '';
+  if (items.length === 0) {
+    empty.hidden = false;
+    announceCount(0);
+    container.setAttribute('aria-busy', 'false');
+    return;
   }
-
-  function renderSkeletons(n){
-    const container=document.getElementById('portfolio-grid');
-    container.innerHTML='';
-    for(let i=0;i<n;i++){
-      const article=document.createElement('article');
-      article.className='case-card border p-4 rounded skeleton dark:border-gray-700';
-      container.appendChild(article);
-    }
-  }
-
-  function render(){
-    const container=document.getElementById('portfolio-grid');
-    const empty=document.getElementById('empty-state');
-    const items=applyFilters(state.items);
-    const visibleItems=items.slice(0,state.visible);
-    container.innerHTML='';
-    if(items.length===0){
-      empty.hidden=false;
-      announceCount(0);
-      return;
-    }
-    empty.hidden=true;
-    visibleItems.forEach(item=>{
-      const article=document.createElement('article');
-      article.className='case-card border p-4 rounded focus-within:ring outline-none hover-lift bg-white dark:bg-gray-800 dark:border-gray-700';
-      article.setAttribute('role','listitem');
-      article.setAttribute('aria-label',item.title);
-      article.innerHTML=`
+  empty.hidden = true;
+  visibleItems.forEach(item => {
+    const article = document.createElement('article');
+    article.className = 'case-card border p-4 rounded focus-within:ring outline-none hover-lift bg-white dark:bg-gray-800 dark:border-gray-700';
+    article.setAttribute('role', 'listitem');
+    article.setAttribute('aria-label', item.title);
+    article.innerHTML = `
         <div class="ph-media mb-3 rounded" role="img" aria-label="Placeholder"></div>
         <span class="badge mb-2">Demo</span>
         <h3 class="font-semibold mb-1">${item.title}</h3>
@@ -144,102 +185,126 @@
           <span class="flex items-center gap-1"><span aria-hidden="true">✅</span>${item.kpis[2]}</span>
         </p>
         <div class="flex flex-wrap gap-3">
-          <a class="btn btn-primary" aria-label="${t.view}: ${item.title}" href="${item.caseUrl}">${t.view}</a>
-          <a class="link" aria-label="${t.demo}: ${item.title}" href="${item.demoUrl}" target="_blank" rel="noopener">${t.demo}</a>
+          <a class="btn btn-primary" data-cta="case" data-slug="${item.slug}" aria-label="${t.view}: ${item.title}" href="${item.caseUrl}">${t.view}</a>
+          <a class="link" data-cta="demo" data-slug="${item.slug}" aria-label="${t.demo}: ${item.title}" href="${item.demoUrl}" target="_blank" rel="noopener">${t.demo}</a>
         </div>`;
-      container.appendChild(article);
-    });
-    const more=document.getElementById('load-more');
-    more.hidden=items.length<=state.visible;
-    more.textContent=t.load;
-    announceCount(visibleItems.length);
-  }
-
-  function updateURL(){
-    const url=new URL(location.href);
-    if(state.type!=='all') url.searchParams.set('type',state.type); else url.searchParams.delete('type');
-    if(state.sort!=='new') url.searchParams.set('sort',state.sort); else url.searchParams.delete('sort');
-    history.replaceState(null,'',url);
-  }
-
-  function initTabs(){
-    const tabs=Array.from(document.querySelectorAll('[data-type]'));
-    tabs.forEach(tab=>{
-      tab.addEventListener('click',()=>{
-        state.type=tab.getAttribute('data-type');
-        normalizeState();
-        updateURL();
-        state.visible=6;
-        updateControls();
-        render();
-      });
-      tab.addEventListener('keydown',e=>{
-        const idx=tabs.indexOf(document.activeElement);
-        if(e.key==='ArrowRight'){e.preventDefault();tabs[(idx+1)%tabs.length].focus();}
-        if(e.key==='ArrowLeft'){e.preventDefault();tabs[(idx-1+tabs.length)%tabs.length].focus();}
-        if(e.key==='Home'){e.preventDefault();tabs[0].focus();}
-        if(e.key==='End'){e.preventDefault();tabs[tabs.length-1].focus();}
-        if(e.key==='Enter'||e.key===' '){e.preventDefault();tab.click();}
-      });
-    });
-  }
-
-  function initSort(){
-    const button=document.getElementById('sort-button');
-    const menu=document.getElementById('sort-menu');
-    const options=Array.from(menu.querySelectorAll('[data-sort]'));
-    function close(){
-      menu.classList.add('hidden');
-      button.setAttribute('aria-expanded','false');
-      button.focus();
-    }
-    button.addEventListener('click',()=>{
-      const open=button.getAttribute('aria-expanded')==='true';
-      if(open){close();return;}
-      menu.classList.remove('hidden');
-      button.setAttribute('aria-expanded','true');
-      options[0].focus();
-    });
-    button.addEventListener('keydown',e=>{
-      if(e.key==='ArrowDown'){e.preventDefault();menu.classList.remove('hidden');button.setAttribute('aria-expanded','true');options[0].focus();}
-    });
-    menu.addEventListener('keydown',e=>{
-      const idx=options.indexOf(document.activeElement);
-      if(e.key==='ArrowDown'){e.preventDefault();options[(idx+1)%options.length].focus();}
-      if(e.key==='ArrowUp'){e.preventDefault();options[(idx-1+options.length)%options.length].focus();}
-      if(e.key==='Home'){e.preventDefault();options[0].focus();}
-      if(e.key==='End'){e.preventDefault();options[options.length-1].focus();}
-      if(e.key==='Escape'){e.preventDefault();close();}
-      if(e.key==='Tab'){e.preventDefault();}
-      if(e.key==='Enter'||e.key===' '){
-        e.preventDefault();
-        state.sort=document.activeElement.getAttribute('data-sort');
-        close();
-        updateURL();
-        updateControls();
-        render();
-      }
-    });
-  }
-
-  function initLoadMore(){
-    const more=document.getElementById('load-more');
-    more.addEventListener('click',()=>{state.visible+=3;render();});
-    if(!prefersReduced){
-      const io=new IntersectionObserver(entries=>{entries.forEach(e=>{if(e.isIntersecting){state.visible+=3;render();}})});
-      io.observe(more);
-    }
-  }
-
-  document.addEventListener('DOMContentLoaded',()=>{
-    applyReducedMotion();
-    renderSkeletons(state.visible);
-    loadData(lang);
-    hydrateFromURL();
-    initTabs();
-    initSort();
-    initLoadMore();
-    const reset=document.getElementById('reset-filters');
-    if(reset) reset.addEventListener('click',()=>{state.type='all';state.sort='new';updateURL();updateControls();render();});
+    container.appendChild(article);
   });
-})();
+  const more = document.getElementById('load-more');
+  more.hidden = items.length <= state.visible;
+  more.textContent = t.load;
+  announceCount(visibleItems.length);
+  bindCtaAnalytics(container);
+  container.setAttribute('aria-busy', 'false');
+}
+
+function updateURL() {
+  const url = new URL(location.href);
+  if (state.type !== 'all') url.searchParams.set('type', state.type); else url.searchParams.delete('type');
+  if (state.sort !== 'new') url.searchParams.set('sort', state.sort); else url.searchParams.delete('sort');
+  history.replaceState(null, '', url);
+}
+
+function initTabs() {
+  const tabs = Array.from(document.querySelectorAll('[data-type]'));
+  tabs.forEach(tab => {
+    tab.addEventListener('click', () => {
+      state.type = tab.getAttribute('data-type');
+      normalizeState();
+      updateURL();
+      state.visible = 6;
+      updateControls();
+      render();
+    });
+    tab.addEventListener('keydown', e => {
+      const idx = tabs.indexOf(document.activeElement);
+      if (e.key === 'ArrowRight') { e.preventDefault(); tabs[(idx + 1) % tabs.length].focus(); }
+      if (e.key === 'ArrowLeft') { e.preventDefault(); tabs[(idx - 1 + tabs.length) % tabs.length].focus(); }
+      if (e.key === 'Home') { e.preventDefault(); tabs[0].focus(); }
+      if (e.key === 'End') { e.preventDefault(); tabs[tabs.length - 1].focus(); }
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); tab.click(); }
+    });
+  });
+}
+
+function initSort() {
+  const button = document.getElementById('sort-button');
+  const menu = document.getElementById('sort-menu');
+  const options = Array.from(menu.querySelectorAll('[data-sort]'));
+  function close() {
+    menu.classList.add('hidden');
+    button.setAttribute('aria-expanded', 'false');
+    button.focus();
+  }
+  button.addEventListener('click', () => {
+    const open = button.getAttribute('aria-expanded') === 'true';
+    if (open) { close(); return; }
+    menu.classList.remove('hidden');
+    button.setAttribute('aria-expanded', 'true');
+    options[0].focus();
+  });
+  button.addEventListener('keydown', e => {
+    if (e.key === 'ArrowDown') { e.preventDefault(); menu.classList.remove('hidden'); button.setAttribute('aria-expanded', 'true'); options[0].focus(); }
+  });
+  menu.addEventListener('keydown', e => {
+    const idx = options.indexOf(document.activeElement);
+    if (e.key === 'ArrowDown') { e.preventDefault(); options[(idx + 1) % options.length].focus(); }
+    if (e.key === 'ArrowUp') { e.preventDefault(); options[(idx - 1 + options.length) % options.length].focus(); }
+    if (e.key === 'Home') { e.preventDefault(); options[0].focus(); }
+    if (e.key === 'End') { e.preventDefault(); options[options.length - 1].focus(); }
+    if (e.key === 'Escape') { e.preventDefault(); close(); }
+    if (e.key === 'Tab') { e.preventDefault(); }
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      state.sort = document.activeElement.getAttribute('data-sort');
+      close();
+      updateURL();
+      updateControls();
+      render();
+    }
+  });
+}
+
+function initLoadMore() {
+  const more = document.getElementById('load-more');
+  more.addEventListener('click', () => { state.visible += 3; render(); });
+  if (!prefersReduced) {
+    const io = new IntersectionObserver(entries => { entries.forEach(e => { if (e.isIntersecting) { state.visible += 3; render(); } }); });
+    io.observe(more);
+  }
+}
+
+function fireEvent(name, detail) {
+  try {
+    console.info('[analytics]', name, detail);
+    if (navigator.sendBeacon) {
+      const data = new Blob([JSON.stringify({ name, detail, ts: Date.now() })], { type: 'application/json' });
+      navigator.sendBeacon('/__lite-analytics', data);
+    }
+  } catch {}
+}
+
+export function bindCtaAnalytics(root = document) {
+  root.querySelectorAll('[data-cta]').forEach(el => {
+    el.addEventListener('click', () => {
+      fireEvent('cta_click', {
+        cta: el.getAttribute('data-cta'),
+        slug: el.getAttribute('data-slug') || null,
+        lang: getCurrentLang()
+      });
+    }, { passive: true });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  applyReducedMotion();
+  renderSkeletons(state.visible);
+  loadData(lang);
+  hydrateFromURL();
+  initTabs();
+  initSort();
+  initLoadMore();
+  const reset = document.getElementById('reset-filters');
+  if (reset) reset.addEventListener('click', () => { state.type = 'all'; state.sort = 'new'; updateURL(); updateControls(); render(); });
+});
+

--- a/assets/js/seo.js
+++ b/assets/js/seo.js
@@ -1,0 +1,56 @@
+export function injectItemListJSONLD({ items, lang, baseUrl, pagePath }) {
+  try {
+    const list = {
+      "@context": "https://schema.org",
+      "@type": "ItemList",
+      "itemListElement": items.map((it, idx) => ({
+        "@type": "ListItem",
+        "position": idx + 1,
+        "url": `${baseUrl}${it.caseUrl}`,
+        "name": it.title
+      }))
+    };
+    const s = document.createElement('script');
+    s.type = 'application/ld+json';
+    s.textContent = JSON.stringify(list);
+    document.head.appendChild(s);
+  } catch {}
+}
+
+export function setCanonicalAndHreflang({ baseUrl, langMap, currentLang, path }) {
+  // Canonical
+  const linkC = document.createElement('link');
+  linkC.rel = 'canonical';
+  linkC.href = `${baseUrl}${path}`;
+  document.head.appendChild(linkC);
+  // hreflang
+  Object.entries(langMap).forEach(([code, href]) => {
+    const l = document.createElement('link');
+    l.rel = 'alternate';
+    l.hreflang = code;
+    l.href = `${baseUrl}${href}`;
+    document.head.appendChild(l);
+  });
+  const xd = document.createElement('link');
+  xd.rel = 'alternate';
+  xd.hreflang = 'x-default';
+  xd.href = `${baseUrl}${langMap[currentLang]}`;
+  document.head.appendChild(xd);
+}
+
+export function setOpenGraphFallback(meta) {
+  const ensure = (name, content) => {
+    if (!document.querySelector(`meta[name="${name}"], meta[property="${name}"]`)) {
+      const m = document.createElement('meta');
+      if (name.startsWith('og:') || name.startsWith('twitter:')) m.setAttribute('property', name);
+      else m.setAttribute('name', name);
+      m.setAttribute('content', content);
+      document.head.appendChild(m);
+    }
+  };
+  ensure('og:type', 'website');
+  ensure('twitter:card', 'summary');
+  if (meta?.title) { ensure('og:title', meta.title); ensure('twitter:title', meta.title); }
+  if (meta?.description) { ensure('og:description', meta.description); ensure('twitter:description', meta.description); }
+}
+

--- a/de/portfolio.html
+++ b/de/portfolio.html
@@ -4,22 +4,11 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Portfolio – TurboSito</title>
-  <meta name="description" content="Demo-Cases – schnell und klar."/>
-  <link rel="canonical" href="https://deine-domain.tld/de/portfolio.html"/>
-  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio.html"/>
-  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio.html"/>
-  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio.html"/>
-  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/portfolio.html"/>
-  <meta property="og:title" content="Portfolio – TurboSito"/>
-  <meta property="og:description" content="Demo-Cases – schnell und klar."/>
-  <meta property="og:url" content="https://deine-domain.tld/de/portfolio.html"/>
-  <meta property="og:locale" content="de_DE"/>
-  <meta name="twitter:card" content="summary"/>
+  <meta name="description" content="Ehrliche Vorschau auf Stil, Struktur und Tempo. So könnte auch Ihr Projekt aussehen."/>
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
   <script src="/TurboSito/assets/js/theme.js" defer></script>
-  <script defer src="/TurboSito/assets/js/portfolio.js"></script>
 </head>
 <body class="font-sans text-gray-900">
   <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Zum Inhalt springen</a>
@@ -50,11 +39,11 @@
   <main id="content" class="max-w-6xl mx-auto px-4 py-12">
     <section class="text-center mb-10">
       <h1 class="text-3xl font-bold mb-2">Portfolio</h1>
-      <p>Ehrliche Vorschau auf unseren Prozess.</p>
+      <p>So könnte auch Ihr Projekt aussehen – schnell, performant, messbar.</p>
     </section>
     <div aria-live="polite" class="sr-only" id="live-status"></div>
     <section>
-      <nav class="flex flex-wrap gap-2 justify-center mb-4" role="tablist">
+      <nav class="flex flex-wrap gap-2 justify-center mb-4" role="tablist" aria-orientation="horizontal">
         <button data-type="all" role="tab" aria-controls="portfolio-grid" aria-selected="true" tabindex="0" class="px-3 py-1 border rounded dark:border-gray-700">Alle</button>
         <button data-type="landing" role="tab" aria-controls="portfolio-grid" aria-selected="false" tabindex="-1" class="px-3 py-1 border rounded dark:border-gray-700">Landingpages</button>
         <button data-type="corporate" role="tab" aria-controls="portfolio-grid" aria-selected="false" tabindex="-1" class="px-3 py-1 border rounded dark:border-gray-700">Corporate</button>
@@ -73,8 +62,8 @@
       </div>
       <div id="portfolio-grid" class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3" role="list"></div>
       <div id="empty-state" class="text-center p-4 border rounded" hidden>
-        <p>Keine Projekte gefunden.</p>
-        <button id="reset-filters" class="btn btn-primary mt-2">Filter zurücksetzen</button>
+        <p>Keine Treffer. Passen Sie Filter oder Sortierung an.</p>
+        <button id="reset-filters" class="btn btn-primary mt-2" aria-label="Filter zurücksetzen und alle Projekte anzeigen">Filter zurücksetzen</button>
       </div>
       <div class="text-center mt-6">
         <button id="load-more" class="px-4 py-2 border rounded"></button>
@@ -84,5 +73,17 @@
   <footer class="text-center py-10 text-sm">
     <p>&copy; TurboSito</p>
   </footer>
+  <script type="module">
+    import { injectItemListJSONLD, setCanonicalAndHreflang, setOpenGraphFallback } from '/TurboSito/assets/js/seo.js';
+    import { getCurrentLang, getBaseUrl, getOverviewItems, getLangPathMap, getMeta } from '/TurboSito/assets/js/portfolio.js';
+    const lang = getCurrentLang();
+    const baseUrl = getBaseUrl();
+    const path = location.pathname.replace(/^\/TurboSito/, '');
+    setCanonicalAndHreflang({ baseUrl, langMap: getLangPathMap(path), currentLang: lang, path });
+    setOpenGraphFallback(getMeta('overview'));
+    document.addEventListener('portfolio:items-ready', () => {
+      injectItemListJSONLD({ items: getOverviewItems(), lang, baseUrl, pagePath: path });
+    });
+  </script>
 </body>
 </html>

--- a/de/portfolio/corporate-site.html
+++ b/de/portfolio/corporate-site.html
@@ -5,16 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Corporate-Site – TurboSito</title>
   <meta name="description" content="Demo-Case: Corporate-Website."/>
-  <link rel="canonical" href="https://deine-domain.tld/de/portfolio/corporate-site.html"/>
-  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio/corporate-site.html"/>
-  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio/corporate-site.html"/>
-  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio/corporate-site.html"/>
-  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/portfolio/corporate-site.html"/>
-  <meta property="og:title" content="Corporate-Site – TurboSito"/>
-  <meta property="og:description" content="Demo-Case: Vertrauen und Struktur."/>
-  <meta property="og:url" content="https://deine-domain.tld/de/portfolio/corporate-site.html"/>
-  <meta property="og:locale" content="de_DE"/>
-  <meta name="twitter:card" content="summary"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
@@ -94,7 +84,15 @@
         const res=await fetch(`/TurboSito/assets/data/portfolio.${lang}.json`);
         const data=await res.json();
         const item=data.items.find(i=>i.slug===slug);
-        if(!item){location.href='../portfolio.html?missing=1';return;}
+        if(!item){
+          const msg=document.createElement('p');
+          msg.textContent='Case nicht gefunden, zurück zum Portfolio';
+          msg.className='sr-only';
+          msg.setAttribute('aria-live','assertive');
+          document.body.appendChild(msg);
+          location.href='../portfolio.html?missing=1';
+          return;
+        }
         document.getElementById('case-title').textContent=item.title;
         document.getElementById('case-summary').textContent=item.summary;
         document.getElementById('kpi-1').textContent=item.kpis[0];
@@ -121,10 +119,24 @@
           ]
         }];
         document.getElementById('ld-json').textContent=JSON.stringify(ld);
-      }catch(e){location.href='../portfolio.html?missing=1';}
+      }catch(e){
+        const msg=document.createElement('p');
+        msg.textContent='Case nicht gefunden, zurück zum Portfolio';
+        msg.className='sr-only';
+        msg.setAttribute('aria-live','assertive');
+        document.body.appendChild(msg);
+        location.href='../portfolio.html?missing=1';
+      }
     })();
     </script>
   </main>
   <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+  <script type="module">
+    import { setCanonicalAndHreflang, setOpenGraphFallback } from '/TurboSito/assets/js/seo.js';
+    import { getCurrentLang, getBaseUrl, getLangPathMap, getMeta } from '/TurboSito/assets/js/portfolio.js';
+    const path = location.pathname.replace(/^\/TurboSito/, '');
+    setCanonicalAndHreflang({ baseUrl: getBaseUrl(), langMap: getLangPathMap(path), currentLang: getCurrentLang(), path });
+    setOpenGraphFallback(getMeta('case'));
+  </script>
 </body>
 </html>

--- a/de/portfolio/fashion-shop.html
+++ b/de/portfolio/fashion-shop.html
@@ -5,16 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Fashion-Shop – TurboSito</title>
   <meta name="description" content="Demo-Case: Fashion-Shop."/>
-  <link rel="canonical" href="https://deine-domain.tld/de/portfolio/fashion-shop.html"/>
-  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio/fashion-shop.html"/>
-  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio/fashion-shop.html"/>
-  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio/fashion-shop.html"/>
-  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/portfolio/fashion-shop.html"/>
-  <meta property="og:title" content="Fashion-Shop – TurboSito"/>
-  <meta property="og:description" content="Demo-Case: Klarer Shop-Fokus."/>
-  <meta property="og:url" content="https://deine-domain.tld/de/portfolio/fashion-shop.html"/>
-  <meta property="og:locale" content="de_DE"/>
-  <meta name="twitter:card" content="summary"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
@@ -94,7 +84,15 @@
         const res=await fetch(`/TurboSito/assets/data/portfolio.${lang}.json`);
         const data=await res.json();
         const item=data.items.find(i=>i.slug===slug);
-        if(!item){location.href='../portfolio.html?missing=1';return;}
+        if(!item){
+          const msg=document.createElement('p');
+          msg.textContent='Case nicht gefunden, zurück zum Portfolio';
+          msg.className='sr-only';
+          msg.setAttribute('aria-live','assertive');
+          document.body.appendChild(msg);
+          location.href='../portfolio.html?missing=1';
+          return;
+        }
         document.getElementById('case-title').textContent=item.title;
         document.getElementById('case-summary').textContent=item.summary;
         document.getElementById('kpi-1').textContent=item.kpis[0];
@@ -121,10 +119,24 @@
           ]
         }];
         document.getElementById('ld-json').textContent=JSON.stringify(ld);
-      }catch(e){location.href='../portfolio.html?missing=1';}
+      }catch(e){
+        const msg=document.createElement('p');
+        msg.textContent='Case nicht gefunden, zurück zum Portfolio';
+        msg.className='sr-only';
+        msg.setAttribute('aria-live','assertive');
+        document.body.appendChild(msg);
+        location.href='../portfolio.html?missing=1';
+      }
     })();
     </script>
   </main>
   <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+  <script type="module">
+    import { setCanonicalAndHreflang, setOpenGraphFallback } from '/TurboSito/assets/js/seo.js';
+    import { getCurrentLang, getBaseUrl, getLangPathMap, getMeta } from '/TurboSito/assets/js/portfolio.js';
+    const path = location.pathname.replace(/^\/TurboSito/, '');
+    setCanonicalAndHreflang({ baseUrl: getBaseUrl(), langMap: getLangPathMap(path), currentLang: getCurrentLang(), path });
+    setOpenGraphFallback(getMeta('case'));
+  </script>
 </body>
 </html>

--- a/de/portfolio/saas-landing.html
+++ b/de/portfolio/saas-landing.html
@@ -5,16 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>SaaS-Landing – TurboSito</title>
   <meta name="description" content="Demo-Case: SaaS-Landingpage."/>
-  <link rel="canonical" href="https://deine-domain.tld/de/portfolio/saas-landing.html"/>
-  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio/saas-landing.html"/>
-  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio/saas-landing.html"/>
-  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio/saas-landing.html"/>
-  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/portfolio/saas-landing.html"/>
-  <meta property="og:title" content="SaaS-Landing – TurboSito"/>
-  <meta property="og:description" content="Demo-Case: Stil, Struktur, Speed."/>
-  <meta property="og:url" content="https://deine-domain.tld/de/portfolio/saas-landing.html"/>
-  <meta property="og:locale" content="de_DE"/>
-  <meta name="twitter:card" content="summary"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
@@ -94,7 +84,15 @@
         const res=await fetch(`/TurboSito/assets/data/portfolio.${lang}.json`);
         const data=await res.json();
         const item=data.items.find(i=>i.slug===slug);
-        if(!item){location.href='../portfolio.html?missing=1';return;}
+        if(!item){
+          const msg=document.createElement('p');
+          msg.textContent='Case nicht gefunden, zurück zum Portfolio';
+          msg.className='sr-only';
+          msg.setAttribute('aria-live','assertive');
+          document.body.appendChild(msg);
+          location.href='../portfolio.html?missing=1';
+          return;
+        }
         document.getElementById('case-title').textContent=item.title;
         document.getElementById('case-summary').textContent=item.summary;
         document.getElementById('kpi-1').textContent=item.kpis[0];
@@ -121,10 +119,24 @@
           ]
         }];
         document.getElementById('ld-json').textContent=JSON.stringify(ld);
-      }catch(e){location.href='../portfolio.html?missing=1';}
+      }catch(e){
+        const msg=document.createElement('p');
+        msg.textContent='Case nicht gefunden, zurück zum Portfolio';
+        msg.className='sr-only';
+        msg.setAttribute('aria-live','assertive');
+        document.body.appendChild(msg);
+        location.href='../portfolio.html?missing=1';
+      }
     })();
     </script>
   </main>
   <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+  <script type="module">
+    import { setCanonicalAndHreflang, setOpenGraphFallback } from '/TurboSito/assets/js/seo.js';
+    import { getCurrentLang, getBaseUrl, getLangPathMap, getMeta } from '/TurboSito/assets/js/portfolio.js';
+    const path = location.pathname.replace(/^\/TurboSito/, '');
+    setCanonicalAndHreflang({ baseUrl: getBaseUrl(), langMap: getLangPathMap(path), currentLang: getCurrentLang(), path });
+    setOpenGraphFallback(getMeta('case'));
+  </script>
 </body>
 </html>

--- a/en/portfolio.html
+++ b/en/portfolio.html
@@ -4,22 +4,11 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Portfolio – TurboSito</title>
-  <meta name="description" content="Demo cases – fast and clear."/>
-  <link rel="canonical" href="https://deine-domain.tld/en/portfolio.html"/>
-  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio.html"/>
-  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio.html"/>
-  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio.html"/>
-  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/portfolio.html"/>
-  <meta property="og:title" content="Portfolio – TurboSito"/>
-  <meta property="og:description" content="Demo cases – fast and clear."/>
-  <meta property="og:url" content="https://deine-domain.tld/en/portfolio.html"/>
-  <meta property="og:locale" content="en_US"/>
-  <meta name="twitter:card" content="summary"/>
+  <meta name="description" content="Honest preview of style, structure and speed. Your project could look like this."/>
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
   <script src="/TurboSito/assets/js/theme.js" defer></script>
-  <script defer src="/TurboSito/assets/js/portfolio.js"></script>
 </head>
 <body class="font-sans text-gray-900">
   <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
@@ -50,11 +39,11 @@
   <main id="content" class="max-w-6xl mx-auto px-4 py-12">
     <section class="text-center mb-10">
       <h1 class="text-3xl font-bold mb-2">Portfolio</h1>
-      <p>Honest preview of our process.</p>
+      <p>See how your project could look – fast, performant, measurable.</p>
     </section>
     <div aria-live="polite" class="sr-only" id="live-status"></div>
     <section>
-      <nav class="flex flex-wrap gap-2 justify-center mb-4" role="tablist">
+      <nav class="flex flex-wrap gap-2 justify-center mb-4" role="tablist" aria-orientation="horizontal">
         <button data-type="all" role="tab" aria-controls="portfolio-grid" aria-selected="true" tabindex="0" class="px-3 py-1 border rounded dark:border-gray-700">All</button>
         <button data-type="landing" role="tab" aria-controls="portfolio-grid" aria-selected="false" tabindex="-1" class="px-3 py-1 border rounded dark:border-gray-700">Landing pages</button>
         <button data-type="corporate" role="tab" aria-controls="portfolio-grid" aria-selected="false" tabindex="-1" class="px-3 py-1 border rounded dark:border-gray-700">Corporate</button>
@@ -73,8 +62,8 @@
       </div>
       <div id="portfolio-grid" class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3" role="list"></div>
       <div id="empty-state" class="text-center p-4 border rounded" hidden>
-        <p>No projects found.</p>
-        <button id="reset-filters" class="btn btn-primary mt-2">Reset filters</button>
+        <p>No matches. Adjust filter or sort.</p>
+        <button id="reset-filters" class="btn btn-primary mt-2" aria-label="Reset filters and show all projects">Reset filters</button>
       </div>
       <div class="text-center mt-6">
         <button id="load-more" class="px-4 py-2 border rounded"></button>
@@ -84,5 +73,17 @@
   <footer class="text-center py-10 text-sm">
     <p>&copy; TurboSito</p>
   </footer>
+  <script type="module">
+    import { injectItemListJSONLD, setCanonicalAndHreflang, setOpenGraphFallback } from '/TurboSito/assets/js/seo.js';
+    import { getCurrentLang, getBaseUrl, getOverviewItems, getLangPathMap, getMeta } from '/TurboSito/assets/js/portfolio.js';
+    const lang = getCurrentLang();
+    const baseUrl = getBaseUrl();
+    const path = location.pathname.replace(/^\/TurboSito/, '');
+    setCanonicalAndHreflang({ baseUrl, langMap: getLangPathMap(path), currentLang: lang, path });
+    setOpenGraphFallback(getMeta('overview'));
+    document.addEventListener('portfolio:items-ready', () => {
+      injectItemListJSONLD({ items: getOverviewItems(), lang, baseUrl, pagePath: path });
+    });
+  </script>
 </body>
 </html>

--- a/en/portfolio/corporate-site.html
+++ b/en/portfolio/corporate-site.html
@@ -5,16 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Corporate Site – TurboSito</title>
   <meta name="description" content="Demo case: corporate website."/>
-  <link rel="canonical" href="https://deine-domain.tld/en/portfolio/corporate-site.html"/>
-  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio/corporate-site.html"/>
-  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio/corporate-site.html"/>
-  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio/corporate-site.html"/>
-  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/portfolio/corporate-site.html"/>
-  <meta property="og:title" content="Corporate Site – TurboSito"/>
-  <meta property="og:description" content="Demo case: trust and structure."/>
-  <meta property="og:url" content="https://deine-domain.tld/en/portfolio/corporate-site.html"/>
-  <meta property="og:locale" content="en_US"/>
-  <meta name="twitter:card" content="summary"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
@@ -94,7 +84,15 @@
         const res=await fetch(`/TurboSito/assets/data/portfolio.${lang}.json`);
         const data=await res.json();
         const item=data.items.find(i=>i.slug===slug);
-        if(!item){location.href='../portfolio.html?missing=1';return;}
+        if(!item){
+          const msg=document.createElement('p');
+          msg.textContent='Case not found, back to portfolio';
+          msg.className='sr-only';
+          msg.setAttribute('aria-live','assertive');
+          document.body.appendChild(msg);
+          location.href='../portfolio.html?missing=1';
+          return;
+        }
         document.getElementById('case-title').textContent=item.title;
         document.getElementById('case-summary').textContent=item.summary;
         document.getElementById('kpi-1').textContent=item.kpis[0];
@@ -121,10 +119,24 @@
           ]
         }];
         document.getElementById('ld-json').textContent=JSON.stringify(ld);
-      }catch(e){location.href='../portfolio.html?missing=1';}
+      }catch(e){
+        const msg=document.createElement('p');
+        msg.textContent='Case not found, back to portfolio';
+        msg.className='sr-only';
+        msg.setAttribute('aria-live','assertive');
+        document.body.appendChild(msg);
+        location.href='../portfolio.html?missing=1';
+      }
     })();
     </script>
   </main>
   <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+  <script type="module">
+    import { setCanonicalAndHreflang, setOpenGraphFallback } from '/TurboSito/assets/js/seo.js';
+    import { getCurrentLang, getBaseUrl, getLangPathMap, getMeta } from '/TurboSito/assets/js/portfolio.js';
+    const path = location.pathname.replace(/^\/TurboSito/, '');
+    setCanonicalAndHreflang({ baseUrl: getBaseUrl(), langMap: getLangPathMap(path), currentLang: getCurrentLang(), path });
+    setOpenGraphFallback(getMeta('case'));
+  </script>
 </body>
 </html>

--- a/en/portfolio/fashion-shop.html
+++ b/en/portfolio/fashion-shop.html
@@ -5,16 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Fashion Shop – TurboSito</title>
   <meta name="description" content="Demo case: fashion shop."/>
-  <link rel="canonical" href="https://deine-domain.tld/en/portfolio/fashion-shop.html"/>
-  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio/fashion-shop.html"/>
-  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio/fashion-shop.html"/>
-  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio/fashion-shop.html"/>
-  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/portfolio/fashion-shop.html"/>
-  <meta property="og:title" content="Fashion Shop – TurboSito"/>
-  <meta property="og:description" content="Demo case: clear shop focus."/>
-  <meta property="og:url" content="https://deine-domain.tld/en/portfolio/fashion-shop.html"/>
-  <meta property="og:locale" content="en_US"/>
-  <meta name="twitter:card" content="summary"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
@@ -94,7 +84,15 @@
         const res=await fetch(`/TurboSito/assets/data/portfolio.${lang}.json`);
         const data=await res.json();
         const item=data.items.find(i=>i.slug===slug);
-        if(!item){location.href='../portfolio.html?missing=1';return;}
+        if(!item){
+          const msg=document.createElement('p');
+          msg.textContent='Case not found, back to portfolio';
+          msg.className='sr-only';
+          msg.setAttribute('aria-live','assertive');
+          document.body.appendChild(msg);
+          location.href='../portfolio.html?missing=1';
+          return;
+        }
         document.getElementById('case-title').textContent=item.title;
         document.getElementById('case-summary').textContent=item.summary;
         document.getElementById('kpi-1').textContent=item.kpis[0];
@@ -121,10 +119,24 @@
           ]
         }];
         document.getElementById('ld-json').textContent=JSON.stringify(ld);
-      }catch(e){location.href='../portfolio.html?missing=1';}
+      }catch(e){
+        const msg=document.createElement('p');
+        msg.textContent='Case not found, back to portfolio';
+        msg.className='sr-only';
+        msg.setAttribute('aria-live','assertive');
+        document.body.appendChild(msg);
+        location.href='../portfolio.html?missing=1';
+      }
     })();
     </script>
   </main>
   <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+  <script type="module">
+    import { setCanonicalAndHreflang, setOpenGraphFallback } from '/TurboSito/assets/js/seo.js';
+    import { getCurrentLang, getBaseUrl, getLangPathMap, getMeta } from '/TurboSito/assets/js/portfolio.js';
+    const path = location.pathname.replace(/^\/TurboSito/, '');
+    setCanonicalAndHreflang({ baseUrl: getBaseUrl(), langMap: getLangPathMap(path), currentLang: getCurrentLang(), path });
+    setOpenGraphFallback(getMeta('case'));
+  </script>
 </body>
 </html>

--- a/en/portfolio/saas-landing.html
+++ b/en/portfolio/saas-landing.html
@@ -5,16 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>SaaS Landing – TurboSito</title>
   <meta name="description" content="Demo case: SaaS landing page."/>
-  <link rel="canonical" href="https://deine-domain.tld/en/portfolio/saas-landing.html"/>
-  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio/saas-landing.html"/>
-  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio/saas-landing.html"/>
-  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio/saas-landing.html"/>
-  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/portfolio/saas-landing.html"/>
-  <meta property="og:title" content="SaaS Landing – TurboSito"/>
-  <meta property="og:description" content="Demo case: style, structure, speed."/>
-  <meta property="og:url" content="https://deine-domain.tld/en/portfolio/saas-landing.html"/>
-  <meta property="og:locale" content="en_US"/>
-  <meta name="twitter:card" content="summary"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
@@ -94,7 +84,15 @@
         const res=await fetch(`/TurboSito/assets/data/portfolio.${lang}.json`);
         const data=await res.json();
         const item=data.items.find(i=>i.slug===slug);
-        if(!item){location.href='../portfolio.html?missing=1';return;}
+        if(!item){
+          const msg=document.createElement('p');
+          msg.textContent='Case not found, back to portfolio';
+          msg.className='sr-only';
+          msg.setAttribute('aria-live','assertive');
+          document.body.appendChild(msg);
+          location.href='../portfolio.html?missing=1';
+          return;
+        }
         document.getElementById('case-title').textContent=item.title;
         document.getElementById('case-summary').textContent=item.summary;
         document.getElementById('kpi-1').textContent=item.kpis[0];
@@ -121,10 +119,24 @@
           ]
         }];
         document.getElementById('ld-json').textContent=JSON.stringify(ld);
-      }catch(e){location.href='../portfolio.html?missing=1';}
+      }catch(e){
+        const msg=document.createElement('p');
+        msg.textContent='Case not found, back to portfolio';
+        msg.className='sr-only';
+        msg.setAttribute('aria-live','assertive');
+        document.body.appendChild(msg);
+        location.href='../portfolio.html?missing=1';
+      }
     })();
     </script>
   </main>
   <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+  <script type="module">
+    import { setCanonicalAndHreflang, setOpenGraphFallback } from '/TurboSito/assets/js/seo.js';
+    import { getCurrentLang, getBaseUrl, getLangPathMap, getMeta } from '/TurboSito/assets/js/portfolio.js';
+    const path = location.pathname.replace(/^\/TurboSito/, '');
+    setCanonicalAndHreflang({ baseUrl: getBaseUrl(), langMap: getLangPathMap(path), currentLang: getCurrentLang(), path });
+    setOpenGraphFallback(getMeta('case'));
+  </script>
 </body>
 </html>

--- a/it/portfolio.html
+++ b/it/portfolio.html
@@ -4,22 +4,11 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Portfolio – TurboSito</title>
-  <meta name="description" content="Demo case – rapidi e chiari."/>
-  <link rel="canonical" href="https://deine-domain.tld/it/portfolio.html"/>
-  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio.html"/>
-  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio.html"/>
-  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio.html"/>
-  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/portfolio.html"/>
-  <meta property="og:title" content="Portfolio – TurboSito"/>
-  <meta property="og:description" content="Demo case – rapidi e chiari."/>
-  <meta property="og:url" content="https://deine-domain.tld/it/portfolio.html"/>
-  <meta property="og:locale" content="it_IT"/>
-  <meta name="twitter:card" content="summary"/>
+  <meta name="description" content="Anteprima onesta di stile, struttura e velocità. Così potrebbe essere il tuo progetto."/>
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
   <script src="/TurboSito/assets/js/theme.js" defer></script>
-  <script defer src="/TurboSito/assets/js/portfolio.js"></script>
 </head>
 <body class="font-sans text-gray-900">
   <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Vai al contenuto</a>
@@ -50,11 +39,11 @@
   <main id="content" class="max-w-6xl mx-auto px-4 py-12">
     <section class="text-center mb-10">
       <h1 class="text-3xl font-bold mb-2">Portfolio</h1>
-      <p>Anteprima onesta del nostro processo.</p>
+      <p>Così potrebbe essere il tuo progetto – veloce, performante, misurabile.</p>
     </section>
     <div aria-live="polite" class="sr-only" id="live-status"></div>
     <section>
-      <nav class="flex flex-wrap gap-2 justify-center mb-4" role="tablist">
+      <nav class="flex flex-wrap gap-2 justify-center mb-4" role="tablist" aria-orientation="horizontal">
         <button data-type="all" role="tab" aria-controls="portfolio-grid" aria-selected="true" tabindex="0" class="px-3 py-1 border rounded dark:border-gray-700">Tutte</button>
         <button data-type="landing" role="tab" aria-controls="portfolio-grid" aria-selected="false" tabindex="-1" class="px-3 py-1 border rounded dark:border-gray-700">Landing page</button>
         <button data-type="corporate" role="tab" aria-controls="portfolio-grid" aria-selected="false" tabindex="-1" class="px-3 py-1 border rounded dark:border-gray-700">Corporate</button>
@@ -73,8 +62,8 @@
       </div>
       <div id="portfolio-grid" class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3" role="list"></div>
       <div id="empty-state" class="text-center p-4 border rounded" hidden>
-        <p>Nessun progetto trovato.</p>
-        <button id="reset-filters" class="btn btn-primary mt-2">Reimposta filtri</button>
+        <p>Nessun risultato. Modifica filtri o ordinamento.</p>
+        <button id="reset-filters" class="btn btn-primary mt-2" aria-label="Reimposta filtri e mostra tutti i progetti">Reimposta filtri</button>
       </div>
       <div class="text-center mt-6">
         <button id="load-more" class="px-4 py-2 border rounded"></button>
@@ -84,5 +73,17 @@
   <footer class="text-center py-10 text-sm">
     <p>&copy; TurboSito</p>
   </footer>
+  <script type="module">
+    import { injectItemListJSONLD, setCanonicalAndHreflang, setOpenGraphFallback } from '/TurboSito/assets/js/seo.js';
+    import { getCurrentLang, getBaseUrl, getOverviewItems, getLangPathMap, getMeta } from '/TurboSito/assets/js/portfolio.js';
+    const lang = getCurrentLang();
+    const baseUrl = getBaseUrl();
+    const path = location.pathname.replace(/^\/TurboSito/, '');
+    setCanonicalAndHreflang({ baseUrl, langMap: getLangPathMap(path), currentLang: lang, path });
+    setOpenGraphFallback(getMeta('overview'));
+    document.addEventListener('portfolio:items-ready', () => {
+      injectItemListJSONLD({ items: getOverviewItems(), lang, baseUrl, pagePath: path });
+    });
+  </script>
 </body>
 </html>

--- a/it/portfolio/corporate-site.html
+++ b/it/portfolio/corporate-site.html
@@ -5,16 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Corporate Site – TurboSito</title>
   <meta name="description" content="Caso demo: sito corporate."/>
-  <link rel="canonical" href="https://deine-domain.tld/it/portfolio/corporate-site.html"/>
-  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio/corporate-site.html"/>
-  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio/corporate-site.html"/>
-  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio/corporate-site.html"/>
-  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/portfolio/corporate-site.html"/>
-  <meta property="og:title" content="Corporate Site – TurboSito"/>
-  <meta property="og:description" content="Caso demo: fiducia e struttura."/>
-  <meta property="og:url" content="https://deine-domain.tld/it/portfolio/corporate-site.html"/>
-  <meta property="og:locale" content="it_IT"/>
-  <meta name="twitter:card" content="summary"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
@@ -94,7 +84,15 @@
         const res=await fetch(`/TurboSito/assets/data/portfolio.${lang}.json`);
         const data=await res.json();
         const item=data.items.find(i=>i.slug===slug);
-        if(!item){location.href='../portfolio.html?missing=1';return;}
+        if(!item){
+          const msg=document.createElement('p');
+          msg.textContent='Case non trovato, torna al portfolio';
+          msg.className='sr-only';
+          msg.setAttribute('aria-live','assertive');
+          document.body.appendChild(msg);
+          location.href='../portfolio.html?missing=1';
+          return;
+        }
         document.getElementById('case-title').textContent=item.title;
         document.getElementById('case-summary').textContent=item.summary;
         document.getElementById('kpi-1').textContent=item.kpis[0];
@@ -121,10 +119,24 @@
           ]
         }];
         document.getElementById('ld-json').textContent=JSON.stringify(ld);
-      }catch(e){location.href='../portfolio.html?missing=1';}
+      }catch(e){
+        const msg=document.createElement('p');
+        msg.textContent='Case non trovato, torna al portfolio';
+        msg.className='sr-only';
+        msg.setAttribute('aria-live','assertive');
+        document.body.appendChild(msg);
+        location.href='../portfolio.html?missing=1';
+      }
     })();
     </script>
   </main>
   <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+  <script type="module">
+    import { setCanonicalAndHreflang, setOpenGraphFallback } from '/TurboSito/assets/js/seo.js';
+    import { getCurrentLang, getBaseUrl, getLangPathMap, getMeta } from '/TurboSito/assets/js/portfolio.js';
+    const path = location.pathname.replace(/^\/TurboSito/, '');
+    setCanonicalAndHreflang({ baseUrl: getBaseUrl(), langMap: getLangPathMap(path), currentLang: getCurrentLang(), path });
+    setOpenGraphFallback(getMeta('case'));
+  </script>
 </body>
 </html>

--- a/it/portfolio/fashion-shop.html
+++ b/it/portfolio/fashion-shop.html
@@ -5,16 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Fashion Shop – TurboSito</title>
   <meta name="description" content="Caso demo: shop moda."/>
-  <link rel="canonical" href="https://deine-domain.tld/it/portfolio/fashion-shop.html"/>
-  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio/fashion-shop.html"/>
-  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio/fashion-shop.html"/>
-  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio/fashion-shop.html"/>
-  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/portfolio/fashion-shop.html"/>
-  <meta property="og:title" content="Fashion Shop – TurboSito"/>
-  <meta property="og:description" content="Caso demo: focus chiaro sullo shop."/>
-  <meta property="og:url" content="https://deine-domain.tld/it/portfolio/fashion-shop.html"/>
-  <meta property="og:locale" content="it_IT"/>
-  <meta name="twitter:card" content="summary"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
@@ -94,7 +84,15 @@
         const res=await fetch(`/TurboSito/assets/data/portfolio.${lang}.json`);
         const data=await res.json();
         const item=data.items.find(i=>i.slug===slug);
-        if(!item){location.href='../portfolio.html?missing=1';return;}
+        if(!item){
+          const msg=document.createElement('p');
+          msg.textContent='Case non trovato, torna al portfolio';
+          msg.className='sr-only';
+          msg.setAttribute('aria-live','assertive');
+          document.body.appendChild(msg);
+          location.href='../portfolio.html?missing=1';
+          return;
+        }
         document.getElementById('case-title').textContent=item.title;
         document.getElementById('case-summary').textContent=item.summary;
         document.getElementById('kpi-1').textContent=item.kpis[0];
@@ -121,10 +119,24 @@
           ]
         }];
         document.getElementById('ld-json').textContent=JSON.stringify(ld);
-      }catch(e){location.href='../portfolio.html?missing=1';}
+      }catch(e){
+        const msg=document.createElement('p');
+        msg.textContent='Case non trovato, torna al portfolio';
+        msg.className='sr-only';
+        msg.setAttribute('aria-live','assertive');
+        document.body.appendChild(msg);
+        location.href='../portfolio.html?missing=1';
+      }
     })();
     </script>
   </main>
   <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+  <script type="module">
+    import { setCanonicalAndHreflang, setOpenGraphFallback } from '/TurboSito/assets/js/seo.js';
+    import { getCurrentLang, getBaseUrl, getLangPathMap, getMeta } from '/TurboSito/assets/js/portfolio.js';
+    const path = location.pathname.replace(/^\/TurboSito/, '');
+    setCanonicalAndHreflang({ baseUrl: getBaseUrl(), langMap: getLangPathMap(path), currentLang: getCurrentLang(), path });
+    setOpenGraphFallback(getMeta('case'));
+  </script>
 </body>
 </html>

--- a/it/portfolio/saas-landing.html
+++ b/it/portfolio/saas-landing.html
@@ -5,16 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Landing SaaS – TurboSito</title>
   <meta name="description" content="Caso demo: landing SaaS."/>
-  <link rel="canonical" href="https://deine-domain.tld/it/portfolio/saas-landing.html"/>
-  <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio/saas-landing.html"/>
-  <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio/saas-landing.html"/>
-  <link rel="alternate" hreflang="it" href="https://deine-domain.tld/it/portfolio/saas-landing.html"/>
-  <link rel="alternate" hreflang="x-default" href="https://deine-domain.tld/en/portfolio/saas-landing.html"/>
-  <meta property="og:title" content="Landing SaaS – TurboSito"/>
-  <meta property="og:description" content="Caso demo: stile, struttura, velocità."/>
-  <meta property="og:url" content="https://deine-domain.tld/it/portfolio/saas-landing.html"/>
-  <meta property="og:locale" content="it_IT"/>
-  <meta name="twitter:card" content="summary"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
@@ -94,7 +84,15 @@
         const res=await fetch(`/TurboSito/assets/data/portfolio.${lang}.json`);
         const data=await res.json();
         const item=data.items.find(i=>i.slug===slug);
-        if(!item){location.href='../portfolio.html?missing=1';return;}
+        if(!item){
+          const msg=document.createElement('p');
+          msg.textContent='Case non trovato, torna al portfolio';
+          msg.className='sr-only';
+          msg.setAttribute('aria-live','assertive');
+          document.body.appendChild(msg);
+          location.href='../portfolio.html?missing=1';
+          return;
+        }
         document.getElementById('case-title').textContent=item.title;
         document.getElementById('case-summary').textContent=item.summary;
         document.getElementById('kpi-1').textContent=item.kpis[0];
@@ -121,10 +119,24 @@
           ]
         }];
         document.getElementById('ld-json').textContent=JSON.stringify(ld);
-      }catch(e){location.href='../portfolio.html?missing=1';}
+      }catch(e){
+        const msg=document.createElement('p');
+        msg.textContent='Case non trovato, torna al portfolio';
+        msg.className='sr-only';
+        msg.setAttribute('aria-live','assertive');
+        document.body.appendChild(msg);
+        location.href='../portfolio.html?missing=1';
+      }
     })();
     </script>
   </main>
   <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+  <script type="module">
+    import { setCanonicalAndHreflang, setOpenGraphFallback } from '/TurboSito/assets/js/seo.js';
+    import { getCurrentLang, getBaseUrl, getLangPathMap, getMeta } from '/TurboSito/assets/js/portfolio.js';
+    const path = location.pathname.replace(/^\/TurboSito/, '');
+    setCanonicalAndHreflang({ baseUrl: getBaseUrl(), langMap: getLangPathMap(path), currentLang: getCurrentLang(), path });
+    setOpenGraphFallback(getMeta('case'));
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add lightweight SEO utilities to inject ItemList JSON-LD, canonical/hreflang pairs, and OpenGraph/Twitter fallbacks
- refine portfolio module with schema validation, aria-busy handling, and anonymous CTA analytics
- update portfolio and case pages across languages with improved microcopy, accessibility, and dynamic meta handling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bee44482a4833289294914c8a1b0bc