### PR TITLE
Load header and footer via partials on portfolio pages

### DIFF
--- a/assets/js/partials.js
+++ b/assets/js/partials.js
@@ -1,0 +1,50 @@
+(function () {
+  const CACHE = new Map();
+
+  function langPrefix() {
+    // Pfad beginnt z.B. mit /de/ | /en/ | /it/ -> liefere "de" etc., sonst ""
+    const m = location.pathname.match(/^\/(de|en|it)\b/);
+    return m ? `/${m[1]}` : "";
+  }
+
+  function resolvePartialPath(rel) {
+    // Partials liegen global unter /partials/*.html
+    const lp = langPrefix(); // für korrekte relative Links in <a href="...">
+    return `${lp || ""}/partials/${rel}`.replace(/\/{2,}/g, "/");
+  }
+
+  async function fetchPartial(url) {
+    if (CACHE.has(url)) return CACHE.get(url);
+    const p = fetch(url, { credentials: "same-origin" })
+      .then(r => (r.ok ? r.text() : Promise.reject(new Error(`HTTP ${r.status}`))))
+      .catch(() => `<!-- partial "${url}" failed to load -->`);
+    CACHE.set(url, p);
+    return p;
+  }
+
+  async function injectPartials(root = document) {
+    const nodes = [...root.querySelectorAll("[data-include]")];
+    for (const el of nodes) {
+      const file = el.getAttribute("data-include");
+      const url = resolvePartialPath(file);
+      const html = await fetchPartial(url);
+      el.outerHTML = html;
+    }
+    // Nach Injection: Theme-Toggle + Nav aktivieren
+    if (window.initThemeToggle) window.initThemeToggle();
+    markActiveNav();
+    document.dispatchEvent(new CustomEvent("partials:ready"));
+  }
+
+  function markActiveNav() {
+    const path = location.pathname.replace(/\/index\.html$/, "/");
+    document.querySelectorAll('a[data-nav]').forEach(a => {
+      const target = a.getAttribute('href').replace(/\/index\.html$/, "/");
+      a.classList.toggle('is-active', target === path);
+      a.setAttribute('aria-current', target === path ? 'page' : null);
+    });
+  }
+
+  // Public
+  window.Partials = { injectPartials };
+})();

--- a/assets/js/portfolio.js
+++ b/assets/js/portfolio.js
@@ -48,6 +48,7 @@
 
   function showError(){
     const container=document.getElementById('portfolio-grid');
+    if(!container) return;
     container.innerHTML=`<div class="p-4 border rounded text-center">${t.none}. <button id="retry" class="btn btn-primary mt-2">Retry</button></div>`;
     document.getElementById('retry').addEventListener('click',()=>{renderSkeletons(state.visible);loadData(lang);});
   }
@@ -108,6 +109,7 @@
 
   function renderSkeletons(n){
     const container=document.getElementById('portfolio-grid');
+    if(!container) return;
     container.innerHTML='';
     for(let i=0;i<n;i++){
       const article=document.createElement('article');
@@ -119,6 +121,7 @@
   function render(){
     const container=document.getElementById('portfolio-grid');
     const empty=document.getElementById('empty-state');
+    if(!container || !empty) return;
     const items=applyFilters(state.items);
     const visibleItems=items.slice(0,state.visible);
     container.innerHTML='';
@@ -150,6 +153,7 @@
       container.appendChild(article);
     });
     const more=document.getElementById('load-more');
+    if(!more) return;
     more.hidden=items.length<=state.visible;
     more.textContent=t.load;
     announceCount(visibleItems.length);
@@ -224,6 +228,7 @@
 
   function initLoadMore(){
     const more=document.getElementById('load-more');
+    if(!more) return;
     more.addEventListener('click',()=>{state.visible+=3;render();});
     if(!prefersReduced){
       const io=new IntersectionObserver(entries=>{entries.forEach(e=>{if(e.isIntersecting){state.visible+=3;render();}})});
@@ -231,7 +236,7 @@
     }
   }
 
-  document.addEventListener('DOMContentLoaded',()=>{
+  function init(){
     applyReducedMotion();
     renderSkeletons(state.visible);
     loadData(lang);
@@ -241,5 +246,7 @@
     initLoadMore();
     const reset=document.getElementById('reset-filters');
     if(reset) reset.addEventListener('click',()=>{state.type='all';state.sort='new';updateURL();updateControls();render();});
-  });
+  }
+
+  window.Portfolio = { init };
 })();

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1,20 +1,35 @@
 (() => {
-  const KEY='site-theme';
-  const root=document.documentElement;
-  const prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;
-  const saved=localStorage.getItem(KEY);
-  const initial = saved || (prefersDark ? 'dark' : 'light');
-  const apply = (mode) => {
+  const KEY = 'site-theme';
+  const root = document.documentElement;
+  let initialized = false;
+
+  function apply(mode) {
     root.setAttribute('data-theme', mode);
     localStorage.setItem(KEY, mode);
-    const btn=document.querySelector('[data-theme-toggle]');
-    if (btn) btn.setAttribute('aria-pressed', mode==='dark' ? 'true' : 'false');
-  };
-  apply(initial);
-  document.addEventListener('click', (e) => {
+    const btn = document.querySelector('[data-theme-toggle]');
+    if (btn) btn.setAttribute('aria-pressed', mode === 'dark' ? 'true' : 'false');
+  }
+
+  function toggle(e) {
     const btn = e.target.closest('[data-theme-toggle]');
     if (!btn) return;
-    const next = (root.getAttribute('data-theme')==='dark') ? 'light' : 'dark';
+    const next = root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
     apply(next);
-  });
+  }
+
+  function initThemeToggle() {
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const saved = localStorage.getItem(KEY);
+    const current = root.getAttribute('data-theme') || saved || (prefersDark ? 'dark' : 'light');
+    apply(current);
+    if (!initialized) {
+      document.addEventListener('click', toggle);
+      initialized = true;
+    }
+  }
+
+  window.initThemeToggle = initThemeToggle;
+
+  if (document.readyState !== 'loading') initThemeToggle();
+  else document.addEventListener('DOMContentLoaded', initThemeToggle);
 })();

--- a/de/portfolio.html
+++ b/de/portfolio.html
@@ -18,35 +18,10 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
-  <script src="/TurboSito/assets/js/theme.js" defer></script>
-  <script defer src="/TurboSito/assets/js/portfolio.js"></script>
 </head>
 <body class="font-sans text-gray-900">
   <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Zum Inhalt springen</a>
-  <header id="site-header">
-    <div class="container flex items-center justify-between gap-4">
-      <nav class="site-nav">
-        <a class="brand" href="/TurboSito/de/">TurboSito</a>
-        <a href="/TurboSito/de/ueber-mich.html">Über mich</a>
-        <a href="/TurboSito/de/leistungen.html">Leistungen</a>
-        <a href="/TurboSito/de/portfolio.html">Portfolio</a>
-        <a href="/TurboSito/de/kontakt.html">Kontakt</a>
-      </nav>
-      <div class="header-right flex items-center gap-2">
-        <nav class="lang-switch" aria-label="Sprachen">
-          <a href="/TurboSito/de/portfolio.html" data-lang="de" hreflang="de">DE</a>
-          <a href="/TurboSito/en/portfolio.html" data-lang="en" hreflang="en">EN</a>
-          <a href="/TurboSito/it/portfolio.html" data-lang="it" hreflang="it">IT</a>
-        </nav>
-        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button>
-        <button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false">
-          <span class="icon sun" aria-hidden="true">☀️</span>
-          <span class="icon moon" aria-hidden="true">🌙</span>
-          <span>Theme</span>
-        </button>
-      </div>
-    </div>
-  </header>
+  <div data-include="header.html"></div>
   <main id="content" class="max-w-6xl mx-auto px-4 py-12">
     <section class="text-center mb-10">
       <h1 class="text-3xl font-bold mb-2">Portfolio</h1>
@@ -81,8 +56,19 @@
       </div>
     </section>
   </main>
-  <footer class="text-center py-10 text-sm">
-    <p>&copy; TurboSito</p>
-  </footer>
+  <div data-include="footer.html"></div>
+
+  <script src="/assets/js/partials.js" defer></script>
+  <script src="/assets/js/theme.js" defer></script>
+  <script src="/assets/js/portfolio.js" defer></script>
+  <script type="module">
+    document.addEventListener("partials:ready", () => {
+      if (window.Portfolio && Portfolio.init) Portfolio.init();
+    });
+    if (!document.querySelector("[data-include]")) {
+      if (window.Portfolio && Portfolio.init) Portfolio.init();
+    }
+    window.Partials && Partials.injectPartials();
+  </script>
 </body>
 </html>

--- a/de/portfolio/corporate-site.html
+++ b/de/portfolio/corporate-site.html
@@ -18,34 +18,10 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
-  <script src="/TurboSito/assets/js/theme.js" defer></script>
 </head>
 <body class="font-sans text-gray-900">
   <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Zum Inhalt springen</a>
-  <header id="site-header">
-    <div class="container flex items-center justify-between gap-4">
-      <nav class="site-nav">
-        <a class="brand" href="/TurboSito/de/">TurboSito</a>
-        <a href="/TurboSito/de/ueber-mich.html">Über mich</a>
-        <a href="/TurboSito/de/leistungen.html">Leistungen</a>
-        <a href="/TurboSito/de/portfolio.html">Portfolio</a>
-        <a href="/TurboSito/de/kontakt.html">Kontakt</a>
-      </nav>
-      <div class="header-right flex items-center gap-2">
-        <nav class="lang-switch" aria-label="Sprachen">
-          <a href="/TurboSito/de/portfolio/corporate-site.html" data-lang="de" hreflang="de">DE</a>
-          <a href="/TurboSito/en/portfolio/corporate-site.html" data-lang="en" hreflang="en">EN</a>
-          <a href="/TurboSito/it/portfolio/corporate-site.html" data-lang="it" hreflang="it">IT</a>
-        </nav>
-        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button>
-        <button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false">
-          <span class="icon sun" aria-hidden="true">☀️</span>
-          <span class="icon moon" aria-hidden="true">🌙</span>
-          <span>Theme</span>
-        </button>
-      </div>
-    </div>
-  </header>
+  <div data-include="header.html"></div>
   <main id="content" class="max-w-3xl mx-auto px-4 py-12">
     <nav aria-label="Brotkrumen" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
@@ -125,6 +101,18 @@
     })();
     </script>
   </main>
-  <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+  <div data-include="footer.html"></div>
+
+  <script src="/assets/js/partials.js" defer></script>
+  <script src="/assets/js/theme.js" defer></script>
+  <script type="module">
+    document.addEventListener("partials:ready", () => {
+      if (window.Portfolio && Portfolio.init) Portfolio.init();
+    });
+    if (!document.querySelector("[data-include]")) {
+      if (window.Portfolio && Portfolio.init) Portfolio.init();
+    }
+    window.Partials && Partials.injectPartials();
+  </script>
 </body>
 </html>

--- a/de/portfolio/fashion-shop.html
+++ b/de/portfolio/fashion-shop.html
@@ -18,34 +18,10 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
-  <script src="/TurboSito/assets/js/theme.js" defer></script>
 </head>
 <body class="font-sans text-gray-900">
   <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Zum Inhalt springen</a>
-  <header id="site-header">
-    <div class="container flex items-center justify-between gap-4">
-      <nav class="site-nav">
-        <a class="brand" href="/TurboSito/de/">TurboSito</a>
-        <a href="/TurboSito/de/ueber-mich.html">Über mich</a>
-        <a href="/TurboSito/de/leistungen.html">Leistungen</a>
-        <a href="/TurboSito/de/portfolio.html">Portfolio</a>
-        <a href="/TurboSito/de/kontakt.html">Kontakt</a>
-      </nav>
-      <div class="header-right flex items-center gap-2">
-        <nav class="lang-switch" aria-label="Sprachen">
-          <a href="/TurboSito/de/portfolio/fashion-shop.html" data-lang="de" hreflang="de">DE</a>
-          <a href="/TurboSito/en/portfolio/fashion-shop.html" data-lang="en" hreflang="en">EN</a>
-          <a href="/TurboSito/it/portfolio/fashion-shop.html" data-lang="it" hreflang="it">IT</a>
-        </nav>
-        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button>
-        <button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false">
-          <span class="icon sun" aria-hidden="true">☀️</span>
-          <span class="icon moon" aria-hidden="true">🌙</span>
-          <span>Theme</span>
-        </button>
-      </div>
-    </div>
-  </header>
+  <div data-include="header.html"></div>
   <main id="content" class="max-w-3xl mx-auto px-4 py-12">
     <nav aria-label="Brotkrumen" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
@@ -125,6 +101,18 @@
     })();
     </script>
   </main>
-  <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+  <div data-include="footer.html"></div>
+
+  <script src="/assets/js/partials.js" defer></script>
+  <script src="/assets/js/theme.js" defer></script>
+  <script type="module">
+    document.addEventListener("partials:ready", () => {
+      if (window.Portfolio && Portfolio.init) Portfolio.init();
+    });
+    if (!document.querySelector("[data-include]")) {
+      if (window.Portfolio && Portfolio.init) Portfolio.init();
+    }
+    window.Partials && Partials.injectPartials();
+  </script>
 </body>
 </html>

--- a/de/portfolio/saas-landing.html
+++ b/de/portfolio/saas-landing.html
@@ -18,34 +18,10 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
-  <script src="/TurboSito/assets/js/theme.js" defer></script>
 </head>
 <body class="font-sans text-gray-900">
   <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Zum Inhalt springen</a>
-  <header id="site-header">
-    <div class="container flex items-center justify-between gap-4">
-      <nav class="site-nav">
-        <a class="brand" href="/TurboSito/de/">TurboSito</a>
-        <a href="/TurboSito/de/ueber-mich.html">Über mich</a>
-        <a href="/TurboSito/de/leistungen.html">Leistungen</a>
-        <a href="/TurboSito/de/portfolio.html">Portfolio</a>
-        <a href="/TurboSito/de/kontakt.html">Kontakt</a>
-      </nav>
-      <div class="header-right flex items-center gap-2">
-        <nav class="lang-switch" aria-label="Sprachen">
-          <a href="/TurboSito/de/portfolio/saas-landing.html" data-lang="de" hreflang="de">DE</a>
-          <a href="/TurboSito/en/portfolio/saas-landing.html" data-lang="en" hreflang="en">EN</a>
-          <a href="/TurboSito/it/portfolio/saas-landing.html" data-lang="it" hreflang="it">IT</a>
-        </nav>
-        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button>
-        <button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false">
-          <span class="icon sun" aria-hidden="true">☀️</span>
-          <span class="icon moon" aria-hidden="true">🌙</span>
-          <span>Theme</span>
-        </button>
-      </div>
-    </div>
-  </header>
+  <div data-include="header.html"></div>
   <main id="content" class="max-w-3xl mx-auto px-4 py-12">
     <nav aria-label="Brotkrumen" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
@@ -125,6 +101,18 @@
     })();
     </script>
   </main>
-  <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+  <div data-include="footer.html"></div>
+
+  <script src="/assets/js/partials.js" defer></script>
+  <script src="/assets/js/theme.js" defer></script>
+  <script type="module">
+    document.addEventListener("partials:ready", () => {
+      if (window.Portfolio && Portfolio.init) Portfolio.init();
+    });
+    if (!document.querySelector("[data-include]")) {
+      if (window.Portfolio && Portfolio.init) Portfolio.init();
+    }
+    window.Partials && Partials.injectPartials();
+  </script>
 </body>
 </html>

--- a/en/portfolio.html
+++ b/en/portfolio.html
@@ -18,35 +18,10 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
-  <script src="/TurboSito/assets/js/theme.js" defer></script>
-  <script defer src="/TurboSito/assets/js/portfolio.js"></script>
 </head>
 <body class="font-sans text-gray-900">
   <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
-  <header id="site-header">
-    <div class="container flex items-center justify-between gap-4">
-      <nav class="site-nav">
-        <a class="brand" href="/TurboSito/en/">TurboSito</a>
-        <a href="/TurboSito/en/about.html">About</a>
-        <a href="/TurboSito/en/services.html">Services</a>
-        <a href="/TurboSito/en/portfolio.html">Portfolio</a>
-        <a href="/TurboSito/en/contact.html">Contact</a>
-      </nav>
-      <div class="header-right flex items-center gap-2">
-        <nav class="lang-switch" aria-label="Languages">
-          <a href="/TurboSito/de/portfolio.html" data-lang="de" hreflang="de">DE</a>
-          <a href="/TurboSito/en/portfolio.html" data-lang="en" hreflang="en">EN</a>
-          <a href="/TurboSito/it/portfolio.html" data-lang="it" hreflang="it">IT</a>
-        </nav>
-        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button>
-        <button class="theme-toggle" data-theme-toggle aria-label="Toggle theme" aria-pressed="false">
-          <span class="icon sun" aria-hidden="true">☀️</span>
-          <span class="icon moon" aria-hidden="true">🌙</span>
-          <span>Theme</span>
-        </button>
-      </div>
-    </div>
-  </header>
+  <div data-include="header.html"></div>
   <main id="content" class="max-w-6xl mx-auto px-4 py-12">
     <section class="text-center mb-10">
       <h1 class="text-3xl font-bold mb-2">Portfolio</h1>
@@ -81,8 +56,19 @@
       </div>
     </section>
   </main>
-  <footer class="text-center py-10 text-sm">
-    <p>&copy; TurboSito</p>
-  </footer>
+  <div data-include="footer.html"></div>
+
+  <script src="/assets/js/partials.js" defer></script>
+  <script src="/assets/js/theme.js" defer></script>
+  <script src="/assets/js/portfolio.js" defer></script>
+  <script type="module">
+    document.addEventListener("partials:ready", () => {
+      if (window.Portfolio && Portfolio.init) Portfolio.init();
+    });
+    if (!document.querySelector("[data-include]")) {
+      if (window.Portfolio && Portfolio.init) Portfolio.init();
+    }
+    window.Partials && Partials.injectPartials();
+  </script>
 </body>
 </html>

--- a/en/portfolio/corporate-site.html
+++ b/en/portfolio/corporate-site.html
@@ -18,34 +18,10 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
-  <script src="/TurboSito/assets/js/theme.js" defer></script>
 </head>
 <body class="font-sans text-gray-900">
   <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
-  <header id="site-header">
-    <div class="container flex items-center justify-between gap-4">
-      <nav class="site-nav">
-        <a class="brand" href="/TurboSito/en/">TurboSito</a>
-        <a href="/TurboSito/en/about.html">About</a>
-        <a href="/TurboSito/en/services.html">Services</a>
-        <a href="/TurboSito/en/portfolio.html">Portfolio</a>
-        <a href="/TurboSito/en/contact.html">Contact</a>
-      </nav>
-      <div class="header-right flex items-center gap-2">
-        <nav class="lang-switch" aria-label="Language switch">
-          <a href="/TurboSito/de/portfolio/corporate-site.html" data-lang="de" hreflang="de">DE</a>
-          <a href="/TurboSito/en/portfolio/corporate-site.html" data-lang="en" hreflang="en">EN</a>
-          <a href="/TurboSito/it/portfolio/corporate-site.html" data-lang="it" hreflang="it">IT</a>
-        </nav>
-        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button>
-        <button class="theme-toggle" data-theme-toggle aria-label="Toggle theme" aria-pressed="false">
-          <span class="icon sun" aria-hidden="true">☀️</span>
-          <span class="icon moon" aria-hidden="true">🌙</span>
-          <span>Theme</span>
-        </button>
-      </div>
-    </div>
-  </header>
+  <div data-include="header.html"></div>
   <main id="content" class="max-w-3xl mx-auto px-4 py-12">
     <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
@@ -125,6 +101,18 @@
     })();
     </script>
   </main>
-  <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+  <div data-include="footer.html"></div>
+
+  <script src="/assets/js/partials.js" defer></script>
+  <script src="/assets/js/theme.js" defer></script>
+  <script type="module">
+    document.addEventListener("partials:ready", () => {
+      if (window.Portfolio && Portfolio.init) Portfolio.init();
+    });
+    if (!document.querySelector("[data-include]")) {
+      if (window.Portfolio && Portfolio.init) Portfolio.init();
+    }
+    window.Partials && Partials.injectPartials();
+  </script>
 </body>
 </html>

--- a/en/portfolio/fashion-shop.html
+++ b/en/portfolio/fashion-shop.html
@@ -18,34 +18,10 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
-  <script src="/TurboSito/assets/js/theme.js" defer></script>
 </head>
 <body class="font-sans text-gray-900">
   <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
-  <header id="site-header">
-    <div class="container flex items-center justify-between gap-4">
-      <nav class="site-nav">
-        <a class="brand" href="/TurboSito/en/">TurboSito</a>
-        <a href="/TurboSito/en/about.html">About</a>
-        <a href="/TurboSito/en/services.html">Services</a>
-        <a href="/TurboSito/en/portfolio.html">Portfolio</a>
-        <a href="/TurboSito/en/contact.html">Contact</a>
-      </nav>
-      <div class="header-right flex items-center gap-2">
-        <nav class="lang-switch" aria-label="Language switch">
-          <a href="/TurboSito/de/portfolio/fashion-shop.html" data-lang="de" hreflang="de">DE</a>
-          <a href="/TurboSito/en/portfolio/fashion-shop.html" data-lang="en" hreflang="en">EN</a>
-          <a href="/TurboSito/it/portfolio/fashion-shop.html" data-lang="it" hreflang="it">IT</a>
-        </nav>
-        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button>
-        <button class="theme-toggle" data-theme-toggle aria-label="Toggle theme" aria-pressed="false">
-          <span class="icon sun" aria-hidden="true">☀️</span>
-          <span class="icon moon" aria-hidden="true">🌙</span>
-          <span>Theme</span>
-        </button>
-      </div>
-    </div>
-  </header>
+  <div data-include="header.html"></div>
   <main id="content" class="max-w-3xl mx-auto px-4 py-12">
     <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
@@ -125,6 +101,18 @@
     })();
     </script>
   </main>
-  <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+  <div data-include="footer.html"></div>
+
+  <script src="/assets/js/partials.js" defer></script>
+  <script src="/assets/js/theme.js" defer></script>
+  <script type="module">
+    document.addEventListener("partials:ready", () => {
+      if (window.Portfolio && Portfolio.init) Portfolio.init();
+    });
+    if (!document.querySelector("[data-include]")) {
+      if (window.Portfolio && Portfolio.init) Portfolio.init();
+    }
+    window.Partials && Partials.injectPartials();
+  </script>
 </body>
 </html>

--- a/en/portfolio/saas-landing.html
+++ b/en/portfolio/saas-landing.html
@@ -18,34 +18,10 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
-  <script src="/TurboSito/assets/js/theme.js" defer></script>
 </head>
 <body class="font-sans text-gray-900">
   <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
-  <header id="site-header">
-    <div class="container flex items-center justify-between gap-4">
-      <nav class="site-nav">
-        <a class="brand" href="/TurboSito/en/">TurboSito</a>
-        <a href="/TurboSito/en/about.html">About</a>
-        <a href="/TurboSito/en/services.html">Services</a>
-        <a href="/TurboSito/en/portfolio.html">Portfolio</a>
-        <a href="/TurboSito/en/contact.html">Contact</a>
-      </nav>
-      <div class="header-right flex items-center gap-2">
-        <nav class="lang-switch" aria-label="Language switch">
-          <a href="/TurboSito/de/portfolio/saas-landing.html" data-lang="de" hreflang="de">DE</a>
-          <a href="/TurboSito/en/portfolio/saas-landing.html" data-lang="en" hreflang="en">EN</a>
-          <a href="/TurboSito/it/portfolio/saas-landing.html" data-lang="it" hreflang="it">IT</a>
-        </nav>
-        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button>
-        <button class="theme-toggle" data-theme-toggle aria-label="Toggle theme" aria-pressed="false">
-          <span class="icon sun" aria-hidden="true">☀️</span>
-          <span class="icon moon" aria-hidden="true">🌙</span>
-          <span>Theme</span>
-        </button>
-      </div>
-    </div>
-  </header>
+  <div data-include="header.html"></div>
   <main id="content" class="max-w-3xl mx-auto px-4 py-12">
     <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
@@ -125,6 +101,18 @@
     })();
     </script>
   </main>
-  <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+  <div data-include="footer.html"></div>
+
+  <script src="/assets/js/partials.js" defer></script>
+  <script src="/assets/js/theme.js" defer></script>
+  <script type="module">
+    document.addEventListener("partials:ready", () => {
+      if (window.Portfolio && Portfolio.init) Portfolio.init();
+    });
+    if (!document.querySelector("[data-include]")) {
+      if (window.Portfolio && Portfolio.init) Portfolio.init();
+    }
+    window.Partials && Partials.injectPartials();
+  </script>
 </body>
 </html>

--- a/it/portfolio.html
+++ b/it/portfolio.html
@@ -18,35 +18,10 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
-  <script src="/TurboSito/assets/js/theme.js" defer></script>
-  <script defer src="/TurboSito/assets/js/portfolio.js"></script>
 </head>
 <body class="font-sans text-gray-900">
   <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Vai al contenuto</a>
-  <header id="site-header">
-    <div class="container flex items-center justify-between gap-4">
-      <nav class="site-nav">
-        <a class="brand" href="/TurboSito/it/">TurboSito</a>
-        <a href="/TurboSito/it/chi-sono.html">Chi sono</a>
-        <a href="/TurboSito/it/servizi.html">Servizi</a>
-        <a href="/TurboSito/it/portfolio.html">Portfolio</a>
-        <a href="/TurboSito/it/contatto.html">Contatto</a>
-      </nav>
-      <div class="header-right flex items-center gap-2">
-        <nav class="lang-switch" aria-label="Lingue">
-          <a href="/TurboSito/de/portfolio.html" data-lang="de" hreflang="de">DE</a>
-          <a href="/TurboSito/en/portfolio.html" data-lang="en" hreflang="en">EN</a>
-          <a href="/TurboSito/it/portfolio.html" data-lang="it" hreflang="it">IT</a>
-        </nav>
-        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menù"><span aria-hidden="true"></span></button>
-        <button class="theme-toggle" data-theme-toggle aria-label="Cambia tema" aria-pressed="false">
-          <span class="icon sun" aria-hidden="true">☀️</span>
-          <span class="icon moon" aria-hidden="true">🌙</span>
-          <span>Theme</span>
-        </button>
-      </div>
-    </div>
-  </header>
+  <div data-include="header.html"></div>
   <main id="content" class="max-w-6xl mx-auto px-4 py-12">
     <section class="text-center mb-10">
       <h1 class="text-3xl font-bold mb-2">Portfolio</h1>
@@ -81,8 +56,19 @@
       </div>
     </section>
   </main>
-  <footer class="text-center py-10 text-sm">
-    <p>&copy; TurboSito</p>
-  </footer>
+  <div data-include="footer.html"></div>
+
+  <script src="/assets/js/partials.js" defer></script>
+  <script src="/assets/js/theme.js" defer></script>
+  <script src="/assets/js/portfolio.js" defer></script>
+  <script type="module">
+    document.addEventListener("partials:ready", () => {
+      if (window.Portfolio && Portfolio.init) Portfolio.init();
+    });
+    if (!document.querySelector("[data-include]")) {
+      if (window.Portfolio && Portfolio.init) Portfolio.init();
+    }
+    window.Partials && Partials.injectPartials();
+  </script>
 </body>
 </html>

--- a/it/portfolio/corporate-site.html
+++ b/it/portfolio/corporate-site.html
@@ -18,34 +18,10 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
-  <script src="/TurboSito/assets/js/theme.js" defer></script>
 </head>
 <body class="font-sans text-gray-900">
   <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Vai al contenuto</a>
-  <header id="site-header">
-    <div class="container flex items-center justify-between gap-4">
-      <nav class="site-nav">
-        <a class="brand" href="/TurboSito/it/">TurboSito</a>
-        <a href="/TurboSito/it/chi-sono.html">Chi sono</a>
-        <a href="/TurboSito/it/servizi.html">Servizi</a>
-        <a href="/TurboSito/it/portfolio.html">Portfolio</a>
-        <a href="/TurboSito/it/contatto.html">Contatto</a>
-      </nav>
-      <div class="header-right flex items-center gap-2">
-        <nav class="lang-switch" aria-label="Lingue">
-          <a href="/TurboSito/de/portfolio/corporate-site.html" data-lang="de" hreflang="de">DE</a>
-          <a href="/TurboSito/en/portfolio/corporate-site.html" data-lang="en" hreflang="en">EN</a>
-          <a href="/TurboSito/it/portfolio/corporate-site.html" data-lang="it" hreflang="it">IT</a>
-        </nav>
-        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menù"><span aria-hidden="true"></span></button>
-        <button class="theme-toggle" data-theme-toggle aria-label="Cambia tema" aria-pressed="false">
-          <span class="icon sun" aria-hidden="true">☀️</span>
-          <span class="icon moon" aria-hidden="true">🌙</span>
-          <span>Theme</span>
-        </button>
-      </div>
-    </div>
-  </header>
+  <div data-include="header.html"></div>
   <main id="content" class="max-w-3xl mx-auto px-4 py-12">
     <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
@@ -125,6 +101,18 @@
     })();
     </script>
   </main>
-  <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+  <div data-include="footer.html"></div>
+
+  <script src="/assets/js/partials.js" defer></script>
+  <script src="/assets/js/theme.js" defer></script>
+  <script type="module">
+    document.addEventListener("partials:ready", () => {
+      if (window.Portfolio && Portfolio.init) Portfolio.init();
+    });
+    if (!document.querySelector("[data-include]")) {
+      if (window.Portfolio && Portfolio.init) Portfolio.init();
+    }
+    window.Partials && Partials.injectPartials();
+  </script>
 </body>
 </html>

--- a/it/portfolio/fashion-shop.html
+++ b/it/portfolio/fashion-shop.html
@@ -18,34 +18,10 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
-  <script src="/TurboSito/assets/js/theme.js" defer></script>
 </head>
 <body class="font-sans text-gray-900">
   <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Vai al contenuto</a>
-  <header id="site-header">
-    <div class="container flex items-center justify-between gap-4">
-      <nav class="site-nav">
-        <a class="brand" href="/TurboSito/it/">TurboSito</a>
-        <a href="/TurboSito/it/chi-sono.html">Chi sono</a>
-        <a href="/TurboSito/it/servizi.html">Servizi</a>
-        <a href="/TurboSito/it/portfolio.html">Portfolio</a>
-        <a href="/TurboSito/it/contatto.html">Contatto</a>
-      </nav>
-      <div class="header-right flex items-center gap-2">
-        <nav class="lang-switch" aria-label="Lingue">
-          <a href="/TurboSito/de/portfolio/fashion-shop.html" data-lang="de" hreflang="de">DE</a>
-          <a href="/TurboSito/en/portfolio/fashion-shop.html" data-lang="en" hreflang="en">EN</a>
-          <a href="/TurboSito/it/portfolio/fashion-shop.html" data-lang="it" hreflang="it">IT</a>
-        </nav>
-        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menù"><span aria-hidden="true"></span></button>
-        <button class="theme-toggle" data-theme-toggle aria-label="Cambia tema" aria-pressed="false">
-          <span class="icon sun" aria-hidden="true">☀️</span>
-          <span class="icon moon" aria-hidden="true">🌙</span>
-          <span>Theme</span>
-        </button>
-      </div>
-    </div>
-  </header>
+  <div data-include="header.html"></div>
   <main id="content" class="max-w-3xl mx-auto px-4 py-12">
     <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
@@ -125,6 +101,18 @@
     })();
     </script>
   </main>
-  <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+  <div data-include="footer.html"></div>
+
+  <script src="/assets/js/partials.js" defer></script>
+  <script src="/assets/js/theme.js" defer></script>
+  <script type="module">
+    document.addEventListener("partials:ready", () => {
+      if (window.Portfolio && Portfolio.init) Portfolio.init();
+    });
+    if (!document.querySelector("[data-include]")) {
+      if (window.Portfolio && Portfolio.init) Portfolio.init();
+    }
+    window.Partials && Partials.injectPartials();
+  </script>
 </body>
 </html>

--- a/it/portfolio/saas-landing.html
+++ b/it/portfolio/saas-landing.html
@@ -18,34 +18,10 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
-  <script src="/TurboSito/assets/js/theme.js" defer></script>
 </head>
 <body class="font-sans text-gray-900">
   <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Vai al contenuto</a>
-  <header id="site-header">
-    <div class="container flex items-center justify-between gap-4">
-      <nav class="site-nav">
-        <a class="brand" href="/TurboSito/it/">TurboSito</a>
-        <a href="/TurboSito/it/chi-sono.html">Chi sono</a>
-        <a href="/TurboSito/it/servizi.html">Servizi</a>
-        <a href="/TurboSito/it/portfolio.html">Portfolio</a>
-        <a href="/TurboSito/it/contatto.html">Contatto</a>
-      </nav>
-      <div class="header-right flex items-center gap-2">
-        <nav class="lang-switch" aria-label="Lingue">
-          <a href="/TurboSito/de/portfolio/saas-landing.html" data-lang="de" hreflang="de">DE</a>
-          <a href="/TurboSito/en/portfolio/saas-landing.html" data-lang="en" hreflang="en">EN</a>
-          <a href="/TurboSito/it/portfolio/saas-landing.html" data-lang="it" hreflang="it">IT</a>
-        </nav>
-        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menù"><span aria-hidden="true"></span></button>
-        <button class="theme-toggle" data-theme-toggle aria-label="Cambia tema" aria-pressed="false">
-          <span class="icon sun" aria-hidden="true">☀️</span>
-          <span class="icon moon" aria-hidden="true">🌙</span>
-          <span>Theme</span>
-        </button>
-      </div>
-    </div>
-  </header>
+  <div data-include="header.html"></div>
   <main id="content" class="max-w-3xl mx-auto px-4 py-12">
     <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
@@ -125,6 +101,18 @@
     })();
     </script>
   </main>
-  <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+  <div data-include="footer.html"></div>
+
+  <script src="/assets/js/partials.js" defer></script>
+  <script src="/assets/js/theme.js" defer></script>
+  <script type="module">
+    document.addEventListener("partials:ready", () => {
+      if (window.Portfolio && Portfolio.init) Portfolio.init();
+    });
+    if (!document.querySelector("[data-include]")) {
+      if (window.Portfolio && Portfolio.init) Portfolio.init();
+    }
+    window.Partials && Partials.injectPartials();
+  </script>
 </body>
 </html>

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -1,0 +1,7 @@
+<footer class="site-footer text-center py-10 text-sm">
+  <p>© TurboSito</p>
+  <ul class="flex justify-center gap-4">
+    <li><a href="/legal/impressum.html">Impressum</a></li>
+    <li><a href="/legal/datenschutz.html">Datenschutz</a></li>
+  </ul>
+</footer>

--- a/partials/header.html
+++ b/partials/header.html
@@ -1,0 +1,12 @@
+<header class="site-header">
+  <nav class="container flex items-center justify-between gap-4">
+    <div class="nav-left">
+      <a href="/" class="brand" data-nav>Start</a>
+      <a href="/ueber-mich/" data-nav>Über mich</a>
+      <a href="/leistungen/" data-nav>Leistungen</a>
+      <a href="/portfolio/" data-nav>Portfolio</a>
+      <a href="/kontakt/" data-nav>Kontakt</a>
+    </div>
+    <button id="theme-toggle" type="button" data-theme-toggle aria-label="Theme umschalten"></button>
+  </nav>
+</header>


### PR DESCRIPTION
## Summary
- add a lightweight client-side partial loader
- expose `initThemeToggle` and `Portfolio.init` for reinvocation after partial injection
- render portfolio pages and case studies with header/footer includes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bee7a1d9c88332a95c719c54cc5cf2