### PR TITLE
Fix portfolio paths for GitHub Pages

### DIFF
--- a/assets/data/portfolio.de.json
+++ b/assets/data/portfolio.de.json
@@ -8,8 +8,8 @@
       "impactScore": 9,
       "timeToLaunchHours": 48,
       "summary": "Demo-Case – Stil, Struktur, Speed.",
-      "demoUrl": "/TurboSito/de/demos/saas-landing.html",
-      "caseUrl": "/TurboSito/de/portfolio/saas-landing.html",
+      "demoUrl": "/de/demos/saas-landing.html",
+      "caseUrl": "/de/portfolio/saas-landing.html",
       "highlights": ["Value Proposition klar", "CTA direkt sichtbar", "Mobile-First"],
       "tags": ["Tailwind", "Static Export", "A11y-Ready"]
     },
@@ -21,8 +21,8 @@
       "impactScore": 8,
       "timeToLaunchHours": 48,
       "summary": "Demo-Case – Vertrauen und Struktur.",
-      "demoUrl": "/TurboSito/de/demos/corporate-site.html",
-      "caseUrl": "/TurboSito/de/portfolio/corporate-site.html",
+      "demoUrl": "/de/demos/corporate-site.html",
+      "caseUrl": "/de/portfolio/corporate-site.html",
       "highlights": ["Fokus auf Leistungen", "Schlanke Navigation", "Responsiv"],
       "tags": ["Tailwind", "Static Export", "SEO-Ready"]
     },
@@ -34,8 +34,8 @@
       "impactScore": 7,
       "timeToLaunchHours": 48,
       "summary": "Demo-Shop – klar und schnell.",
-      "demoUrl": "/TurboSito/de/demos/fashion-shop.html",
-      "caseUrl": "/TurboSito/de/portfolio/fashion-shop.html",
+      "demoUrl": "/de/demos/fashion-shop.html",
+      "caseUrl": "/de/portfolio/fashion-shop.html",
       "highlights": ["Einfaches Grid", "Schneller Warenkorb", "Mobile-First"],
       "tags": ["Tailwind", "Static Export", "Snipcart"]
     }

--- a/assets/data/portfolio.en.json
+++ b/assets/data/portfolio.en.json
@@ -8,8 +8,8 @@
       "impactScore": 9,
       "timeToLaunchHours": 48,
       "summary": "Demo case – style, structure, speed.",
-      "demoUrl": "/TurboSito/de/demos/saas-landing.html",
-      "caseUrl": "/TurboSito/en/portfolio/saas-landing.html",
+      "demoUrl": "/de/demos/saas-landing.html",
+      "caseUrl": "/en/portfolio/saas-landing.html",
       "highlights": ["Value proposition clear", "Above-the-fold CTA", "Mobile-first"],
       "tags": ["Tailwind", "Static Export", "A11y-Ready"]
     },
@@ -21,8 +21,8 @@
       "impactScore": 8,
       "timeToLaunchHours": 48,
       "summary": "Demo case – trust and structure.",
-      "demoUrl": "/TurboSito/de/demos/corporate-site.html",
-      "caseUrl": "/TurboSito/en/portfolio/corporate-site.html",
+      "demoUrl": "/de/demos/corporate-site.html",
+      "caseUrl": "/en/portfolio/corporate-site.html",
       "highlights": ["Focused services", "Lean navigation", "Responsive"],
       "tags": ["Tailwind", "Static Export", "SEO-Ready"]
     },
@@ -34,8 +34,8 @@
       "impactScore": 7,
       "timeToLaunchHours": 48,
       "summary": "Demo store – clean and quick.",
-      "demoUrl": "/TurboSito/de/demos/fashion-shop.html",
-      "caseUrl": "/TurboSito/en/portfolio/fashion-shop.html",
+      "demoUrl": "/de/demos/fashion-shop.html",
+      "caseUrl": "/en/portfolio/fashion-shop.html",
       "highlights": ["Simple grid", "Quick cart", "Mobile-first"],
       "tags": ["Tailwind", "Static Export", "Snipcart"]
     }

--- a/assets/data/portfolio.it.json
+++ b/assets/data/portfolio.it.json
@@ -8,8 +8,8 @@
       "impactScore": 9,
       "timeToLaunchHours": 48,
       "summary": "Caso demo – stile, struttura, velocità.",
-      "demoUrl": "/TurboSito/de/demos/saas-landing.html",
-      "caseUrl": "/TurboSito/it/portfolio/saas-landing.html",
+      "demoUrl": "/de/demos/saas-landing.html",
+      "caseUrl": "/it/portfolio/saas-landing.html",
       "highlights": ["Value proposition chiara", "CTA above-the-fold", "Mobile-first"],
       "tags": ["Tailwind", "Static Export", "A11y-Ready"]
     },
@@ -21,8 +21,8 @@
       "impactScore": 8,
       "timeToLaunchHours": 48,
       "summary": "Caso demo – fiducia e struttura.",
-      "demoUrl": "/TurboSito/de/demos/corporate-site.html",
-      "caseUrl": "/TurboSito/it/portfolio/corporate-site.html",
+      "demoUrl": "/de/demos/corporate-site.html",
+      "caseUrl": "/it/portfolio/corporate-site.html",
       "highlights": ["Servizi focalizzati", "Navigazione snella", "Responsive"],
       "tags": ["Tailwind", "Static Export", "SEO-Ready"]
     },
@@ -34,8 +34,8 @@
       "impactScore": 7,
       "timeToLaunchHours": 48,
       "summary": "Negozio demo – pulito e rapido.",
-      "demoUrl": "/TurboSito/de/demos/fashion-shop.html",
-      "caseUrl": "/TurboSito/it/portfolio/fashion-shop.html",
+      "demoUrl": "/de/demos/fashion-shop.html",
+      "caseUrl": "/it/portfolio/fashion-shop.html",
       "highlights": ["Grid semplice", "Carrello rapido", "Mobile-first"],
       "tags": ["Tailwind", "Static Export", "Snipcart"]
     }

--- a/assets/js/partials.js
+++ b/assets/js/partials.js
@@ -45,7 +45,11 @@
     const nodes = [...root.querySelectorAll('[data-include]')];
     for (const el of nodes) {
       const file = el.getAttribute('data-include');
-      const html = await fetchPartial(resolvePartialPath(file));
+      // Wenn ein Custom-Resolver vorhanden ist, den zuerst nutzen.
+      let url = (window.Partials && window.Partials.__resolve)
+        ? await window.Partials.__resolve(file)
+        : resolvePartialPath(file);
+      const html = await fetchPartial(url);
       const wrapper = document.createElement('div');
       wrapper.innerHTML = html;
       el.replaceWith(...wrapper.childNodes);

--- a/assets/js/path.portfolio.js
+++ b/assets/js/path.portfolio.js
@@ -1,0 +1,36 @@
+export function basePath(){
+  // optional per <meta name="base-path"> überschreibbar
+  const m = document.querySelector('meta[name="base-path"]')?.content;
+  if (m) return m.replace(/\/+$/,'');
+  const seg = location.pathname.split('/').filter(Boolean);
+  const isGh = /\.github\.io$/.test(location.hostname);
+  return isGh && seg.length ? '/' + seg[0] : '';
+}
+export function langPrefix(){
+  const p = location.pathname.replace(basePath(),'');
+  const m = p.match(/^\/(de|en|it)\b/);
+  return m ? '/' + m[1] : '';
+}
+export const withBase = p => (basePath() + '/' + String(p).replace(/^\/+/,'')).replace(/\/{2,}/g,'/');
+export const asset    = p => withBase('/' + String(p).replace(/^\/+/,''));
+// Partials sind sprachneutral unter /partials/*
+export function partial(path){
+  if (/^\.\.?(?:\/).*/.test(path)) return path; // relative bleibt relativ
+  return withBase('/partials/' + path);
+}
+
+// Fallback, wenn jemand versehentlich eine sprachspezifische Partial-URL erwartet
+export async function resolvePartialSafe(file){
+  const url1 = partial(file);                         // /partials/header.html
+  const url2 = withBase(langPrefix() + '/partials/' + file); // /de/partials/header.html (nur falls vorhanden)
+  try{
+    const r = await fetch(url1,{method:'HEAD'});
+    if(r.ok) return url1;
+  }catch{}
+  return url2; // als Fallback probieren
+}
+
+export const dataPath = f => asset('assets/data/' + f); // <— falls deine JSONs NICHT sprach-unterteilt sind
+
+// Wenn deine Datasets sprachspezifisch sind (portfolio.de.json etc.):
+// export const dataPath = f => asset('assets/data/' + f); so lassen und in Schritt 3 die richtige Datei wählen.

--- a/assets/js/portfolio.js
+++ b/assets/js/portfolio.js
@@ -13,7 +13,8 @@
  * @property {string[]} [highlights]
  */
 /** @typedef {{items: PortfolioItem[]}} LocalizedDataset */
-const lang = document.documentElement.lang || 'en';
+import { dataPath, langPrefix, withBase, basePath } from './path.portfolio.js';
+const lang = (langPrefix().slice(1) || 'de');
 const labels = {
   en: {view:'View case study', demo:'Open demo', load:'Load more', none:'No projects', reset:'Reset filters'},
   de: {view:'Case Study ansehen', demo:'Demo öffnen', load:'Mehr laden', none:'Keine Projekte', reset:'Filter zurücksetzen'},
@@ -35,7 +36,8 @@ function validateItem(item){
 
 async function loadData(language){
   try{
-    const res = await fetch(`/TurboSito/assets/data/portfolio.${language}.json`,{cache:'force-cache'});
+    const file = `portfolio.${language}.json`;
+    const res = await fetch(dataPath(file),{cache:'force-cache', credentials:'same-origin'});
     const json = /** @type {LocalizedDataset} */(await res.json());
     state.items = json.items.filter(validateItem);
     announceCount(applyFilters(state.items).length);
@@ -146,8 +148,8 @@ function render(){
         <span class="flex items-center gap-1"><span aria-hidden="true">✅</span>${item.kpis[2]}</span>
       </p>
       <div class="flex flex-wrap gap-3">
-        <a class="btn btn-primary" aria-label="${t.view}: ${item.title}" href="${item.caseUrl}">${t.view}</a>
-        <a class="link" aria-label="${t.demo}: ${item.title}" href="${item.demoUrl}" target="_blank" rel="noopener">${t.demo}</a>
+        <a class="btn btn-primary" aria-label="${t.view}: ${item.title}" href="${withBase(item.caseUrl)}">${t.view}</a>
+        <a class="link" aria-label="${t.demo}: ${item.title}" href="${withBase(item.demoUrl)}" target="_blank" rel="noopener">${t.demo}</a>
       </div>`;
     container.appendChild(article);
   });
@@ -239,6 +241,7 @@ let _booted = false;
 export function init(){
   if (_booted) return;
   _booted = true;
+  /* DEBUG */ console.debug('[portfolio] base', basePath?.(), 'lang', langPrefix?.());
   const list = document.getElementById("portfolio-grid");
   if (list) list.setAttribute("aria-busy","true");
   

--- a/assets/js/seo.js
+++ b/assets/js/seo.js
@@ -1,3 +1,5 @@
+import { asset } from './path.portfolio.js';
+
 export function injectItemListJSONLD({ items, lang, baseUrl, pagePath }) {
   try {
     const list = {
@@ -21,21 +23,26 @@ export function setCanonicalAndHreflang({ baseUrl, langMap, currentLang, path })
   // Canonical
   const linkC = document.createElement('link');
   linkC.rel = 'canonical';
-  linkC.href = `${baseUrl}${path}`;
+  linkC.href = (baseUrl + path).replace(/\/{2,}/g,'/');
   document.head.appendChild(linkC);
   // hreflang
   Object.entries(langMap).forEach(([code, href]) => {
     const l = document.createElement('link');
     l.rel = 'alternate';
     l.hreflang = code;
-    l.href = `${baseUrl}${href}`;
+    l.href = (baseUrl + href).replace(/\/{2,}/g,'/');
     document.head.appendChild(l);
   });
   const xd = document.createElement('link');
   xd.rel = 'alternate';
   xd.hreflang = 'x-default';
-  xd.href = `${baseUrl}${langMap[currentLang]}`;
+  xd.href = (baseUrl + langMap[currentLang]).replace(/\/{2,}/g,'/');
   document.head.appendChild(xd);
+}
+
+export async function fetchSiteMeta(lang){
+  const res = await fetch(asset(`assets/data/site.meta.${lang}.json`));
+  return await res.json();
 }
 
 export function setOpenGraphFallback(meta) {

--- a/de/portfolio.html
+++ b/de/portfolio.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Portfolio – TurboSito</title>
   <meta name="description" content="Demo-Cases – schnell und klar."/>
+  <meta name="base-path" content="/TurboSito">
   <link rel="canonical" href="https://deine-domain.tld/de/portfolio.html"/>
   <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio.html"/>
   <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio.html"/>
@@ -20,7 +21,7 @@
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
 </head>
 <body class="font-sans text-gray-900">
-  <div data-include="header.html"></div>
+  <div data-include="../partials/header.html"></div>
   <main id="main" class="max-w-6xl mx-auto px-4 py-12">
     <section class="text-center mb-10">
       <h1 class="text-3xl font-bold mb-2">Portfolio</h1>
@@ -55,20 +56,22 @@
       </div>
     </section>
   </main>
-  <div data-include="footer.html"></div>
+  <div data-include="../partials/footer.html"></div>
 
-  <script src="/assets/js/partials.js" defer></script>
-  <script src="/assets/js/theme.js" defer></script>
   <script type="module">
-  import { init as portfolioInit } from '/assets/js/portfolio.js';
-  (async () => {
-    if (window.Partials?.injectPartials) {
-      window.Partials.injectPartials();
-      await window.Partials.ready();
-    }
-    if (window.initThemeToggle) window.initThemeToggle();
-    if (typeof portfolioInit === 'function') portfolioInit();
-  })();
-</script>
+  import { resolvePartialSafe } from '../assets/js/path.portfolio.js';
+  import '../assets/js/partials.js';
+  import { init as portfolioInit } from '../assets/js/portfolio.js';
+  import '../assets/js/theme.js';
+  import '../assets/js/seo.js';
+
+  // Custom-Resolver nur für Portfolio-Seiten aktivieren
+  if (window.Partials) window.Partials.__resolve = resolvePartialSafe;
+
+  window.Partials?.injectPartials();
+  await window.Partials?.ready?.();
+  window.initThemeToggle && window.initThemeToggle();
+  portfolioInit && portfolioInit();
+  </script>
 </body>
 </html>

--- a/de/portfolio/corporate-site.html
+++ b/de/portfolio/corporate-site.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Corporate-Site – TurboSito</title>
   <meta name="description" content="Demo-Case: Corporate-Website."/>
+  <meta name="base-path" content="/TurboSito">
   <link rel="canonical" href="https://deine-domain.tld/de/portfolio/corporate-site.html"/>
   <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio/corporate-site.html"/>
   <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio/corporate-site.html"/>
@@ -20,7 +21,7 @@
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
 </head>
 <body class="font-sans text-gray-900">
-  <div data-include="header.html"></div>
+  <div data-include="../../partials/header.html"></div>
   <main id="main" class="max-w-3xl mx-auto px-4 py-12">
     <nav aria-label="Brotkrumen" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
@@ -57,16 +58,17 @@
       <div id="stack-tags" class="mt-4 flex flex-wrap gap-2"></div>
     </section>
     <section class="flex justify-center gap-4 mt-8">
-      <a class="btn btn-primary" href="/TurboSito/de/kontakt.html">Projekt starten</a>
+      <a class="btn btn-primary" href="../kontakt.html">Projekt starten</a>
       <a class="btn btn-outline" href="../portfolio.html">Weitere Beispiele</a>
     </section>
-    <script id="ld-json" type="application/ld+json"></script>
-    <script type="module">
+  <script id="ld-json" type="application/ld+json"></script>
+  <script type="module">
+    import { dataPath, withBase } from '../../assets/js/path.portfolio.js';
     (async()=>{
       const slug='corporate-site';
       const lang=document.documentElement.lang;
       try{
-        const res=await fetch(`/TurboSito/assets/data/portfolio.${lang}.json`);
+        const res=await fetch(dataPath(`portfolio.${lang}.json`));
         const data=await res.json();
         const item=data.items.find(i=>i.slug===slug);
         if(!item){location.href='../portfolio.html?missing=1';return;}
@@ -90,8 +92,8 @@
           "@context":"https://schema.org",
           "@type":"BreadcrumbList",
           "itemListElement":[
-            {"@type":"ListItem","position":1,"name":"Home","item":"/TurboSito/"+lang+"/"},
-            {"@type":"ListItem","position":2,"name":"Portfolio","item":"/TurboSito/"+lang+"/portfolio.html"},
+            {"@type":"ListItem","position":1,"name":"Home","item":withBase('/'+lang+'/')},
+            {"@type":"ListItem","position":2,"name":"Portfolio","item":withBase('/'+lang+'/portfolio.html')},
             {"@type":"ListItem","position":3,"name":item.title,"item":location.pathname}
           ]
         }];
@@ -100,20 +102,22 @@
     })();
     </script>
   </main>
-  <div data-include="footer.html"></div>
+  <div data-include="../../partials/footer.html"></div>
 
-  <script src="/assets/js/partials.js" defer></script>
-  <script src="/assets/js/theme.js" defer></script>
   <script type="module">
-  import { init as portfolioInit } from '/assets/js/portfolio.js';
-  (async () => {
-    if (window.Partials?.injectPartials) {
-      window.Partials.injectPartials();
-      await window.Partials.ready();
-    }
-    if (window.initThemeToggle) window.initThemeToggle();
-    if (typeof portfolioInit === 'function') portfolioInit();
-  })();
-</script>
+  import { resolvePartialSafe } from '../../assets/js/path.portfolio.js';
+  import '../../assets/js/partials.js';
+  import { init as portfolioInit } from '../../assets/js/portfolio.js';
+  import '../../assets/js/theme.js';
+  import '../../assets/js/seo.js';
+
+  // Custom-Resolver nur für Portfolio-Seiten aktivieren
+  if (window.Partials) window.Partials.__resolve = resolvePartialSafe;
+
+  window.Partials?.injectPartials();
+  await window.Partials?.ready?.();
+  window.initThemeToggle && window.initThemeToggle();
+  portfolioInit && portfolioInit();
+  </script>
 </body>
 </html>

--- a/de/portfolio/fashion-shop.html
+++ b/de/portfolio/fashion-shop.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Fashion-Shop – TurboSito</title>
   <meta name="description" content="Demo-Case: Fashion-Shop."/>
+  <meta name="base-path" content="/TurboSito">
   <link rel="canonical" href="https://deine-domain.tld/de/portfolio/fashion-shop.html"/>
   <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio/fashion-shop.html"/>
   <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio/fashion-shop.html"/>
@@ -20,7 +21,7 @@
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
 </head>
 <body class="font-sans text-gray-900">
-  <div data-include="header.html"></div>
+  <div data-include="../../partials/header.html"></div>
   <main id="main" class="max-w-3xl mx-auto px-4 py-12">
     <nav aria-label="Brotkrumen" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
@@ -57,16 +58,17 @@
       <div id="stack-tags" class="mt-4 flex flex-wrap gap-2"></div>
     </section>
     <section class="flex justify-center gap-4 mt-8">
-      <a class="btn btn-primary" href="/TurboSito/de/kontakt.html">Projekt starten</a>
+      <a class="btn btn-primary" href="../kontakt.html">Projekt starten</a>
       <a class="btn btn-outline" href="../portfolio.html">Weitere Beispiele</a>
     </section>
-    <script id="ld-json" type="application/ld+json"></script>
-    <script type="module">
+  <script id="ld-json" type="application/ld+json"></script>
+  <script type="module">
+    import { dataPath, withBase } from '../../assets/js/path.portfolio.js';
     (async()=>{
       const slug='fashion-shop';
       const lang=document.documentElement.lang;
       try{
-        const res=await fetch(`/TurboSito/assets/data/portfolio.${lang}.json`);
+        const res=await fetch(dataPath(`portfolio.${lang}.json`));
         const data=await res.json();
         const item=data.items.find(i=>i.slug===slug);
         if(!item){location.href='../portfolio.html?missing=1';return;}
@@ -90,8 +92,8 @@
           "@context":"https://schema.org",
           "@type":"BreadcrumbList",
           "itemListElement":[
-            {"@type":"ListItem","position":1,"name":"Home","item":"/TurboSito/"+lang+"/"},
-            {"@type":"ListItem","position":2,"name":"Portfolio","item":"/TurboSito/"+lang+"/portfolio.html"},
+            {"@type":"ListItem","position":1,"name":"Home","item":withBase('/'+lang+'/')},
+            {"@type":"ListItem","position":2,"name":"Portfolio","item":withBase('/'+lang+'/portfolio.html')},
             {"@type":"ListItem","position":3,"name":item.title,"item":location.pathname}
           ]
         }];
@@ -100,20 +102,22 @@
     })();
     </script>
   </main>
-  <div data-include="footer.html"></div>
+  <div data-include="../../partials/footer.html"></div>
 
-  <script src="/assets/js/partials.js" defer></script>
-  <script src="/assets/js/theme.js" defer></script>
   <script type="module">
-  import { init as portfolioInit } from '/assets/js/portfolio.js';
-  (async () => {
-    if (window.Partials?.injectPartials) {
-      window.Partials.injectPartials();
-      await window.Partials.ready();
-    }
-    if (window.initThemeToggle) window.initThemeToggle();
-    if (typeof portfolioInit === 'function') portfolioInit();
-  })();
-</script>
+  import { resolvePartialSafe } from '../../assets/js/path.portfolio.js';
+  import '../../assets/js/partials.js';
+  import { init as portfolioInit } from '../../assets/js/portfolio.js';
+  import '../../assets/js/theme.js';
+  import '../../assets/js/seo.js';
+
+  // Custom-Resolver nur für Portfolio-Seiten aktivieren
+  if (window.Partials) window.Partials.__resolve = resolvePartialSafe;
+
+  window.Partials?.injectPartials();
+  await window.Partials?.ready?.();
+  window.initThemeToggle && window.initThemeToggle();
+  portfolioInit && portfolioInit();
+  </script>
 </body>
 </html>

--- a/de/portfolio/saas-landing.html
+++ b/de/portfolio/saas-landing.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>SaaS-Landing – TurboSito</title>
   <meta name="description" content="Demo-Case: SaaS-Landingpage."/>
+  <meta name="base-path" content="/TurboSito">
   <link rel="canonical" href="https://deine-domain.tld/de/portfolio/saas-landing.html"/>
   <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio/saas-landing.html"/>
   <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio/saas-landing.html"/>
@@ -20,7 +21,7 @@
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
 </head>
 <body class="font-sans text-gray-900">
-  <div data-include="header.html"></div>
+  <div data-include="../../partials/header.html"></div>
   <main id="main" class="max-w-3xl mx-auto px-4 py-12">
     <nav aria-label="Brotkrumen" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
@@ -57,16 +58,17 @@
       <div id="stack-tags" class="mt-4 flex flex-wrap gap-2"></div>
     </section>
     <section class="flex justify-center gap-4 mt-8">
-      <a class="btn btn-primary" href="/TurboSito/de/kontakt.html">Projekt starten</a>
+      <a class="btn btn-primary" href="../kontakt.html">Projekt starten</a>
       <a class="btn btn-outline" href="../portfolio.html">Weitere Beispiele</a>
     </section>
-    <script id="ld-json" type="application/ld+json"></script>
-    <script type="module">
+  <script id="ld-json" type="application/ld+json"></script>
+  <script type="module">
+    import { dataPath, withBase } from '../../assets/js/path.portfolio.js';
     (async()=>{
       const slug='saas-landing';
       const lang=document.documentElement.lang;
       try{
-        const res=await fetch(`/TurboSito/assets/data/portfolio.${lang}.json`);
+        const res=await fetch(dataPath(`portfolio.${lang}.json`));
         const data=await res.json();
         const item=data.items.find(i=>i.slug===slug);
         if(!item){location.href='../portfolio.html?missing=1';return;}
@@ -90,8 +92,8 @@
           "@context":"https://schema.org",
           "@type":"BreadcrumbList",
           "itemListElement":[
-            {"@type":"ListItem","position":1,"name":"Home","item":"/TurboSito/"+lang+"/"},
-            {"@type":"ListItem","position":2,"name":"Portfolio","item":"/TurboSito/"+lang+"/portfolio.html"},
+            {"@type":"ListItem","position":1,"name":"Home","item":withBase('/'+lang+'/')},
+            {"@type":"ListItem","position":2,"name":"Portfolio","item":withBase('/'+lang+'/portfolio.html')},
             {"@type":"ListItem","position":3,"name":item.title,"item":location.pathname}
           ]
         }];
@@ -100,20 +102,22 @@
     })();
     </script>
   </main>
-  <div data-include="footer.html"></div>
+  <div data-include="../../partials/footer.html"></div>
 
-  <script src="/assets/js/partials.js" defer></script>
-  <script src="/assets/js/theme.js" defer></script>
   <script type="module">
-  import { init as portfolioInit } from '/assets/js/portfolio.js';
-  (async () => {
-    if (window.Partials?.injectPartials) {
-      window.Partials.injectPartials();
-      await window.Partials.ready();
-    }
-    if (window.initThemeToggle) window.initThemeToggle();
-    if (typeof portfolioInit === 'function') portfolioInit();
-  })();
-</script>
+  import { resolvePartialSafe } from '../../assets/js/path.portfolio.js';
+  import '../../assets/js/partials.js';
+  import { init as portfolioInit } from '../../assets/js/portfolio.js';
+  import '../../assets/js/theme.js';
+  import '../../assets/js/seo.js';
+
+  // Custom-Resolver nur für Portfolio-Seiten aktivieren
+  if (window.Partials) window.Partials.__resolve = resolvePartialSafe;
+
+  window.Partials?.injectPartials();
+  await window.Partials?.ready?.();
+  window.initThemeToggle && window.initThemeToggle();
+  portfolioInit && portfolioInit();
+  </script>
 </body>
 </html>

--- a/en/portfolio.html
+++ b/en/portfolio.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Portfolio – TurboSito</title>
   <meta name="description" content="Demo cases – fast and clear."/>
+  <meta name="base-path" content="/TurboSito">
   <link rel="canonical" href="https://deine-domain.tld/en/portfolio.html"/>
   <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio.html"/>
   <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio.html"/>
@@ -20,7 +21,7 @@
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
 </head>
 <body class="font-sans text-gray-900">
-  <div data-include="header.html"></div>
+  <div data-include="../partials/header.html"></div>
   <main id="main" class="max-w-6xl mx-auto px-4 py-12">
     <section class="text-center mb-10">
       <h1 class="text-3xl font-bold mb-2">Portfolio</h1>
@@ -55,20 +56,22 @@
       </div>
     </section>
   </main>
-  <div data-include="footer.html"></div>
+  <div data-include="../partials/footer.html"></div>
 
-  <script src="/assets/js/partials.js" defer></script>
-  <script src="/assets/js/theme.js" defer></script>
   <script type="module">
-  import { init as portfolioInit } from '/assets/js/portfolio.js';
-  (async () => {
-    if (window.Partials?.injectPartials) {
-      window.Partials.injectPartials();
-      await window.Partials.ready();
-    }
-    if (window.initThemeToggle) window.initThemeToggle();
-    if (typeof portfolioInit === 'function') portfolioInit();
-  })();
-</script>
+  import { resolvePartialSafe } from '../assets/js/path.portfolio.js';
+  import '../assets/js/partials.js';
+  import { init as portfolioInit } from '../assets/js/portfolio.js';
+  import '../assets/js/theme.js';
+  import '../assets/js/seo.js';
+
+  // Custom-Resolver nur für Portfolio-Seiten aktivieren
+  if (window.Partials) window.Partials.__resolve = resolvePartialSafe;
+
+  window.Partials?.injectPartials();
+  await window.Partials?.ready?.();
+  window.initThemeToggle && window.initThemeToggle();
+  portfolioInit && portfolioInit();
+  </script>
 </body>
 </html>

--- a/en/portfolio/corporate-site.html
+++ b/en/portfolio/corporate-site.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Corporate Site – TurboSito</title>
   <meta name="description" content="Demo case: corporate website."/>
+  <meta name="base-path" content="/TurboSito">
   <link rel="canonical" href="https://deine-domain.tld/en/portfolio/corporate-site.html"/>
   <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio/corporate-site.html"/>
   <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio/corporate-site.html"/>
@@ -20,7 +21,7 @@
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
 </head>
 <body class="font-sans text-gray-900">
-  <div data-include="header.html"></div>
+  <div data-include="../../partials/header.html"></div>
   <main id="main" class="max-w-3xl mx-auto px-4 py-12">
     <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
@@ -57,16 +58,17 @@
       <div id="stack-tags" class="mt-4 flex flex-wrap gap-2"></div>
     </section>
     <section class="flex justify-center gap-4 mt-8">
-      <a class="btn btn-primary" href="/TurboSito/en/contact.html">Start project</a>
+      <a class="btn btn-primary" href="../contact.html">Start project</a>
       <a class="btn btn-outline" href="../portfolio.html">More examples</a>
     </section>
     <script id="ld-json" type="application/ld+json"></script>
     <script type="module">
+    import { dataPath, withBase } from '../../assets/js/path.portfolio.js';
     (async()=>{
       const slug='corporate-site';
       const lang=document.documentElement.lang;
       try{
-        const res=await fetch(`/TurboSito/assets/data/portfolio.${lang}.json`);
+        const res=await fetch(dataPath(`portfolio.${lang}.json`));
         const data=await res.json();
         const item=data.items.find(i=>i.slug===slug);
         if(!item){location.href='../portfolio.html?missing=1';return;}
@@ -90,8 +92,8 @@
           "@context":"https://schema.org",
           "@type":"BreadcrumbList",
           "itemListElement":[
-            {"@type":"ListItem","position":1,"name":"Home","item":"/TurboSito/"+lang+"/"},
-            {"@type":"ListItem","position":2,"name":"Portfolio","item":"/TurboSito/"+lang+"/portfolio.html"},
+            {"@type":"ListItem","position":1,"name":"Home","item":withBase('/'+lang+'/')},
+            {"@type":"ListItem","position":2,"name":"Portfolio","item":withBase('/'+lang+'/portfolio.html')},
             {"@type":"ListItem","position":3,"name":item.title,"item":location.pathname}
           ]
         }];
@@ -100,20 +102,22 @@
     })();
     </script>
   </main>
-  <div data-include="footer.html"></div>
+  <div data-include="../../partials/footer.html"></div>
 
-  <script src="/assets/js/partials.js" defer></script>
-  <script src="/assets/js/theme.js" defer></script>
   <script type="module">
-  import { init as portfolioInit } from '/assets/js/portfolio.js';
-  (async () => {
-    if (window.Partials?.injectPartials) {
-      window.Partials.injectPartials();
-      await window.Partials.ready();
-    }
-    if (window.initThemeToggle) window.initThemeToggle();
-    if (typeof portfolioInit === 'function') portfolioInit();
-  })();
-</script>
+  import { resolvePartialSafe } from '../../assets/js/path.portfolio.js';
+  import '../../assets/js/partials.js';
+  import { init as portfolioInit } from '../../assets/js/portfolio.js';
+  import '../../assets/js/theme.js';
+  import '../../assets/js/seo.js';
+
+  // Custom-Resolver nur für Portfolio-Seiten aktivieren
+  if (window.Partials) window.Partials.__resolve = resolvePartialSafe;
+
+  window.Partials?.injectPartials();
+  await window.Partials?.ready?.();
+  window.initThemeToggle && window.initThemeToggle();
+  portfolioInit && portfolioInit();
+  </script>
 </body>
 </html>

--- a/en/portfolio/fashion-shop.html
+++ b/en/portfolio/fashion-shop.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Fashion Shop – TurboSito</title>
   <meta name="description" content="Demo case: fashion shop."/>
+  <meta name="base-path" content="/TurboSito">
   <link rel="canonical" href="https://deine-domain.tld/en/portfolio/fashion-shop.html"/>
   <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio/fashion-shop.html"/>
   <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio/fashion-shop.html"/>
@@ -20,7 +21,7 @@
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
 </head>
 <body class="font-sans text-gray-900">
-  <div data-include="header.html"></div>
+  <div data-include="../../partials/header.html"></div>
   <main id="main" class="max-w-3xl mx-auto px-4 py-12">
     <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
@@ -57,16 +58,17 @@
       <div id="stack-tags" class="mt-4 flex flex-wrap gap-2"></div>
     </section>
     <section class="flex justify-center gap-4 mt-8">
-      <a class="btn btn-primary" href="/TurboSito/en/contact.html">Start project</a>
+      <a class="btn btn-primary" href="../contact.html">Start project</a>
       <a class="btn btn-outline" href="../portfolio.html">More examples</a>
     </section>
     <script id="ld-json" type="application/ld+json"></script>
     <script type="module">
+    import { dataPath, withBase } from '../../assets/js/path.portfolio.js';
     (async()=>{
       const slug='fashion-shop';
       const lang=document.documentElement.lang;
       try{
-        const res=await fetch(`/TurboSito/assets/data/portfolio.${lang}.json`);
+        const res=await fetch(dataPath(`portfolio.${lang}.json`));
         const data=await res.json();
         const item=data.items.find(i=>i.slug===slug);
         if(!item){location.href='../portfolio.html?missing=1';return;}
@@ -90,8 +92,8 @@
           "@context":"https://schema.org",
           "@type":"BreadcrumbList",
           "itemListElement":[
-            {"@type":"ListItem","position":1,"name":"Home","item":"/TurboSito/"+lang+"/"},
-            {"@type":"ListItem","position":2,"name":"Portfolio","item":"/TurboSito/"+lang+"/portfolio.html"},
+            {"@type":"ListItem","position":1,"name":"Home","item":withBase('/'+lang+'/')},
+            {"@type":"ListItem","position":2,"name":"Portfolio","item":withBase('/'+lang+'/portfolio.html')},
             {"@type":"ListItem","position":3,"name":item.title,"item":location.pathname}
           ]
         }];
@@ -100,20 +102,22 @@
     })();
     </script>
   </main>
-  <div data-include="footer.html"></div>
+  <div data-include="../../partials/footer.html"></div>
 
-  <script src="/assets/js/partials.js" defer></script>
-  <script src="/assets/js/theme.js" defer></script>
   <script type="module">
-  import { init as portfolioInit } from '/assets/js/portfolio.js';
-  (async () => {
-    if (window.Partials?.injectPartials) {
-      window.Partials.injectPartials();
-      await window.Partials.ready();
-    }
-    if (window.initThemeToggle) window.initThemeToggle();
-    if (typeof portfolioInit === 'function') portfolioInit();
-  })();
-</script>
+  import { resolvePartialSafe } from '../../assets/js/path.portfolio.js';
+  import '../../assets/js/partials.js';
+  import { init as portfolioInit } from '../../assets/js/portfolio.js';
+  import '../../assets/js/theme.js';
+  import '../../assets/js/seo.js';
+
+  // Custom-Resolver nur für Portfolio-Seiten aktivieren
+  if (window.Partials) window.Partials.__resolve = resolvePartialSafe;
+
+  window.Partials?.injectPartials();
+  await window.Partials?.ready?.();
+  window.initThemeToggle && window.initThemeToggle();
+  portfolioInit && portfolioInit();
+  </script>
 </body>
 </html>

--- a/en/portfolio/saas-landing.html
+++ b/en/portfolio/saas-landing.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>SaaS Landing – TurboSito</title>
   <meta name="description" content="Demo case: SaaS landing page."/>
+  <meta name="base-path" content="/TurboSito">
   <link rel="canonical" href="https://deine-domain.tld/en/portfolio/saas-landing.html"/>
   <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio/saas-landing.html"/>
   <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio/saas-landing.html"/>
@@ -20,7 +21,7 @@
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
 </head>
 <body class="font-sans text-gray-900">
-  <div data-include="header.html"></div>
+  <div data-include="../../partials/header.html"></div>
   <main id="main" class="max-w-3xl mx-auto px-4 py-12">
     <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
@@ -57,16 +58,17 @@
       <div id="stack-tags" class="mt-4 flex flex-wrap gap-2"></div>
     </section>
     <section class="flex justify-center gap-4 mt-8">
-      <a class="btn btn-primary" href="/TurboSito/en/contact.html">Start project</a>
+      <a class="btn btn-primary" href="../contact.html">Start project</a>
       <a class="btn btn-outline" href="../portfolio.html">More examples</a>
     </section>
     <script id="ld-json" type="application/ld+json"></script>
     <script type="module">
+    import { dataPath, withBase } from '../../assets/js/path.portfolio.js';
     (async()=>{
       const slug='saas-landing';
       const lang=document.documentElement.lang;
       try{
-        const res=await fetch(`/TurboSito/assets/data/portfolio.${lang}.json`);
+        const res=await fetch(dataPath(`portfolio.${lang}.json`));
         const data=await res.json();
         const item=data.items.find(i=>i.slug===slug);
         if(!item){location.href='../portfolio.html?missing=1';return;}
@@ -90,8 +92,8 @@
           "@context":"https://schema.org",
           "@type":"BreadcrumbList",
           "itemListElement":[
-            {"@type":"ListItem","position":1,"name":"Home","item":"/TurboSito/"+lang+"/"},
-            {"@type":"ListItem","position":2,"name":"Portfolio","item":"/TurboSito/"+lang+"/portfolio.html"},
+            {"@type":"ListItem","position":1,"name":"Home","item":withBase('/'+lang+'/')},
+            {"@type":"ListItem","position":2,"name":"Portfolio","item":withBase('/'+lang+'/portfolio.html')},
             {"@type":"ListItem","position":3,"name":item.title,"item":location.pathname}
           ]
         }];
@@ -100,20 +102,22 @@
     })();
     </script>
   </main>
-  <div data-include="footer.html"></div>
+  <div data-include="../../partials/footer.html"></div>
 
-  <script src="/assets/js/partials.js" defer></script>
-  <script src="/assets/js/theme.js" defer></script>
   <script type="module">
-  import { init as portfolioInit } from '/assets/js/portfolio.js';
-  (async () => {
-    if (window.Partials?.injectPartials) {
-      window.Partials.injectPartials();
-      await window.Partials.ready();
-    }
-    if (window.initThemeToggle) window.initThemeToggle();
-    if (typeof portfolioInit === 'function') portfolioInit();
-  })();
-</script>
+  import { resolvePartialSafe } from '../../assets/js/path.portfolio.js';
+  import '../../assets/js/partials.js';
+  import { init as portfolioInit } from '../../assets/js/portfolio.js';
+  import '../../assets/js/theme.js';
+  import '../../assets/js/seo.js';
+
+  // Custom-Resolver nur für Portfolio-Seiten aktivieren
+  if (window.Partials) window.Partials.__resolve = resolvePartialSafe;
+
+  window.Partials?.injectPartials();
+  await window.Partials?.ready?.();
+  window.initThemeToggle && window.initThemeToggle();
+  portfolioInit && portfolioInit();
+  </script>
 </body>
 </html>

--- a/it/portfolio.html
+++ b/it/portfolio.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Portfolio – TurboSito</title>
   <meta name="description" content="Demo case – rapidi e chiari."/>
+  <meta name="base-path" content="/TurboSito">
   <link rel="canonical" href="https://deine-domain.tld/it/portfolio.html"/>
   <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio.html"/>
   <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio.html"/>
@@ -20,7 +21,7 @@
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
 </head>
 <body class="font-sans text-gray-900">
-  <div data-include="header.html"></div>
+  <div data-include="../partials/header.html"></div>
   <main id="main" class="max-w-6xl mx-auto px-4 py-12">
     <section class="text-center mb-10">
       <h1 class="text-3xl font-bold mb-2">Portfolio</h1>
@@ -55,20 +56,22 @@
       </div>
     </section>
   </main>
-  <div data-include="footer.html"></div>
+  <div data-include="../partials/footer.html"></div>
 
-  <script src="/assets/js/partials.js" defer></script>
-  <script src="/assets/js/theme.js" defer></script>
   <script type="module">
-  import { init as portfolioInit } from '/assets/js/portfolio.js';
-  (async () => {
-    if (window.Partials?.injectPartials) {
-      window.Partials.injectPartials();
-      await window.Partials.ready();
-    }
-    if (window.initThemeToggle) window.initThemeToggle();
-    if (typeof portfolioInit === 'function') portfolioInit();
-  })();
-</script>
+  import { resolvePartialSafe } from '../assets/js/path.portfolio.js';
+  import '../assets/js/partials.js';
+  import { init as portfolioInit } from '../assets/js/portfolio.js';
+  import '../assets/js/theme.js';
+  import '../assets/js/seo.js';
+
+  // Custom-Resolver nur für Portfolio-Seiten aktivieren
+  if (window.Partials) window.Partials.__resolve = resolvePartialSafe;
+
+  window.Partials?.injectPartials();
+  await window.Partials?.ready?.();
+  window.initThemeToggle && window.initThemeToggle();
+  portfolioInit && portfolioInit();
+  </script>
 </body>
 </html>

--- a/it/portfolio/corporate-site.html
+++ b/it/portfolio/corporate-site.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Corporate Site – TurboSito</title>
   <meta name="description" content="Caso demo: sito corporate."/>
+  <meta name="base-path" content="/TurboSito">
   <link rel="canonical" href="https://deine-domain.tld/it/portfolio/corporate-site.html"/>
   <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio/corporate-site.html"/>
   <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio/corporate-site.html"/>
@@ -20,7 +21,7 @@
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
 </head>
 <body class="font-sans text-gray-900">
-  <div data-include="header.html"></div>
+  <div data-include="../../partials/header.html"></div>
   <main id="main" class="max-w-3xl mx-auto px-4 py-12">
     <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
@@ -57,16 +58,17 @@
       <div id="stack-tags" class="mt-4 flex flex-wrap gap-2"></div>
     </section>
     <section class="flex justify-center gap-4 mt-8">
-      <a class="btn btn-primary" href="/TurboSito/it/contatto.html">Avvia progetto</a>
+      <a class="btn btn-primary" href="../contatti.html">Avvia progetto</a>
       <a class="btn btn-outline" href="../portfolio.html">Altri esempi</a>
     </section>
     <script id="ld-json" type="application/ld+json"></script>
     <script type="module">
+    import { dataPath, withBase } from '../../assets/js/path.portfolio.js';
     (async()=>{
       const slug='corporate-site';
       const lang=document.documentElement.lang;
       try{
-        const res=await fetch(`/TurboSito/assets/data/portfolio.${lang}.json`);
+        const res=await fetch(dataPath(`portfolio.${lang}.json`));
         const data=await res.json();
         const item=data.items.find(i=>i.slug===slug);
         if(!item){location.href='../portfolio.html?missing=1';return;}
@@ -90,8 +92,8 @@
           "@context":"https://schema.org",
           "@type":"BreadcrumbList",
           "itemListElement":[
-            {"@type":"ListItem","position":1,"name":"Home","item":"/TurboSito/"+lang+"/"},
-            {"@type":"ListItem","position":2,"name":"Portfolio","item":"/TurboSito/"+lang+"/portfolio.html"},
+            {"@type":"ListItem","position":1,"name":"Home","item":withBase('/'+lang+'/')},
+            {"@type":"ListItem","position":2,"name":"Portfolio","item":withBase('/'+lang+'/portfolio.html')},
             {"@type":"ListItem","position":3,"name":item.title,"item":location.pathname}
           ]
         }];
@@ -100,20 +102,22 @@
     })();
     </script>
   </main>
-  <div data-include="footer.html"></div>
+  <div data-include="../../partials/footer.html"></div>
 
-  <script src="/assets/js/partials.js" defer></script>
-  <script src="/assets/js/theme.js" defer></script>
   <script type="module">
-  import { init as portfolioInit } from '/assets/js/portfolio.js';
-  (async () => {
-    if (window.Partials?.injectPartials) {
-      window.Partials.injectPartials();
-      await window.Partials.ready();
-    }
-    if (window.initThemeToggle) window.initThemeToggle();
-    if (typeof portfolioInit === 'function') portfolioInit();
-  })();
-</script>
+  import { resolvePartialSafe } from '../../assets/js/path.portfolio.js';
+  import '../../assets/js/partials.js';
+  import { init as portfolioInit } from '../../assets/js/portfolio.js';
+  import '../../assets/js/theme.js';
+  import '../../assets/js/seo.js';
+
+  // Custom-Resolver nur für Portfolio-Seiten aktivieren
+  if (window.Partials) window.Partials.__resolve = resolvePartialSafe;
+
+  window.Partials?.injectPartials();
+  await window.Partials?.ready?.();
+  window.initThemeToggle && window.initThemeToggle();
+  portfolioInit && portfolioInit();
+  </script>
 </body>
 </html>

--- a/it/portfolio/fashion-shop.html
+++ b/it/portfolio/fashion-shop.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Fashion Shop – TurboSito</title>
   <meta name="description" content="Caso demo: shop moda."/>
+  <meta name="base-path" content="/TurboSito">
   <link rel="canonical" href="https://deine-domain.tld/it/portfolio/fashion-shop.html"/>
   <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio/fashion-shop.html"/>
   <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio/fashion-shop.html"/>
@@ -20,7 +21,7 @@
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
 </head>
 <body class="font-sans text-gray-900">
-  <div data-include="header.html"></div>
+  <div data-include="../../partials/header.html"></div>
   <main id="main" class="max-w-3xl mx-auto px-4 py-12">
     <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
@@ -57,16 +58,17 @@
       <div id="stack-tags" class="mt-4 flex flex-wrap gap-2"></div>
     </section>
     <section class="flex justify-center gap-4 mt-8">
-      <a class="btn btn-primary" href="/TurboSito/it/contatto.html">Avvia progetto</a>
+      <a class="btn btn-primary" href="../contatti.html">Avvia progetto</a>
       <a class="btn btn-outline" href="../portfolio.html">Altri esempi</a>
     </section>
     <script id="ld-json" type="application/ld+json"></script>
     <script type="module">
+    import { dataPath, withBase } from '../../assets/js/path.portfolio.js';
     (async()=>{
       const slug='fashion-shop';
       const lang=document.documentElement.lang;
       try{
-        const res=await fetch(`/TurboSito/assets/data/portfolio.${lang}.json`);
+        const res=await fetch(dataPath(`portfolio.${lang}.json`));
         const data=await res.json();
         const item=data.items.find(i=>i.slug===slug);
         if(!item){location.href='../portfolio.html?missing=1';return;}
@@ -90,8 +92,8 @@
           "@context":"https://schema.org",
           "@type":"BreadcrumbList",
           "itemListElement":[
-            {"@type":"ListItem","position":1,"name":"Home","item":"/TurboSito/"+lang+"/"},
-            {"@type":"ListItem","position":2,"name":"Portfolio","item":"/TurboSito/"+lang+"/portfolio.html"},
+            {"@type":"ListItem","position":1,"name":"Home","item":withBase('/'+lang+'/')},
+            {"@type":"ListItem","position":2,"name":"Portfolio","item":withBase('/'+lang+'/portfolio.html')},
             {"@type":"ListItem","position":3,"name":item.title,"item":location.pathname}
           ]
         }];
@@ -100,20 +102,22 @@
     })();
     </script>
   </main>
-  <div data-include="footer.html"></div>
+  <div data-include="../../partials/footer.html"></div>
 
-  <script src="/assets/js/partials.js" defer></script>
-  <script src="/assets/js/theme.js" defer></script>
   <script type="module">
-  import { init as portfolioInit } from '/assets/js/portfolio.js';
-  (async () => {
-    if (window.Partials?.injectPartials) {
-      window.Partials.injectPartials();
-      await window.Partials.ready();
-    }
-    if (window.initThemeToggle) window.initThemeToggle();
-    if (typeof portfolioInit === 'function') portfolioInit();
-  })();
-</script>
+  import { resolvePartialSafe } from '../../assets/js/path.portfolio.js';
+  import '../../assets/js/partials.js';
+  import { init as portfolioInit } from '../../assets/js/portfolio.js';
+  import '../../assets/js/theme.js';
+  import '../../assets/js/seo.js';
+
+  // Custom-Resolver nur für Portfolio-Seiten aktivieren
+  if (window.Partials) window.Partials.__resolve = resolvePartialSafe;
+
+  window.Partials?.injectPartials();
+  await window.Partials?.ready?.();
+  window.initThemeToggle && window.initThemeToggle();
+  portfolioInit && portfolioInit();
+  </script>
 </body>
 </html>

--- a/it/portfolio/saas-landing.html
+++ b/it/portfolio/saas-landing.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Landing SaaS – TurboSito</title>
   <meta name="description" content="Caso demo: landing SaaS."/>
+  <meta name="base-path" content="/TurboSito">
   <link rel="canonical" href="https://deine-domain.tld/it/portfolio/saas-landing.html"/>
   <link rel="alternate" hreflang="de" href="https://deine-domain.tld/de/portfolio/saas-landing.html"/>
   <link rel="alternate" hreflang="en" href="https://deine-domain.tld/en/portfolio/saas-landing.html"/>
@@ -20,7 +21,7 @@
   <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
 </head>
 <body class="font-sans text-gray-900">
-  <div data-include="header.html"></div>
+  <div data-include="../../partials/header.html"></div>
   <main id="main" class="max-w-3xl mx-auto px-4 py-12">
     <nav aria-label="Breadcrumb" class="mb-4"><a href="../portfolio.html" class="text-sm text-gray-400 hover:text-orange-400">← Portfolio</a></nav>
     <header class="mb-8">
@@ -57,16 +58,17 @@
       <div id="stack-tags" class="mt-4 flex flex-wrap gap-2"></div>
     </section>
     <section class="flex justify-center gap-4 mt-8">
-      <a class="btn btn-primary" href="/TurboSito/it/contatto.html">Avvia progetto</a>
+      <a class="btn btn-primary" href="../contatti.html">Avvia progetto</a>
       <a class="btn btn-outline" href="../portfolio.html">Altri esempi</a>
     </section>
     <script id="ld-json" type="application/ld+json"></script>
     <script type="module">
+    import { dataPath, withBase } from '../../assets/js/path.portfolio.js';
     (async()=>{
       const slug='saas-landing';
       const lang=document.documentElement.lang;
       try{
-        const res=await fetch(`/TurboSito/assets/data/portfolio.${lang}.json`);
+        const res=await fetch(dataPath(`portfolio.${lang}.json`));
         const data=await res.json();
         const item=data.items.find(i=>i.slug===slug);
         if(!item){location.href='../portfolio.html?missing=1';return;}
@@ -90,8 +92,8 @@
           "@context":"https://schema.org",
           "@type":"BreadcrumbList",
           "itemListElement":[
-            {"@type":"ListItem","position":1,"name":"Home","item":"/TurboSito/"+lang+"/"},
-            {"@type":"ListItem","position":2,"name":"Portfolio","item":"/TurboSito/"+lang+"/portfolio.html"},
+            {"@type":"ListItem","position":1,"name":"Home","item":withBase('/'+lang+'/')},
+            {"@type":"ListItem","position":2,"name":"Portfolio","item":withBase('/'+lang+'/portfolio.html')},
             {"@type":"ListItem","position":3,"name":item.title,"item":location.pathname}
           ]
         }];
@@ -100,20 +102,22 @@
     })();
     </script>
   </main>
-  <div data-include="footer.html"></div>
+  <div data-include="../../partials/footer.html"></div>
 
-  <script src="/assets/js/partials.js" defer></script>
-  <script src="/assets/js/theme.js" defer></script>
   <script type="module">
-  import { init as portfolioInit } from '/assets/js/portfolio.js';
-  (async () => {
-    if (window.Partials?.injectPartials) {
-      window.Partials.injectPartials();
-      await window.Partials.ready();
-    }
-    if (window.initThemeToggle) window.initThemeToggle();
-    if (typeof portfolioInit === 'function') portfolioInit();
-  })();
-</script>
+  import { resolvePartialSafe } from '../../assets/js/path.portfolio.js';
+  import '../../assets/js/partials.js';
+  import { init as portfolioInit } from '../../assets/js/portfolio.js';
+  import '../../assets/js/theme.js';
+  import '../../assets/js/seo.js';
+
+  // Custom-Resolver nur für Portfolio-Seiten aktivieren
+  if (window.Partials) window.Partials.__resolve = resolvePartialSafe;
+
+  window.Partials?.injectPartials();
+  await window.Partials?.ready?.();
+  window.initThemeToggle && window.initThemeToggle();
+  portfolioInit && portfolioInit();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- resolve partials via a language-neutral helper with fallback and custom resolver
- use async custom resolver in partial loader and hook it on portfolio pages and cases
- log base path during portfolio init and ensure case pages load data through repo-aware helpers

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bef26629c083328aee04b7bc19567c