### PR TITLE
Load header and footer via partials on portfolio pages

### DIFF
--- a/assets/js/partials.js
+++ b/assets/js/partials.js
@@ -1,0 +1,88 @@
+(() => {
+  const CACHE = new Map();
+  let injected = false;
+  const once = (fn) => { let ran=false; return (...a)=>{ if(ran) return; ran=true; return fn(...a);} };
+
+  const langRe = /^\/(de|en|it)\b/;
+  const norm = (p) => p.replace(/\/index\.html$/,'/').replace(/\/+$/,'/');
+
+  function langPrefix() {
+    const m = location.pathname.match(langRe);
+    return m ? `/${m[1]}` : '';
+  }
+
+  function resolvePartialPath(rel) {
+    // Partials liegen unter /partials/ (nicht sprachspezifisch)
+    return `${langPrefix()}/partials/${rel}`.replace(/\/{2,}/g,'/');
+  }
+
+  function fetchWithTimeout(url, { timeout = 6000 } = {}) {
+    const ctrl = new AbortController();
+    const id = setTimeout(() => ctrl.abort(), timeout);
+    return fetch(url, { signal: ctrl.signal, credentials: 'same-origin' })
+      .finally(() => clearTimeout(id));
+  }
+
+  async function fetchPartial(url, retries = 1) {
+    if (CACHE.has(url)) return CACHE.get(url);
+    const p = (async () => {
+      try {
+        const r = await fetchWithTimeout(url);
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return await r.text();
+      } catch (e) {
+        if (retries > 0) return fetchPartial(url, retries - 1);
+        console.warn('[partials] failed:', url, e);
+        return `<!-- partial "${url}" failed -->`;
+      }
+    })();
+    CACHE.set(url, p);
+    return p;
+  }
+
+  async function injectPartials(root = document) {
+    if (injected) return; // idempotent
+    const nodes = [...root.querySelectorAll('[data-include]')];
+    for (const el of nodes) {
+      const file = el.getAttribute('data-include');
+      const html = await fetchPartial(resolvePartialPath(file));
+      const wrapper = document.createElement('div');
+      wrapper.innerHTML = html;
+      el.replaceWith(...wrapper.childNodes);
+    }
+    injected = true;
+    if (window.initThemeToggle) window.initThemeToggle();
+
+    const cur = norm(location.pathname);
+    document.querySelectorAll('a[data-nav]').forEach(a => {
+      const target = norm(a.getAttribute('href') || '/');
+      const langed = target.match(langRe) ? target : (langPrefix() + target);
+      const isActive = norm(langed) === cur;
+      a.classList.toggle('is-active', isActive);
+      a.setAttribute('aria-current', isActive ? 'page' : null);
+    });
+
+    const main = document.querySelector('main');
+    if (main && !main.id) main.id = 'main';
+    const skip = document.querySelector('a[href="#main"]');
+    if (skip) skip.removeAttribute('hidden');
+
+    focusHash();
+    document.dispatchEvent(new CustomEvent('partials:ready'));
+  }
+
+  function focusHash() {
+    if (!location.hash) return;
+    const target = document.getElementById(location.hash.slice(1));
+    if (target) target.setAttribute('tabindex', '-1'), target.focus();
+  }
+  window.addEventListener('hashchange', focusHash, { passive: true });
+
+  window.Partials = {
+    injectPartials,
+    ready: () => new Promise(r => {
+      if (injected) return r();
+      document.addEventListener('partials:ready', once(r), { once: true });
+    })
+  };
+})();

--- a/assets/js/portfolio.js
+++ b/assets/js/portfolio.js
@@ -13,233 +13,247 @@
  * @property {string[]} [highlights]
  */
 /** @typedef {{items: PortfolioItem[]}} LocalizedDataset */
-(function(){
-  const lang = document.documentElement.lang || 'en';
-  const labels = {
-    en: {view:'View case study', demo:'Open demo', load:'Load more', none:'No projects', reset:'Reset filters'},
-    de: {view:'Case Study ansehen', demo:'Demo öffnen', load:'Mehr laden', none:'Keine Projekte', reset:'Filter zurücksetzen'},
-    it: {view:'Vedi case study', demo:'Apri demo', load:'Carica altro', none:'Nessun progetto', reset:'Reimposta filtri'}
-  };
-  const t = labels[lang] || labels.en;
-  const live = document.getElementById('live-status');
-  const state = {type:'all', sort:'new', visible:6, items:[], search:'', missing:false};
-  const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+const lang = document.documentElement.lang || 'en';
+const labels = {
+  en: {view:'View case study', demo:'Open demo', load:'Load more', none:'No projects', reset:'Reset filters'},
+  de: {view:'Case Study ansehen', demo:'Demo öffnen', load:'Mehr laden', none:'Keine Projekte', reset:'Filter zurücksetzen'},
+  it: {view:'Vedi case study', demo:'Apri demo', load:'Carica altro', none:'Nessun progetto', reset:'Reimposta filtri'}
+};
+const t = labels[lang] || labels.en;
+const live = document.getElementById('live-status');
+const state = {type:'all', sort:'new', visible:6, items:[], search:'', missing:false};
+const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-  function applyReducedMotion(){
-    if(prefersReduced) document.documentElement.classList.add('reduced-motion');
+function applyReducedMotion(){
+  if(prefersReduced) document.documentElement.classList.add('reduced-motion');
+}
+
+function validateItem(item){
+  const required=['slug','title','type','kpis','impactScore','timeToLaunchHours','summary','demoUrl','caseUrl','tags'];
+  return required.every(k=>k in item);
+}
+
+async function loadData(language){
+  try{
+    const res = await fetch(`/TurboSito/assets/data/portfolio.${language}.json`,{cache:'force-cache'});
+    const json = /** @type {LocalizedDataset} */(await res.json());
+    state.items = json.items.filter(validateItem);
+    announceCount(applyFilters(state.items).length);
+    render();
+  }catch(e){
+    showError();
   }
+}
 
-  function validateItem(item){
-    const required=['slug','title','type','kpis','impactScore','timeToLaunchHours','summary','demoUrl','caseUrl','tags'];
-    return required.every(k=>k in item);
-  }
+function showError(){
+  const container=document.getElementById('portfolio-grid');
+  if(!container) return;
+  container.innerHTML=`<div class="p-4 border rounded text-center">${t.none}. <button id="retry" class="btn btn-primary mt-2">Retry</button></div>`;
+  document.getElementById('retry').addEventListener('click',()=>{renderSkeletons(state.visible);loadData(lang);});
+}
 
-  async function loadData(language){
-    try{
-      const res = await fetch(`/TurboSito/assets/data/portfolio.${language}.json`,{cache:'force-cache'});
-      const json = /** @type {LocalizedDataset} */(await res.json());
-      state.items = json.items.filter(validateItem);
-      announceCount(applyFilters(state.items).length);
-      render();
-    }catch(e){
-      showError();
-    }
-  }
+function normalizeState(){
+  const validTypes=['all','landing','corporate','shop','app'];
+  const validSort=['new','impact','speed'];
+  if(!validTypes.includes(state.type)) state.type='all';
+  if(!validSort.includes(state.sort)) state.sort='new';
+}
 
-  function showError(){
-    const container=document.getElementById('portfolio-grid');
-    container.innerHTML=`<div class="p-4 border rounded text-center">${t.none}. <button id="retry" class="btn btn-primary mt-2">Retry</button></div>`;
-    document.getElementById('retry').addEventListener('click',()=>{renderSkeletons(state.visible);loadData(lang);});
-  }
+function hydrateFromURL(){
+  const params=new URLSearchParams(location.search);
+  state.type=params.get('type')||'all';
+  state.sort=params.get('sort')||'new';
+  state.missing=params.get('missing')==='1';
+  normalizeState();
+  updateControls();
+  if(state.missing && live) live.textContent='Case nicht gefunden';
+}
 
-  function normalizeState(){
-    const validTypes=['all','landing','corporate','shop','app'];
-    const validSort=['new','impact','speed'];
-    if(!validTypes.includes(state.type)) state.type='all';
-    if(!validSort.includes(state.sort)) state.sort='new';
-  }
-
-  function hydrateFromURL(){
-    const params=new URLSearchParams(location.search);
-    state.type=params.get('type')||'all';
-    state.sort=params.get('sort')||'new';
-    state.missing=params.get('missing')==='1';
-    normalizeState();
-    updateControls();
-    if(state.missing && live) live.textContent='Case nicht gefunden';
-  }
-
-  function updateControls(){
-    document.querySelectorAll('[data-type]').forEach(btn=>{
-      const active=btn.getAttribute('data-type')===state.type;
-      btn.setAttribute('aria-selected', active);
-      btn.tabIndex=active?0:-1;
-    });
-    const btn=document.getElementById('sort-button');
-    if(btn){
-      const current=document.querySelector(`#sort-menu [data-sort="${state.sort}"]`);
-      if(current) btn.textContent=current.textContent;
-      document.querySelectorAll('#sort-menu [data-sort]').forEach(opt=>{
-        const sel=opt.getAttribute('data-sort')===state.sort;
-        opt.setAttribute('aria-selected', sel);
-      });
-    }
-  }
-
-  function applyFilters(items){
-    let res = state.type!=='all'? items.filter(i=>i.type===state.type):items;
-    if(state.search){
-      const q=state.search.toLowerCase();
-      res=res.filter(i=>(i.title+i.summary+i.tags.join('')).toLowerCase().includes(q));
-    }
-    return applySort(res);
-  }
-
-  function applySort(items){
-    const arr=[...items];
-    if(state.sort==='impact') arr.sort((a,b)=>b.impactScore-a.impactScore);
-    else if(state.sort==='speed') arr.sort((a,b)=>a.timeToLaunchHours-b.timeToLaunchHours);
-    return arr;
-  }
-
-  function announceCount(count){
-    if(live) live.textContent=`${count} ${count===1?'project':'projects'} visible`;
-  }
-
-  function renderSkeletons(n){
-    const container=document.getElementById('portfolio-grid');
-    container.innerHTML='';
-    for(let i=0;i<n;i++){
-      const article=document.createElement('article');
-      article.className='case-card border p-4 rounded skeleton dark:border-gray-700';
-      container.appendChild(article);
-    }
-  }
-
-  function render(){
-    const container=document.getElementById('portfolio-grid');
-    const empty=document.getElementById('empty-state');
-    const items=applyFilters(state.items);
-    const visibleItems=items.slice(0,state.visible);
-    container.innerHTML='';
-    if(items.length===0){
-      empty.hidden=false;
-      announceCount(0);
-      return;
-    }
-    empty.hidden=true;
-    visibleItems.forEach(item=>{
-      const article=document.createElement('article');
-      article.className='case-card border p-4 rounded focus-within:ring outline-none hover-lift bg-white dark:bg-gray-800 dark:border-gray-700';
-      article.setAttribute('role','listitem');
-      article.setAttribute('aria-label',item.title);
-      article.innerHTML=`
-        <div class="ph-media mb-3 rounded" role="img" aria-label="Placeholder"></div>
-        <span class="badge mb-2">Demo</span>
-        <h3 class="font-semibold mb-1">${item.title}</h3>
-        <ul class="flex flex-wrap gap-1 text-sm mb-2">${item.tags.slice(0,3).map(t=>`<li class="tag-pill">${t}</li>`).join('')}</ul>
-        <p class="kpi-row text-sm mb-3 flex flex-wrap gap-3">
-          <span class="flex items-center gap-1"><span aria-hidden="true">⏱</span>${item.kpis[0]}</span>
-          <span class="flex items-center gap-1"><span aria-hidden="true">⚡</span>${item.kpis[1]}</span>
-          <span class="flex items-center gap-1"><span aria-hidden="true">✅</span>${item.kpis[2]}</span>
-        </p>
-        <div class="flex flex-wrap gap-3">
-          <a class="btn btn-primary" aria-label="${t.view}: ${item.title}" href="${item.caseUrl}">${t.view}</a>
-          <a class="link" aria-label="${t.demo}: ${item.title}" href="${item.demoUrl}" target="_blank" rel="noopener">${t.demo}</a>
-        </div>`;
-      container.appendChild(article);
-    });
-    const more=document.getElementById('load-more');
-    more.hidden=items.length<=state.visible;
-    more.textContent=t.load;
-    announceCount(visibleItems.length);
-  }
-
-  function updateURL(){
-    const url=new URL(location.href);
-    if(state.type!=='all') url.searchParams.set('type',state.type); else url.searchParams.delete('type');
-    if(state.sort!=='new') url.searchParams.set('sort',state.sort); else url.searchParams.delete('sort');
-    history.replaceState(null,'',url);
-  }
-
-  function initTabs(){
-    const tabs=Array.from(document.querySelectorAll('[data-type]'));
-    tabs.forEach(tab=>{
-      tab.addEventListener('click',()=>{
-        state.type=tab.getAttribute('data-type');
-        normalizeState();
-        updateURL();
-        state.visible=6;
-        updateControls();
-        render();
-      });
-      tab.addEventListener('keydown',e=>{
-        const idx=tabs.indexOf(document.activeElement);
-        if(e.key==='ArrowRight'){e.preventDefault();tabs[(idx+1)%tabs.length].focus();}
-        if(e.key==='ArrowLeft'){e.preventDefault();tabs[(idx-1+tabs.length)%tabs.length].focus();}
-        if(e.key==='Home'){e.preventDefault();tabs[0].focus();}
-        if(e.key==='End'){e.preventDefault();tabs[tabs.length-1].focus();}
-        if(e.key==='Enter'||e.key===' '){e.preventDefault();tab.click();}
-      });
-    });
-  }
-
-  function initSort(){
-    const button=document.getElementById('sort-button');
-    const menu=document.getElementById('sort-menu');
-    const options=Array.from(menu.querySelectorAll('[data-sort]'));
-    function close(){
-      menu.classList.add('hidden');
-      button.setAttribute('aria-expanded','false');
-      button.focus();
-    }
-    button.addEventListener('click',()=>{
-      const open=button.getAttribute('aria-expanded')==='true';
-      if(open){close();return;}
-      menu.classList.remove('hidden');
-      button.setAttribute('aria-expanded','true');
-      options[0].focus();
-    });
-    button.addEventListener('keydown',e=>{
-      if(e.key==='ArrowDown'){e.preventDefault();menu.classList.remove('hidden');button.setAttribute('aria-expanded','true');options[0].focus();}
-    });
-    menu.addEventListener('keydown',e=>{
-      const idx=options.indexOf(document.activeElement);
-      if(e.key==='ArrowDown'){e.preventDefault();options[(idx+1)%options.length].focus();}
-      if(e.key==='ArrowUp'){e.preventDefault();options[(idx-1+options.length)%options.length].focus();}
-      if(e.key==='Home'){e.preventDefault();options[0].focus();}
-      if(e.key==='End'){e.preventDefault();options[options.length-1].focus();}
-      if(e.key==='Escape'){e.preventDefault();close();}
-      if(e.key==='Tab'){e.preventDefault();}
-      if(e.key==='Enter'||e.key===' '){
-        e.preventDefault();
-        state.sort=document.activeElement.getAttribute('data-sort');
-        close();
-        updateURL();
-        updateControls();
-        render();
-      }
-    });
-  }
-
-  function initLoadMore(){
-    const more=document.getElementById('load-more');
-    more.addEventListener('click',()=>{state.visible+=3;render();});
-    if(!prefersReduced){
-      const io=new IntersectionObserver(entries=>{entries.forEach(e=>{if(e.isIntersecting){state.visible+=3;render();}})});
-      io.observe(more);
-    }
-  }
-
-  document.addEventListener('DOMContentLoaded',()=>{
-    applyReducedMotion();
-    renderSkeletons(state.visible);
-    loadData(lang);
-    hydrateFromURL();
-    initTabs();
-    initSort();
-    initLoadMore();
-    const reset=document.getElementById('reset-filters');
-    if(reset) reset.addEventListener('click',()=>{state.type='all';state.sort='new';updateURL();updateControls();render();});
+function updateControls(){
+  document.querySelectorAll('[data-type]').forEach(btn=>{
+    const active=btn.getAttribute('data-type')===state.type;
+    btn.setAttribute('aria-selected', active);
+    btn.tabIndex=active?0:-1;
   });
-})();
+  const btn=document.getElementById('sort-button');
+  if(btn){
+    const current=document.querySelector(`#sort-menu [data-sort="${state.sort}"]`);
+    if(current) btn.textContent=current.textContent;
+    document.querySelectorAll('#sort-menu [data-sort]').forEach(opt=>{
+      const sel=opt.getAttribute('data-sort')===state.sort;
+      opt.setAttribute('aria-selected', sel);
+    });
+  }
+}
+
+function applyFilters(items){
+  let res = state.type!=='all'? items.filter(i=>i.type===state.type):items;
+  if(state.search){
+    const q=state.search.toLowerCase();
+    res=res.filter(i=>(i.title+i.summary+i.tags.join('')).toLowerCase().includes(q));
+  }
+  return applySort(res);
+}
+
+function applySort(items){
+  const arr=[...items];
+  if(state.sort==='impact') arr.sort((a,b)=>b.impactScore-a.impactScore);
+  else if(state.sort==='speed') arr.sort((a,b)=>a.timeToLaunchHours-b.timeToLaunchHours);
+  return arr;
+}
+
+function announceCount(count){
+  if(live) live.textContent=`${count} ${count===1?'project':'projects'} visible`;
+}
+
+function renderSkeletons(n){
+  const container=document.getElementById('portfolio-grid');
+  if(!container) return;
+  container.innerHTML='';
+  for(let i=0;i<n;i++){
+    const article=document.createElement('article');
+    article.className='case-card border p-4 rounded skeleton dark:border-gray-700';
+    container.appendChild(article);
+  }
+}
+
+function render(){
+  const container=document.getElementById('portfolio-grid');
+  const empty=document.getElementById('empty-state');
+  if(!container || !empty) return;
+  const items=applyFilters(state.items);
+  const visibleItems=items.slice(0,state.visible);
+  container.innerHTML='';
+  if(items.length===0){
+    empty.hidden=false;
+    announceCount(0);
+    return;
+  }
+  empty.hidden=true;
+  visibleItems.forEach(item=>{
+    const article=document.createElement('article');
+    article.className='case-card border p-4 rounded focus-within:ring outline-none hover-lift bg-white dark:bg-gray-800 dark:border-gray-700';
+    article.setAttribute('role','listitem');
+    article.setAttribute('aria-label',item.title);
+    article.innerHTML=`
+      <div class="ph-media mb-3 rounded" role="img" aria-label="Placeholder"></div>
+      <span class="badge mb-2">Demo</span>
+      <h3 class="font-semibold mb-1">${item.title}</h3>
+      <ul class="flex flex-wrap gap-1 text-sm mb-2">${item.tags.slice(0,3).map(t=>`<li class="tag-pill">${t}</li>`).join('')}</ul>
+      <p class="kpi-row text-sm mb-3 flex flex-wrap gap-3">
+        <span class="flex items-center gap-1"><span aria-hidden="true">⏱</span>${item.kpis[0]}</span>
+        <span class="flex items-center gap-1"><span aria-hidden="true">⚡</span>${item.kpis[1]}</span>
+        <span class="flex items-center gap-1"><span aria-hidden="true">✅</span>${item.kpis[2]}</span>
+      </p>
+      <div class="flex flex-wrap gap-3">
+        <a class="btn btn-primary" aria-label="${t.view}: ${item.title}" href="${item.caseUrl}">${t.view}</a>
+        <a class="link" aria-label="${t.demo}: ${item.title}" href="${item.demoUrl}" target="_blank" rel="noopener">${t.demo}</a>
+      </div>`;
+    container.appendChild(article);
+  });
+  const more=document.getElementById('load-more');
+  if(!more) return;
+  more.hidden=items.length<=state.visible;
+  more.textContent=t.load;
+  announceCount(visibleItems.length);
+}
+
+function updateURL(){
+  const url=new URL(location.href);
+  if(state.type!=='all') url.searchParams.set('type',state.type); else url.searchParams.delete('type');
+  if(state.sort!=='new') url.searchParams.set('sort',state.sort); else url.searchParams.delete('sort');
+  history.replaceState(null,'',url);
+}
+
+function initTabs(){
+  const tabs=Array.from(document.querySelectorAll('[data-type]'));
+  tabs.forEach(tab=>{
+    tab.addEventListener('click',()=>{
+      state.type=tab.getAttribute('data-type');
+      normalizeState();
+      updateURL();
+      state.visible=6;
+      updateControls();
+      render();
+    });
+    tab.addEventListener('keydown',e=>{
+      const idx=tabs.indexOf(document.activeElement);
+      if(e.key==='ArrowRight'){e.preventDefault();tabs[(idx+1)%tabs.length].focus();}
+      if(e.key==='ArrowLeft'){e.preventDefault();tabs[(idx-1+tabs.length)%tabs.length].focus();}
+      if(e.key==='Home'){e.preventDefault();tabs[0].focus();}
+      if(e.key==='End'){e.preventDefault();tabs[tabs.length-1].focus();}
+      if(e.key==='Enter'||e.key===' '){e.preventDefault();tab.click();}
+    });
+  });
+}
+
+function initSort(){
+  const button=document.getElementById('sort-button');
+  const menu=document.getElementById('sort-menu');
+  const options=Array.from(menu.querySelectorAll('[data-sort]'));
+  function close(){
+    menu.classList.add('hidden');
+    button.setAttribute('aria-expanded','false');
+    button.focus();
+  }
+  button.addEventListener('click',()=>{
+    const open=button.getAttribute('aria-expanded')==='true';
+    if(open){close();return;}
+    menu.classList.remove('hidden');
+    button.setAttribute('aria-expanded','true');
+    options[0].focus();
+  });
+  button.addEventListener('keydown',e=>{
+    if(e.key==='ArrowDown'){e.preventDefault();menu.classList.remove('hidden');button.setAttribute('aria-expanded','true');options[0].focus();}
+  });
+  menu.addEventListener('keydown',e=>{
+    const idx=options.indexOf(document.activeElement);
+    if(e.key==='ArrowDown'){e.preventDefault();options[(idx+1)%options.length].focus();}
+    if(e.key==='ArrowUp'){e.preventDefault();options[(idx-1+options.length)%options.length].focus();}
+    if(e.key==='Home'){e.preventDefault();options[0].focus();}
+    if(e.key==='End'){e.preventDefault();options[options.length-1].focus();}
+    if(e.key==='Escape'){e.preventDefault();close();}
+    if(e.key==='Tab'){e.preventDefault();}
+    if(e.key==='Enter'||e.key===' '){
+      e.preventDefault();
+      state.sort=document.activeElement.getAttribute('data-sort');
+      close();
+      updateURL();
+      updateControls();
+      render();
+    }
+  });
+}
+
+function initLoadMore(){
+  const more=document.getElementById('load-more');
+  if(!more) return;
+  more.addEventListener('click',()=>{state.visible+=3;render();});
+  if(!prefersReduced){
+    const io=new IntersectionObserver(entries=>{entries.forEach(e=>{if(e.isIntersecting){state.visible+=3;render();}})});
+    io.observe(more);
+  }
+}
+
+let _booted = false;
+export function init(){
+  if (_booted) return;
+  _booted = true;
+  const list = document.getElementById("portfolio-grid");
+  if (list) list.setAttribute("aria-busy","true");
+  
+  function afterRender(){ if (list) list.setAttribute("aria-busy","false"); }
+  const _render = render;
+  render = (...a) => { const v = _render(...a); Promise.resolve().then(afterRender); return v; };
+
+  applyReducedMotion();
+  renderSkeletons(state.visible);
+  loadData(lang);
+  hydrateFromURL();
+  initTabs();
+  initSort();
+  initLoadMore();
+  const reset=document.getElementById('reset-filters');
+  if(reset) reset.addEventListener('click',()=>{state.type='all';state.sort='new';updateURL();updateControls();render();});
+}
+

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1,20 +1,35 @@
 (() => {
-  const KEY='site-theme';
-  const root=document.documentElement;
-  const prefersDark=window.matchMedia('(prefers-color-scheme: dark)').matches;
-  const saved=localStorage.getItem(KEY);
-  const initial = saved || (prefersDark ? 'dark' : 'light');
-  const apply = (mode) => {
+  const KEY = 'site-theme';
+  const root = document.documentElement;
+  let initialized = false;
+
+  function apply(mode) {
     root.setAttribute('data-theme', mode);
     localStorage.setItem(KEY, mode);
-    const btn=document.querySelector('[data-theme-toggle]');
-    if (btn) btn.setAttribute('aria-pressed', mode==='dark' ? 'true' : 'false');
-  };
-  apply(initial);
-  document.addEventListener('click', (e) => {
+    const btn = document.querySelector('[data-theme-toggle]');
+    if (btn) btn.setAttribute('aria-pressed', mode === 'dark' ? 'true' : 'false');
+  }
+
+  function toggle(e) {
     const btn = e.target.closest('[data-theme-toggle]');
     if (!btn) return;
-    const next = (root.getAttribute('data-theme')==='dark') ? 'light' : 'dark';
+    const next = root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
     apply(next);
-  });
+  }
+
+  function initThemeToggle() {
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const saved = localStorage.getItem(KEY);
+    const current = root.getAttribute('data-theme') || saved || (prefersDark ? 'dark' : 'light');
+    apply(current);
+    if (!initialized) {
+      document.addEventListener('click', toggle);
+      initialized = true;
+    }
+  }
+
+  window.initThemeToggle = initThemeToggle;
+
+  if (document.readyState !== 'loading') initThemeToggle();
+  else document.addEventListener('DOMContentLoaded', initThemeToggle);
 })();

--- a/de/portfolio.html
+++ b/de/portfolio.html
@@ -18,36 +18,10 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
-  <script src="/TurboSito/assets/js/theme.js" defer></script>
-  <script defer src="/TurboSito/assets/js/portfolio.js"></script>
 </head>
 <body class="font-sans text-gray-900">
-  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Zum Inhalt springen</a>
-  <header id="site-header">
-    <div class="container flex items-center justify-between gap-4">
-      <nav class="site-nav">
-        <a class="brand" href="/TurboSito/de/">TurboSito</a>
-        <a href="/TurboSito/de/ueber-mich.html">Über mich</a>
-        <a href="/TurboSito/de/leistungen.html">Leistungen</a>
-        <a href="/TurboSito/de/portfolio.html">Portfolio</a>
-        <a href="/TurboSito/de/kontakt.html">Kontakt</a>
-      </nav>
-      <div class="header-right flex items-center gap-2">
-        <nav class="lang-switch" aria-label="Sprachen">
-          <a href="/TurboSito/de/portfolio.html" data-lang="de" hreflang="de">DE</a>
-          <a href="/TurboSito/en/portfolio.html" data-lang="en" hreflang="en">EN</a>
-          <a href="/TurboSito/it/portfolio.html" data-lang="it" hreflang="it">IT</a>
-        </nav>
-        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button>
-        <button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false">
-          <span class="icon sun" aria-hidden="true">☀️</span>
-          <span class="icon moon" aria-hidden="true">🌙</span>
-          <span>Theme</span>
-        </button>
-      </div>
-    </div>
-  </header>
-  <main id="content" class="max-w-6xl mx-auto px-4 py-12">
+  <div data-include="header.html"></div>
+  <main id="main" class="max-w-6xl mx-auto px-4 py-12">
     <section class="text-center mb-10">
       <h1 class="text-3xl font-bold mb-2">Portfolio</h1>
       <p>Ehrliche Vorschau auf unseren Prozess.</p>
@@ -81,8 +55,20 @@
       </div>
     </section>
   </main>
-  <footer class="text-center py-10 text-sm">
-    <p>&copy; TurboSito</p>
-  </footer>
+  <div data-include="footer.html"></div>
+
+  <script src="/assets/js/partials.js" defer></script>
+  <script src="/assets/js/theme.js" defer></script>
+  <script type="module">
+  import { init as portfolioInit } from '/assets/js/portfolio.js';
+  (async () => {
+    if (window.Partials?.injectPartials) {
+      window.Partials.injectPartials();
+      await window.Partials.ready();
+    }
+    if (window.initThemeToggle) window.initThemeToggle();
+    if (typeof portfolioInit === 'function') portfolioInit();
+  })();
+</script>
 </body>
 </html>

--- a/de/portfolio/corporate-site.html
+++ b/de/portfolio/corporate-site.html
@@ -18,35 +18,10 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
-  <script src="/TurboSito/assets/js/theme.js" defer></script>
 </head>
 <body class="font-sans text-gray-900">
-  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Zum Inhalt springen</a>
-  <header id="site-header">
-    <div class="container flex items-center justify-between gap-4">
-      <nav class="site-nav">
-        <a class="brand" href="/TurboSito/de/">TurboSito</a>
-        <a href="/TurboSito/de/ueber-mich.html">Über mich</a>
-        <a href="/TurboSito/de/leistungen.html">Leistungen</a>
-        <a href="/TurboSito/de/portfolio.html">Portfolio</a>
-        <a href="/TurboSito/de/kontakt.html">Kontakt</a>
-      </nav>
-      <div class="header-right flex items-center gap-2">
-        <nav class="lang-switch" aria-label="Sprachen">
-          <a href="/TurboSito/de/portfolio/corporate-site.html" data-lang="de" hreflang="de">DE</a>
-          <a href="/TurboSito/en/portfolio/corporate-site.html" data-lang="en" hreflang="en">EN</a>
-          <a href="/TurboSito/it/portfolio/corporate-site.html" data-lang="it" hreflang="it">IT</a>
-        </nav>
-        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button>
-        <button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false">
-          <span class="icon sun" aria-hidden="true">☀️</span>
-          <span class="icon moon" aria-hidden="true">🌙</span>
-          <span>Theme</span>
-        </button>
-      </div>
-    </div>
-  </header>
-  <main id="content" class="max-w-3xl mx-auto px-4 py-12">
+  <div data-include="header.html"></div>
+  <main id="main" class="max-w-3xl mx-auto px-4 py-12">
     <nav aria-label="Brotkrumen" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
       <h1 id="case-title" class="text-3xl font-bold mb-2">Corporate-Site (Demo)</h1>
@@ -86,7 +61,7 @@
       <a class="btn btn-outline" href="../portfolio.html">Weitere Beispiele</a>
     </section>
     <script id="ld-json" type="application/ld+json"></script>
-    <script>
+    <script type="module">
     (async()=>{
       const slug='corporate-site';
       const lang=document.documentElement.lang;
@@ -125,6 +100,20 @@
     })();
     </script>
   </main>
-  <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+  <div data-include="footer.html"></div>
+
+  <script src="/assets/js/partials.js" defer></script>
+  <script src="/assets/js/theme.js" defer></script>
+  <script type="module">
+  import { init as portfolioInit } from '/assets/js/portfolio.js';
+  (async () => {
+    if (window.Partials?.injectPartials) {
+      window.Partials.injectPartials();
+      await window.Partials.ready();
+    }
+    if (window.initThemeToggle) window.initThemeToggle();
+    if (typeof portfolioInit === 'function') portfolioInit();
+  })();
+</script>
 </body>
 </html>

--- a/de/portfolio/fashion-shop.html
+++ b/de/portfolio/fashion-shop.html
@@ -18,35 +18,10 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
-  <script src="/TurboSito/assets/js/theme.js" defer></script>
 </head>
 <body class="font-sans text-gray-900">
-  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Zum Inhalt springen</a>
-  <header id="site-header">
-    <div class="container flex items-center justify-between gap-4">
-      <nav class="site-nav">
-        <a class="brand" href="/TurboSito/de/">TurboSito</a>
-        <a href="/TurboSito/de/ueber-mich.html">Über mich</a>
-        <a href="/TurboSito/de/leistungen.html">Leistungen</a>
-        <a href="/TurboSito/de/portfolio.html">Portfolio</a>
-        <a href="/TurboSito/de/kontakt.html">Kontakt</a>
-      </nav>
-      <div class="header-right flex items-center gap-2">
-        <nav class="lang-switch" aria-label="Sprachen">
-          <a href="/TurboSito/de/portfolio/fashion-shop.html" data-lang="de" hreflang="de">DE</a>
-          <a href="/TurboSito/en/portfolio/fashion-shop.html" data-lang="en" hreflang="en">EN</a>
-          <a href="/TurboSito/it/portfolio/fashion-shop.html" data-lang="it" hreflang="it">IT</a>
-        </nav>
-        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button>
-        <button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false">
-          <span class="icon sun" aria-hidden="true">☀️</span>
-          <span class="icon moon" aria-hidden="true">🌙</span>
-          <span>Theme</span>
-        </button>
-      </div>
-    </div>
-  </header>
-  <main id="content" class="max-w-3xl mx-auto px-4 py-12">
+  <div data-include="header.html"></div>
+  <main id="main" class="max-w-3xl mx-auto px-4 py-12">
     <nav aria-label="Brotkrumen" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
       <h1 id="case-title" class="text-3xl font-bold mb-2">Fashion-Shop (Demo)</h1>
@@ -86,7 +61,7 @@
       <a class="btn btn-outline" href="../portfolio.html">Weitere Beispiele</a>
     </section>
     <script id="ld-json" type="application/ld+json"></script>
-    <script>
+    <script type="module">
     (async()=>{
       const slug='fashion-shop';
       const lang=document.documentElement.lang;
@@ -125,6 +100,20 @@
     })();
     </script>
   </main>
-  <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+  <div data-include="footer.html"></div>
+
+  <script src="/assets/js/partials.js" defer></script>
+  <script src="/assets/js/theme.js" defer></script>
+  <script type="module">
+  import { init as portfolioInit } from '/assets/js/portfolio.js';
+  (async () => {
+    if (window.Partials?.injectPartials) {
+      window.Partials.injectPartials();
+      await window.Partials.ready();
+    }
+    if (window.initThemeToggle) window.initThemeToggle();
+    if (typeof portfolioInit === 'function') portfolioInit();
+  })();
+</script>
 </body>
 </html>

--- a/de/portfolio/saas-landing.html
+++ b/de/portfolio/saas-landing.html
@@ -18,35 +18,10 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
-  <script src="/TurboSito/assets/js/theme.js" defer></script>
 </head>
 <body class="font-sans text-gray-900">
-  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Zum Inhalt springen</a>
-  <header id="site-header">
-    <div class="container flex items-center justify-between gap-4">
-      <nav class="site-nav">
-        <a class="brand" href="/TurboSito/de/">TurboSito</a>
-        <a href="/TurboSito/de/ueber-mich.html">Über mich</a>
-        <a href="/TurboSito/de/leistungen.html">Leistungen</a>
-        <a href="/TurboSito/de/portfolio.html">Portfolio</a>
-        <a href="/TurboSito/de/kontakt.html">Kontakt</a>
-      </nav>
-      <div class="header-right flex items-center gap-2">
-        <nav class="lang-switch" aria-label="Sprachen">
-          <a href="/TurboSito/de/portfolio/saas-landing.html" data-lang="de" hreflang="de">DE</a>
-          <a href="/TurboSito/en/portfolio/saas-landing.html" data-lang="en" hreflang="en">EN</a>
-          <a href="/TurboSito/it/portfolio/saas-landing.html" data-lang="it" hreflang="it">IT</a>
-        </nav>
-        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menü"><span aria-hidden="true"></span></button>
-        <button class="theme-toggle" data-theme-toggle aria-label="Theme umschalten" aria-pressed="false">
-          <span class="icon sun" aria-hidden="true">☀️</span>
-          <span class="icon moon" aria-hidden="true">🌙</span>
-          <span>Theme</span>
-        </button>
-      </div>
-    </div>
-  </header>
-  <main id="content" class="max-w-3xl mx-auto px-4 py-12">
+  <div data-include="header.html"></div>
+  <main id="main" class="max-w-3xl mx-auto px-4 py-12">
     <nav aria-label="Brotkrumen" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
       <h1 id="case-title" class="text-3xl font-bold mb-2">SaaS-Landing (Demo)</h1>
@@ -86,7 +61,7 @@
       <a class="btn btn-outline" href="../portfolio.html">Weitere Beispiele</a>
     </section>
     <script id="ld-json" type="application/ld+json"></script>
-    <script>
+    <script type="module">
     (async()=>{
       const slug='saas-landing';
       const lang=document.documentElement.lang;
@@ -125,6 +100,20 @@
     })();
     </script>
   </main>
-  <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+  <div data-include="footer.html"></div>
+
+  <script src="/assets/js/partials.js" defer></script>
+  <script src="/assets/js/theme.js" defer></script>
+  <script type="module">
+  import { init as portfolioInit } from '/assets/js/portfolio.js';
+  (async () => {
+    if (window.Partials?.injectPartials) {
+      window.Partials.injectPartials();
+      await window.Partials.ready();
+    }
+    if (window.initThemeToggle) window.initThemeToggle();
+    if (typeof portfolioInit === 'function') portfolioInit();
+  })();
+</script>
 </body>
 </html>

--- a/en/portfolio.html
+++ b/en/portfolio.html
@@ -18,36 +18,10 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
-  <script src="/TurboSito/assets/js/theme.js" defer></script>
-  <script defer src="/TurboSito/assets/js/portfolio.js"></script>
 </head>
 <body class="font-sans text-gray-900">
-  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
-  <header id="site-header">
-    <div class="container flex items-center justify-between gap-4">
-      <nav class="site-nav">
-        <a class="brand" href="/TurboSito/en/">TurboSito</a>
-        <a href="/TurboSito/en/about.html">About</a>
-        <a href="/TurboSito/en/services.html">Services</a>
-        <a href="/TurboSito/en/portfolio.html">Portfolio</a>
-        <a href="/TurboSito/en/contact.html">Contact</a>
-      </nav>
-      <div class="header-right flex items-center gap-2">
-        <nav class="lang-switch" aria-label="Languages">
-          <a href="/TurboSito/de/portfolio.html" data-lang="de" hreflang="de">DE</a>
-          <a href="/TurboSito/en/portfolio.html" data-lang="en" hreflang="en">EN</a>
-          <a href="/TurboSito/it/portfolio.html" data-lang="it" hreflang="it">IT</a>
-        </nav>
-        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button>
-        <button class="theme-toggle" data-theme-toggle aria-label="Toggle theme" aria-pressed="false">
-          <span class="icon sun" aria-hidden="true">☀️</span>
-          <span class="icon moon" aria-hidden="true">🌙</span>
-          <span>Theme</span>
-        </button>
-      </div>
-    </div>
-  </header>
-  <main id="content" class="max-w-6xl mx-auto px-4 py-12">
+  <div data-include="header.html"></div>
+  <main id="main" class="max-w-6xl mx-auto px-4 py-12">
     <section class="text-center mb-10">
       <h1 class="text-3xl font-bold mb-2">Portfolio</h1>
       <p>Honest preview of our process.</p>
@@ -81,8 +55,20 @@
       </div>
     </section>
   </main>
-  <footer class="text-center py-10 text-sm">
-    <p>&copy; TurboSito</p>
-  </footer>
+  <div data-include="footer.html"></div>
+
+  <script src="/assets/js/partials.js" defer></script>
+  <script src="/assets/js/theme.js" defer></script>
+  <script type="module">
+  import { init as portfolioInit } from '/assets/js/portfolio.js';
+  (async () => {
+    if (window.Partials?.injectPartials) {
+      window.Partials.injectPartials();
+      await window.Partials.ready();
+    }
+    if (window.initThemeToggle) window.initThemeToggle();
+    if (typeof portfolioInit === 'function') portfolioInit();
+  })();
+</script>
 </body>
 </html>

--- a/en/portfolio/corporate-site.html
+++ b/en/portfolio/corporate-site.html
@@ -18,35 +18,10 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
-  <script src="/TurboSito/assets/js/theme.js" defer></script>
 </head>
 <body class="font-sans text-gray-900">
-  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
-  <header id="site-header">
-    <div class="container flex items-center justify-between gap-4">
-      <nav class="site-nav">
-        <a class="brand" href="/TurboSito/en/">TurboSito</a>
-        <a href="/TurboSito/en/about.html">About</a>
-        <a href="/TurboSito/en/services.html">Services</a>
-        <a href="/TurboSito/en/portfolio.html">Portfolio</a>
-        <a href="/TurboSito/en/contact.html">Contact</a>
-      </nav>
-      <div class="header-right flex items-center gap-2">
-        <nav class="lang-switch" aria-label="Language switch">
-          <a href="/TurboSito/de/portfolio/corporate-site.html" data-lang="de" hreflang="de">DE</a>
-          <a href="/TurboSito/en/portfolio/corporate-site.html" data-lang="en" hreflang="en">EN</a>
-          <a href="/TurboSito/it/portfolio/corporate-site.html" data-lang="it" hreflang="it">IT</a>
-        </nav>
-        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button>
-        <button class="theme-toggle" data-theme-toggle aria-label="Toggle theme" aria-pressed="false">
-          <span class="icon sun" aria-hidden="true">☀️</span>
-          <span class="icon moon" aria-hidden="true">🌙</span>
-          <span>Theme</span>
-        </button>
-      </div>
-    </div>
-  </header>
-  <main id="content" class="max-w-3xl mx-auto px-4 py-12">
+  <div data-include="header.html"></div>
+  <main id="main" class="max-w-3xl mx-auto px-4 py-12">
     <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
       <h1 id="case-title" class="text-3xl font-bold mb-2">Corporate Site (Demo)</h1>
@@ -86,7 +61,7 @@
       <a class="btn btn-outline" href="../portfolio.html">More examples</a>
     </section>
     <script id="ld-json" type="application/ld+json"></script>
-    <script>
+    <script type="module">
     (async()=>{
       const slug='corporate-site';
       const lang=document.documentElement.lang;
@@ -125,6 +100,20 @@
     })();
     </script>
   </main>
-  <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+  <div data-include="footer.html"></div>
+
+  <script src="/assets/js/partials.js" defer></script>
+  <script src="/assets/js/theme.js" defer></script>
+  <script type="module">
+  import { init as portfolioInit } from '/assets/js/portfolio.js';
+  (async () => {
+    if (window.Partials?.injectPartials) {
+      window.Partials.injectPartials();
+      await window.Partials.ready();
+    }
+    if (window.initThemeToggle) window.initThemeToggle();
+    if (typeof portfolioInit === 'function') portfolioInit();
+  })();
+</script>
 </body>
 </html>

--- a/en/portfolio/fashion-shop.html
+++ b/en/portfolio/fashion-shop.html
@@ -18,35 +18,10 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
-  <script src="/TurboSito/assets/js/theme.js" defer></script>
 </head>
 <body class="font-sans text-gray-900">
-  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
-  <header id="site-header">
-    <div class="container flex items-center justify-between gap-4">
-      <nav class="site-nav">
-        <a class="brand" href="/TurboSito/en/">TurboSito</a>
-        <a href="/TurboSito/en/about.html">About</a>
-        <a href="/TurboSito/en/services.html">Services</a>
-        <a href="/TurboSito/en/portfolio.html">Portfolio</a>
-        <a href="/TurboSito/en/contact.html">Contact</a>
-      </nav>
-      <div class="header-right flex items-center gap-2">
-        <nav class="lang-switch" aria-label="Language switch">
-          <a href="/TurboSito/de/portfolio/fashion-shop.html" data-lang="de" hreflang="de">DE</a>
-          <a href="/TurboSito/en/portfolio/fashion-shop.html" data-lang="en" hreflang="en">EN</a>
-          <a href="/TurboSito/it/portfolio/fashion-shop.html" data-lang="it" hreflang="it">IT</a>
-        </nav>
-        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button>
-        <button class="theme-toggle" data-theme-toggle aria-label="Toggle theme" aria-pressed="false">
-          <span class="icon sun" aria-hidden="true">☀️</span>
-          <span class="icon moon" aria-hidden="true">🌙</span>
-          <span>Theme</span>
-        </button>
-      </div>
-    </div>
-  </header>
-  <main id="content" class="max-w-3xl mx-auto px-4 py-12">
+  <div data-include="header.html"></div>
+  <main id="main" class="max-w-3xl mx-auto px-4 py-12">
     <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
       <h1 id="case-title" class="text-3xl font-bold mb-2">Fashion Shop (Demo)</h1>
@@ -86,7 +61,7 @@
       <a class="btn btn-outline" href="../portfolio.html">More examples</a>
     </section>
     <script id="ld-json" type="application/ld+json"></script>
-    <script>
+    <script type="module">
     (async()=>{
       const slug='fashion-shop';
       const lang=document.documentElement.lang;
@@ -125,6 +100,20 @@
     })();
     </script>
   </main>
-  <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+  <div data-include="footer.html"></div>
+
+  <script src="/assets/js/partials.js" defer></script>
+  <script src="/assets/js/theme.js" defer></script>
+  <script type="module">
+  import { init as portfolioInit } from '/assets/js/portfolio.js';
+  (async () => {
+    if (window.Partials?.injectPartials) {
+      window.Partials.injectPartials();
+      await window.Partials.ready();
+    }
+    if (window.initThemeToggle) window.initThemeToggle();
+    if (typeof portfolioInit === 'function') portfolioInit();
+  })();
+</script>
 </body>
 </html>

--- a/en/portfolio/saas-landing.html
+++ b/en/portfolio/saas-landing.html
@@ -18,35 +18,10 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
-  <script src="/TurboSito/assets/js/theme.js" defer></script>
 </head>
 <body class="font-sans text-gray-900">
-  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Skip to content</a>
-  <header id="site-header">
-    <div class="container flex items-center justify-between gap-4">
-      <nav class="site-nav">
-        <a class="brand" href="/TurboSito/en/">TurboSito</a>
-        <a href="/TurboSito/en/about.html">About</a>
-        <a href="/TurboSito/en/services.html">Services</a>
-        <a href="/TurboSito/en/portfolio.html">Portfolio</a>
-        <a href="/TurboSito/en/contact.html">Contact</a>
-      </nav>
-      <div class="header-right flex items-center gap-2">
-        <nav class="lang-switch" aria-label="Language switch">
-          <a href="/TurboSito/de/portfolio/saas-landing.html" data-lang="de" hreflang="de">DE</a>
-          <a href="/TurboSito/en/portfolio/saas-landing.html" data-lang="en" hreflang="en">EN</a>
-          <a href="/TurboSito/it/portfolio/saas-landing.html" data-lang="it" hreflang="it">IT</a>
-        </nav>
-        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menu"><span aria-hidden="true"></span></button>
-        <button class="theme-toggle" data-theme-toggle aria-label="Toggle theme" aria-pressed="false">
-          <span class="icon sun" aria-hidden="true">☀️</span>
-          <span class="icon moon" aria-hidden="true">🌙</span>
-          <span>Theme</span>
-        </button>
-      </div>
-    </div>
-  </header>
-  <main id="content" class="max-w-3xl mx-auto px-4 py-12">
+  <div data-include="header.html"></div>
+  <main id="main" class="max-w-3xl mx-auto px-4 py-12">
     <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
       <h1 id="case-title" class="text-3xl font-bold mb-2">SaaS Landing (Demo)</h1>
@@ -86,7 +61,7 @@
       <a class="btn btn-outline" href="../portfolio.html">More examples</a>
     </section>
     <script id="ld-json" type="application/ld+json"></script>
-    <script>
+    <script type="module">
     (async()=>{
       const slug='saas-landing';
       const lang=document.documentElement.lang;
@@ -125,6 +100,20 @@
     })();
     </script>
   </main>
-  <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+  <div data-include="footer.html"></div>
+
+  <script src="/assets/js/partials.js" defer></script>
+  <script src="/assets/js/theme.js" defer></script>
+  <script type="module">
+  import { init as portfolioInit } from '/assets/js/portfolio.js';
+  (async () => {
+    if (window.Partials?.injectPartials) {
+      window.Partials.injectPartials();
+      await window.Partials.ready();
+    }
+    if (window.initThemeToggle) window.initThemeToggle();
+    if (typeof portfolioInit === 'function') portfolioInit();
+  })();
+</script>
 </body>
 </html>

--- a/it/portfolio.html
+++ b/it/portfolio.html
@@ -18,36 +18,10 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
-  <script src="/TurboSito/assets/js/theme.js" defer></script>
-  <script defer src="/TurboSito/assets/js/portfolio.js"></script>
 </head>
 <body class="font-sans text-gray-900">
-  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Vai al contenuto</a>
-  <header id="site-header">
-    <div class="container flex items-center justify-between gap-4">
-      <nav class="site-nav">
-        <a class="brand" href="/TurboSito/it/">TurboSito</a>
-        <a href="/TurboSito/it/chi-sono.html">Chi sono</a>
-        <a href="/TurboSito/it/servizi.html">Servizi</a>
-        <a href="/TurboSito/it/portfolio.html">Portfolio</a>
-        <a href="/TurboSito/it/contatto.html">Contatto</a>
-      </nav>
-      <div class="header-right flex items-center gap-2">
-        <nav class="lang-switch" aria-label="Lingue">
-          <a href="/TurboSito/de/portfolio.html" data-lang="de" hreflang="de">DE</a>
-          <a href="/TurboSito/en/portfolio.html" data-lang="en" hreflang="en">EN</a>
-          <a href="/TurboSito/it/portfolio.html" data-lang="it" hreflang="it">IT</a>
-        </nav>
-        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menù"><span aria-hidden="true"></span></button>
-        <button class="theme-toggle" data-theme-toggle aria-label="Cambia tema" aria-pressed="false">
-          <span class="icon sun" aria-hidden="true">☀️</span>
-          <span class="icon moon" aria-hidden="true">🌙</span>
-          <span>Theme</span>
-        </button>
-      </div>
-    </div>
-  </header>
-  <main id="content" class="max-w-6xl mx-auto px-4 py-12">
+  <div data-include="header.html"></div>
+  <main id="main" class="max-w-6xl mx-auto px-4 py-12">
     <section class="text-center mb-10">
       <h1 class="text-3xl font-bold mb-2">Portfolio</h1>
       <p>Anteprima onesta del nostro processo.</p>
@@ -81,8 +55,20 @@
       </div>
     </section>
   </main>
-  <footer class="text-center py-10 text-sm">
-    <p>&copy; TurboSito</p>
-  </footer>
+  <div data-include="footer.html"></div>
+
+  <script src="/assets/js/partials.js" defer></script>
+  <script src="/assets/js/theme.js" defer></script>
+  <script type="module">
+  import { init as portfolioInit } from '/assets/js/portfolio.js';
+  (async () => {
+    if (window.Partials?.injectPartials) {
+      window.Partials.injectPartials();
+      await window.Partials.ready();
+    }
+    if (window.initThemeToggle) window.initThemeToggle();
+    if (typeof portfolioInit === 'function') portfolioInit();
+  })();
+</script>
 </body>
 </html>

--- a/it/portfolio/corporate-site.html
+++ b/it/portfolio/corporate-site.html
@@ -18,35 +18,10 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
-  <script src="/TurboSito/assets/js/theme.js" defer></script>
 </head>
 <body class="font-sans text-gray-900">
-  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Vai al contenuto</a>
-  <header id="site-header">
-    <div class="container flex items-center justify-between gap-4">
-      <nav class="site-nav">
-        <a class="brand" href="/TurboSito/it/">TurboSito</a>
-        <a href="/TurboSito/it/chi-sono.html">Chi sono</a>
-        <a href="/TurboSito/it/servizi.html">Servizi</a>
-        <a href="/TurboSito/it/portfolio.html">Portfolio</a>
-        <a href="/TurboSito/it/contatto.html">Contatto</a>
-      </nav>
-      <div class="header-right flex items-center gap-2">
-        <nav class="lang-switch" aria-label="Lingue">
-          <a href="/TurboSito/de/portfolio/corporate-site.html" data-lang="de" hreflang="de">DE</a>
-          <a href="/TurboSito/en/portfolio/corporate-site.html" data-lang="en" hreflang="en">EN</a>
-          <a href="/TurboSito/it/portfolio/corporate-site.html" data-lang="it" hreflang="it">IT</a>
-        </nav>
-        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menù"><span aria-hidden="true"></span></button>
-        <button class="theme-toggle" data-theme-toggle aria-label="Cambia tema" aria-pressed="false">
-          <span class="icon sun" aria-hidden="true">☀️</span>
-          <span class="icon moon" aria-hidden="true">🌙</span>
-          <span>Theme</span>
-        </button>
-      </div>
-    </div>
-  </header>
-  <main id="content" class="max-w-3xl mx-auto px-4 py-12">
+  <div data-include="header.html"></div>
+  <main id="main" class="max-w-3xl mx-auto px-4 py-12">
     <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
       <h1 id="case-title" class="text-3xl font-bold mb-2">Corporate Site (Demo)</h1>
@@ -86,7 +61,7 @@
       <a class="btn btn-outline" href="../portfolio.html">Altri esempi</a>
     </section>
     <script id="ld-json" type="application/ld+json"></script>
-    <script>
+    <script type="module">
     (async()=>{
       const slug='corporate-site';
       const lang=document.documentElement.lang;
@@ -125,6 +100,20 @@
     })();
     </script>
   </main>
-  <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+  <div data-include="footer.html"></div>
+
+  <script src="/assets/js/partials.js" defer></script>
+  <script src="/assets/js/theme.js" defer></script>
+  <script type="module">
+  import { init as portfolioInit } from '/assets/js/portfolio.js';
+  (async () => {
+    if (window.Partials?.injectPartials) {
+      window.Partials.injectPartials();
+      await window.Partials.ready();
+    }
+    if (window.initThemeToggle) window.initThemeToggle();
+    if (typeof portfolioInit === 'function') portfolioInit();
+  })();
+</script>
 </body>
 </html>

--- a/it/portfolio/fashion-shop.html
+++ b/it/portfolio/fashion-shop.html
@@ -18,35 +18,10 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
-  <script src="/TurboSito/assets/js/theme.js" defer></script>
 </head>
 <body class="font-sans text-gray-900">
-  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Vai al contenuto</a>
-  <header id="site-header">
-    <div class="container flex items-center justify-between gap-4">
-      <nav class="site-nav">
-        <a class="brand" href="/TurboSito/it/">TurboSito</a>
-        <a href="/TurboSito/it/chi-sono.html">Chi sono</a>
-        <a href="/TurboSito/it/servizi.html">Servizi</a>
-        <a href="/TurboSito/it/portfolio.html">Portfolio</a>
-        <a href="/TurboSito/it/contatto.html">Contatto</a>
-      </nav>
-      <div class="header-right flex items-center gap-2">
-        <nav class="lang-switch" aria-label="Lingue">
-          <a href="/TurboSito/de/portfolio/fashion-shop.html" data-lang="de" hreflang="de">DE</a>
-          <a href="/TurboSito/en/portfolio/fashion-shop.html" data-lang="en" hreflang="en">EN</a>
-          <a href="/TurboSito/it/portfolio/fashion-shop.html" data-lang="it" hreflang="it">IT</a>
-        </nav>
-        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menù"><span aria-hidden="true"></span></button>
-        <button class="theme-toggle" data-theme-toggle aria-label="Cambia tema" aria-pressed="false">
-          <span class="icon sun" aria-hidden="true">☀️</span>
-          <span class="icon moon" aria-hidden="true">🌙</span>
-          <span>Theme</span>
-        </button>
-      </div>
-    </div>
-  </header>
-  <main id="content" class="max-w-3xl mx-auto px-4 py-12">
+  <div data-include="header.html"></div>
+  <main id="main" class="max-w-3xl mx-auto px-4 py-12">
     <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
       <h1 id="case-title" class="text-3xl font-bold mb-2">Fashion Shop (Demo)</h1>
@@ -86,7 +61,7 @@
       <a class="btn btn-outline" href="../portfolio.html">Altri esempi</a>
     </section>
     <script id="ld-json" type="application/ld+json"></script>
-    <script>
+    <script type="module">
     (async()=>{
       const slug='fashion-shop';
       const lang=document.documentElement.lang;
@@ -125,6 +100,20 @@
     })();
     </script>
   </main>
-  <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+  <div data-include="footer.html"></div>
+
+  <script src="/assets/js/partials.js" defer></script>
+  <script src="/assets/js/theme.js" defer></script>
+  <script type="module">
+  import { init as portfolioInit } from '/assets/js/portfolio.js';
+  (async () => {
+    if (window.Partials?.injectPartials) {
+      window.Partials.injectPartials();
+      await window.Partials.ready();
+    }
+    if (window.initThemeToggle) window.initThemeToggle();
+    if (typeof portfolioInit === 'function') portfolioInit();
+  })();
+</script>
 </body>
 </html>

--- a/it/portfolio/saas-landing.html
+++ b/it/portfolio/saas-landing.html
@@ -18,35 +18,10 @@
   <link rel="stylesheet" href="/TurboSito/assets/css/theme.css"/>
   <link rel="stylesheet" href="/TurboSito/assets/css/portfolio.css"/>
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
-  <script src="/TurboSito/assets/js/theme.js" defer></script>
 </head>
 <body class="font-sans text-gray-900">
-  <a href="#content" class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:bg-white text-black px-3 py-2 rounded">Vai al contenuto</a>
-  <header id="site-header">
-    <div class="container flex items-center justify-between gap-4">
-      <nav class="site-nav">
-        <a class="brand" href="/TurboSito/it/">TurboSito</a>
-        <a href="/TurboSito/it/chi-sono.html">Chi sono</a>
-        <a href="/TurboSito/it/servizi.html">Servizi</a>
-        <a href="/TurboSito/it/portfolio.html">Portfolio</a>
-        <a href="/TurboSito/it/contatto.html">Contatto</a>
-      </nav>
-      <div class="header-right flex items-center gap-2">
-        <nav class="lang-switch" aria-label="Lingue">
-          <a href="/TurboSito/de/portfolio/saas-landing.html" data-lang="de" hreflang="de">DE</a>
-          <a href="/TurboSito/en/portfolio/saas-landing.html" data-lang="en" hreflang="en">EN</a>
-          <a href="/TurboSito/it/portfolio/saas-landing.html" data-lang="it" hreflang="it">IT</a>
-        </nav>
-        <button class="hamburger md:hidden" data-nav-toggle aria-controls="mobile-menu" aria-expanded="false" aria-label="Menù"><span aria-hidden="true"></span></button>
-        <button class="theme-toggle" data-theme-toggle aria-label="Cambia tema" aria-pressed="false">
-          <span class="icon sun" aria-hidden="true">☀️</span>
-          <span class="icon moon" aria-hidden="true">🌙</span>
-          <span>Theme</span>
-        </button>
-      </div>
-    </div>
-  </header>
-  <main id="content" class="max-w-3xl mx-auto px-4 py-12">
+  <div data-include="header.html"></div>
+  <main id="main" class="max-w-3xl mx-auto px-4 py-12">
     <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
       <h1 id="case-title" class="text-3xl font-bold mb-2">Landing SaaS (Demo)</h1>
@@ -86,7 +61,7 @@
       <a class="btn btn-outline" href="../portfolio.html">Altri esempi</a>
     </section>
     <script id="ld-json" type="application/ld+json"></script>
-    <script>
+    <script type="module">
     (async()=>{
       const slug='saas-landing';
       const lang=document.documentElement.lang;
@@ -125,6 +100,20 @@
     })();
     </script>
   </main>
-  <footer class="text-center py-10 text-sm"><p>&copy; TurboSito</p></footer>
+  <div data-include="footer.html"></div>
+
+  <script src="/assets/js/partials.js" defer></script>
+  <script src="/assets/js/theme.js" defer></script>
+  <script type="module">
+  import { init as portfolioInit } from '/assets/js/portfolio.js';
+  (async () => {
+    if (window.Partials?.injectPartials) {
+      window.Partials.injectPartials();
+      await window.Partials.ready();
+    }
+    if (window.initThemeToggle) window.initThemeToggle();
+    if (typeof portfolioInit === 'function') portfolioInit();
+  })();
+</script>
 </body>
 </html>

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -1,0 +1,7 @@
+<footer class="site-footer text-center py-10 text-sm">
+  <p>© TurboSito</p>
+  <ul class="flex justify-center gap-4">
+    <li><a href="/legal/impressum.html">Impressum</a></li>
+    <li><a href="/legal/datenschutz.html">Datenschutz</a></li>
+  </ul>
+</footer>

--- a/partials/header.html
+++ b/partials/header.html
@@ -1,0 +1,15 @@
+<a href="#main"
+   class="sr-only focus:not-sr-only focus:absolute focus:m-2 focus:p-2 focus:bg-black/80 focus:text-white rounded"
+   hidden>Zum Inhalt springen</a>
+<header class="site-header">
+  <nav class="container flex items-center justify-between gap-4">
+    <div class="nav-left">
+      <a href="/" class="brand" data-nav>Start</a>
+      <a href="/ueber-mich/" data-nav>Über mich</a>
+      <a href="/leistungen/" data-nav>Leistungen</a>
+      <a href="/portfolio/" data-nav>Portfolio</a>
+      <a href="/kontakt/" data-nav>Kontakt</a>
+    </div>
+    <button type="button" data-theme-toggle aria-label="Theme umschalten"></button>
+  </nav>
+</header>


### PR DESCRIPTION
## Summary
- harden partial loader with timeout, retries and robust navigation handling
- expose idempotent portfolio initialiser and sequence partial injection before feature scripts
- include skip link and theme toggle hook in shared header

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bee7a1d9c88332a95c719c54cc5cf2